### PR TITLE
fix: fetch data from e-invoice log in E-Invoice summary report

### DIFF
--- a/india_compliance/gst_india/report/e_invoice_summary/e_invoice_summary.js
+++ b/india_compliance/gst_india/report/e_invoice_summary/e_invoice_summary.js
@@ -2,7 +2,7 @@
 // For license information, please see license.txt
 /* eslint-disable */
 
-frappe.query_reports["E-Invoice Summary"] = {
+frappe.query_reports["e-Invoice Summary"] = {
 	"filters": [
 		{
 			"fieldtype": "Link",

--- a/india_compliance/gst_india/report/e_invoice_summary/e_invoice_summary.json
+++ b/india_compliance/gst_india/report/e_invoice_summary/e_invoice_summary.json
@@ -11,14 +11,14 @@
  "is_standard": "Yes",
  "json": "{}",
  "letter_head": "",
- "modified": "2022-03-01 15:49:12.868970",
+ "modified": "2022-03-01 15:49:13.912294",
  "modified_by": "Administrator",
  "module": "GST India",
- "name": "E-Invoice Summary",
+ "name": "e-Invoice Summary",
  "owner": "Administrator",
  "prepared_report": 0,
  "ref_doctype": "Sales Invoice",
- "report_name": "E-Invoice Summary",
+ "report_name": "e-Invoice Summary",
  "report_type": "Script Report",
  "roles": [
   {

--- a/india_compliance/gst_india/report/e_invoice_summary/e_invoice_summary.py
+++ b/india_compliance/gst_india/report/e_invoice_summary/e_invoice_summary.py
@@ -3,6 +3,7 @@
 
 import frappe
 from frappe import _
+from frappe.query_builder import Case
 
 
 def execute(filters=None):
@@ -52,7 +53,7 @@ def get_data(filters=None):
             sales_invoice.posting_date,
             sales_invoice.einvoice_status,
             sales_invoice.customer,
-            sales_invoice.is_return,
+            Case().when(sales_invoice.is_return == 1, "Y").else_("N").as_("is_return"),
             sales_invoice.base_grand_total,
             e_invoice_log.sales_invoice,
             e_invoice_log.acknowledgement_number,
@@ -86,7 +87,7 @@ def get_columns():
         },
         {
             "fieldtype": "Link",
-            "fieldname": "name",
+            "fieldname": "sales_invoice",
             "label": _("Sales Invoice"),
             "options": "Sales Invoice",
             "width": 140,
@@ -104,7 +105,7 @@ def get_columns():
             "label": _("Customer"),
         },
         {
-            "fieldtype": "Check",
+            "fieldtype": "Data",
             "fieldname": "is_return",
             "label": _("Is Return"),
             "width": 85,

--- a/india_compliance/patches/post_install/update_e_invoice_fields_and_logs.py
+++ b/india_compliance/patches/post_install/update_e_invoice_fields_and_logs.py
@@ -302,3 +302,7 @@ def delete_e_invoice_fields():
 def delete_old_doctypes():
     for doctype in ("E Invoice Settings", "E Invoice User", "E Invoice Request Log"):
         frappe.delete_doc("DocType", doctype, force=True)
+
+
+def delete_old_report():
+    frappe.delete_doc("Report", "E-Invoice Summary", force=True)


### PR DESCRIPTION
Before, data in the `E-Invoice Summary` report was fetched from Sales Invoice only. 

Now, data will be fetched from `e-Invoice Log` and `Sales Invoice` with applied filters.