### PR TITLE
fix: `Session Start Failed` error

### DIFF
--- a/india_compliance/gst_india/utils/__init__.py
+++ b/india_compliance/gst_india/utils/__init__.py
@@ -349,7 +349,7 @@ def delete_custom_fields(custom_fields):
             frappe.db.delete(
                 "Custom Field",
                 {
-                    "fieldname": ("in", [field.fieldname for field in fields]),
+                    "fieldname": ("in", [field["fieldname"] for field in fields]),
                     "dt": doctype,
                 },
             )

--- a/india_compliance/patches/post_install/update_e_invoice_fields_and_logs.py
+++ b/india_compliance/patches/post_install/update_e_invoice_fields_and_logs.py
@@ -9,6 +9,7 @@ def execute():
     migrate_e_invoice_request_log()
     delete_e_invoice_fields()
     delete_old_doctypes()
+    delete_old_reports()
 
 
 def migrate_e_waybill_fields():
@@ -304,5 +305,6 @@ def delete_old_doctypes():
         frappe.delete_doc("DocType", doctype, force=True)
 
 
-def delete_old_report():
-    frappe.delete_doc("Report", "E-Invoice Summary", force=True)
+def delete_old_reports():
+    for report in ("E-Invoice Summary",):
+        frappe.delete_doc("Report", report, force=True)


### PR DESCRIPTION
## Changes Made
 - generalize `delete_old_reports`
 - fixed the attribute error (we are getting field as `dict`, not `frappe._dict`)

## Fixes
![telegram-cloud-photo-size-5-6251015322836512407-x](https://user-images.githubusercontent.com/43115036/163364058-e8176dcc-419c-4ea0-bde9-ccbdaff1fd9d.jpg)
