### PR TITLE
fix: random document name generation for sandbox

### DIFF
--- a/india_compliance/gst_india/utils/e_invoice.py
+++ b/india_compliance/gst_india/utils/e_invoice.py
@@ -1,11 +1,15 @@
-import random
-import string
-
 import jwt
 
 import frappe
 from frappe import _
-from frappe.utils import add_to_date, cstr, format_date, get_datetime, getdate
+from frappe.utils import (
+    add_to_date,
+    cstr,
+    format_date,
+    get_datetime,
+    getdate,
+    random_string,
+)
 
 from india_compliance.gst_india.api_classes.e_invoice import EInvoiceAPI
 from india_compliance.gst_india.constants import EXPORT_TYPES, GST_CATEGORIES
@@ -128,12 +132,7 @@ def cancel_e_invoice(docname, values):
 
 
 def log_e_invoice(doc, log_data):
-    frappe.enqueue(
-        _log_e_invoice,
-        queue="short",
-        at_front=True,
-        log_data=log_data,
-    )
+    frappe.enqueue(_log_e_invoice, queue="short", at_front=True, log_data=log_data)
 
     update_onload(doc, "e_invoice_info", log_data)
 
@@ -363,14 +362,12 @@ class EInvoiceData(GSTTransactionData):
                 "state_number": "36",
                 "pincode": 500055,
             }
-
             self.company_address.update(seller)
             self.dispatch_address.update(seller)
             self.billing_address.update(buyer)
             self.shipping_address.update(buyer)
-            self.transaction_details.name = "".join(
-                random.choices(string.ascii_letters + string.digits, k=6)
-            )
+            self.transaction_details.name = random_string(6).lstrip("0")
+
             if self.transaction_details.total_igst_amount > 0:
                 self.transaction_details.place_of_supply = "36"
             else:

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -1,9 +1,6 @@
-import random
-import string
-
 import frappe
 from frappe import _
-from frappe.utils import add_to_date, get_datetime, get_fullname
+from frappe.utils import add_to_date, get_datetime, get_fullname, random_string
 from frappe.utils.file_manager import save_file
 
 from india_compliance.gst_india.api_classes.e_invoice import EInvoiceAPI
@@ -703,9 +700,7 @@ class EWaybillData(GSTTransactionData):
             self.transaction_details.update(
                 {
                     "company_gstin": "05AAACG2115R1ZN",
-                    "name": "".join(
-                        random.choices(string.ascii_letters + string.digits, k=6)
-                    ),
+                    "name": random_string(6).lstrip("0"),
                 }
             )
             self.company_address.gstin = "05AAACG2115R1ZN"


### PR DESCRIPTION
**Issue**
Sometimes random number for sandbox starts with 0 which is not allowed.

**Fixed**
A random number will be a combination of letters and digits that starts with letters.

 