### PR TITLE
fix: issue on delete old report

### DIFF
--- a/india_compliance/patches/post_install/update_e_invoice_fields_and_logs.py
+++ b/india_compliance/patches/post_install/update_e_invoice_fields_and_logs.py
@@ -307,4 +307,6 @@ def delete_old_doctypes():
 
 def delete_old_reports():
     for report in ("E-Invoice Summary",):
-        frappe.delete_doc("Report", report, force=True, ignore_permissions=True)
+        frappe.delete_doc(
+            "Report", report, force=True, ignore_permissions=True, ignore_on_trash=True
+        )


### PR DESCRIPTION
Error on trash:
Cannot delete standard report.

Ignored error on trash.