### PR TITLE
feat: setup default gst settings on install of app

### DIFF
--- a/india_compliance/gst_india/doctype/gst_settings/gst_settings.json
+++ b/india_compliance/gst_india/doctype/gst_settings/gst_settings.json
@@ -50,7 +50,7 @@
    "label": "Round Off GST Values"
   },
   {
-   "default": "0",
+   "default": "1",
    "fieldname": "hsn_wise_tax_breakup",
    "fieldtype": "Check",
    "label": "View Tax Breakup Table Based On HSN Code"
@@ -66,7 +66,7 @@
    "label": "API Secret"
   },
   {
-   "default": "0",
+   "default": "1",
    "description": "As per <a href=\"https://www.cbic.gov.in/resources/htdocs-cbec/gst/notfctn-78-central-tax-english-2020.pdf\">Central Tax Notification No. 78/2020</a>, HSN/SAC code must be specified in Sales Invoice with atleast 4 or 6 digits (based on turnover)",
    "fieldname": "validate_hsn_code",
    "fieldtype": "Check",
@@ -108,7 +108,7 @@
    "label": "e-Waybill"
   },
   {
-   "default": "0",
+   "default": "1",
    "fieldname": "enable_e_waybill",
    "fieldtype": "Check",
    "label": "Enable e-Waybill Features"
@@ -118,7 +118,7 @@
    "fieldtype": "Column Break"
   },
   {
-   "default": "0",
+   "default": "1",
    "depends_on": "eval: doc.enable_api && doc.enable_e_waybill",
    "description": "If checked, a PDF of the e-Waybill will be automatically attached to the transaction after it's generation",
    "fieldname": "attach_e_waybill_print",
@@ -127,7 +127,6 @@
   },
   {
    "default": "0",
-   "depends_on": "eval: doc.api_secret",
    "description": "Enable this to use API features like e-Waybill / e-Invoice generation from your ERP",
    "fieldname": "enable_api",
    "fieldtype": "Check",
@@ -160,7 +159,7 @@
    "label": "Invoice Value Threshold for e-Waybill Generation"
   },
   {
-   "default": "0",
+   "default": "1",
    "depends_on": "eval: doc.enable_api && doc.enable_e_waybill",
    "description": "e-Waybill will be automatically generated after Sales Invoice submission if the invoice value threshold is met, and data is available and valid",
    "fieldname": "auto_generate_e_waybill",
@@ -169,7 +168,7 @@
    "read_only_depends_on": "eval: doc.enable_e_invoice && doc.auto_generate_e_invoice"
   },
   {
-   "default": "0",
+   "default": "1",
    "depends_on": "eval: doc.enable_api && doc.enable_e_waybill",
    "description": "Automatically fetch e-Waybill data after it's generation for printing or logging purposes. This will lead to one additional API request.",
    "fieldname": "fetch_e_waybill_data",
@@ -178,7 +177,7 @@
    "read_only_depends_on": "eval: doc.attach_e_waybill_print"
   },
   {
-   "default": "0",
+   "default": "1",
    "depends_on": "eval: doc.enable_e_invoice",
    "description": "e-Invoice will be automatically generated after Sales Invoice submission if applicable",
    "fieldname": "auto_generate_e_invoice",
@@ -218,7 +217,7 @@
    "label": "Other APIs"
   },
   {
-   "default": "0",
+   "default": "1",
    "description": "When creating a new Customer / Supplier / Address using the Quick Entry form, other fields will be automatically fetched based on the GSTIN entered",
    "fieldname": "autofill_party_info",
    "fieldtype": "Check",
@@ -228,7 +227,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2022-06-14 09:17:17.584499",
+ "modified": "2022-06-14 08:57:22.354250",
  "modified_by": "Administrator",
  "module": "GST India",
  "name": "GST Settings",

--- a/india_compliance/gst_india/doctype/gst_settings/gst_settings.py
+++ b/india_compliance/gst_india/doctype/gst_settings/gst_settings.py
@@ -109,14 +109,20 @@ class GSTSettings(Document):
             )
 
     def validate_credentials(self):
-        if not self.enable_api or not (self.enable_e_invoice or self.enable_e_waybill):
-            return
-
-        for credential in self.credentials:
-            if credential.service == "e-Waybill / e-Invoice":
-                return
-
-        frappe.msgprint(
-            # TODO: Add Link to Documentation.
-            "Please set credentials for e-Waybill / e-Invoice to use API features"
-        )
+        if (
+            self.enable_api
+            and (self.enable_e_invoice or self.enable_e_waybill)
+            and all(
+                credential.service != "e-Waybill / e-Invoice"
+                for credential in self.credentials
+            )
+        ):
+            frappe.msgprint(
+                # TODO: Add Link to Documentation.
+                _(
+                    "Please set credentials for e-Waybill / e-Invoice to use API"
+                    " features"
+                ),
+                indicator="yellow",
+                alert=True,
+            )

--- a/india_compliance/gst_india/setup/__init__.py
+++ b/india_compliance/gst_india/setup/__init__.py
@@ -28,6 +28,7 @@ def after_install():
 
     create_property_setters()
     create_address_template()
+    setup_default_gst_settings()
     frappe.enqueue(create_hsn_codes, now=frappe.flags.in_test)
 
 
@@ -86,4 +87,5 @@ def setup_default_gst_settings():
     )
 
     # Hide the fields as not enabled by default
-    toggle_custom_fields(SALES_REVERSE_CHARGE_FIELDS, False)
+    for fields in (E_INVOICE_FIELDS, SALES_REVERSE_CHARGE_FIELDS):
+        toggle_custom_fields(fields, False)

--- a/india_compliance/install.py
+++ b/india_compliance/install.py
@@ -23,6 +23,7 @@ POST_INSTALL_PATCHES = (
     "update_e_invoice_fields_and_logs",
     "delete_gst_e_invoice_print_format",
     "remove_customer_gstin_field",
+    "set_default_gst_settings",
 )
 
 

--- a/india_compliance/patches/post_install/migrate_e_invoice_settings_to_gst_settings.py
+++ b/india_compliance/patches/post_install/migrate_e_invoice_settings_to_gst_settings.py
@@ -4,6 +4,9 @@ import frappe
 from frappe.utils import sbool
 from frappe.utils.password import decrypt
 
+from india_compliance.gst_india.constants.custom_fields import E_INVOICE_FIELDS
+from india_compliance.gst_india.utils import toggle_custom_fields
+
 
 def execute():
     singles = frappe.qb.DocType("Singles")
@@ -28,14 +31,13 @@ def execute():
         gst_settings.extend("gst_credentials", old_credentials)
         gst_settings.update_child_table("gst_credentials")
 
-    if not sbool(old_settings.enable):
-        return
-
-    click.secho(
-        "Your e-Invoice Settings have been migrated to GST Settings."
-        " Please enable the e-Invoice API in GST Settings manually.",
-        fg="yellow",
-    )
+    if sbool(old_settings.enable):
+        toggle_custom_fields(E_INVOICE_FIELDS, True)
+        click.secho(
+            "Your e-Invoice Settings have been migrated to GST Settings."
+            " Please enable the e-Invoice API in GST Settings manually.",
+            fg="yellow",
+        )
 
 
 def get_credentials_from_e_invoice_user():

--- a/india_compliance/patches/post_install/set_default_gst_settings.py
+++ b/india_compliance/patches/post_install/set_default_gst_settings.py
@@ -1,0 +1,53 @@
+import frappe
+
+from india_compliance.gst_india.constants.custom_fields import (
+    SALES_REVERSE_CHARGE_FIELDS,
+)
+from india_compliance.gst_india.utils import toggle_custom_fields
+
+# Enable setting only if transaction exists in last 3 years.
+POSTING_DATE_CONDITION = {
+    "posting_date": (">", "2019-04-01"),
+}
+
+
+def execute():
+    new_settings = {}
+    enable_overseas_transactions(new_settings)
+    enable_reverse_charge_in_sales(new_settings)
+    enable_e_waybill_from_dn(new_settings)
+
+    if new_settings:
+        frappe.db.set_value("GST Settings", None, new_settings)
+
+
+def enable_e_waybill_from_dn(settings):
+    if frappe.db.exists(
+        "Delivery Note",
+        {"ewaybill": ("not in", ("", None)), **POSTING_DATE_CONDITION},
+    ):
+        return
+
+    settings["enable_e_waybill_from_dn"] = 1
+
+
+def enable_overseas_transactions(settings):
+    if not frappe.db.exists(
+        "Sales Invoice",
+        {"gst_category": ("in", ("Overseas", "SEZ")), **POSTING_DATE_CONDITION},
+    ):
+        return
+
+    settings["enable_overseas_transactions"] = 1
+
+
+def enable_reverse_charge_in_sales(settings):
+    if not frappe.db.exists(
+        "Sales Invoice",
+        {"is_reverse_charge": 1, **POSTING_DATE_CONDITION},
+    ):
+        # No reverse charge invoices in the last three years, keep setting disabled.
+        return
+
+    settings["enable_reverse_charge_in_sales"] = 1
+    toggle_custom_fields(SALES_REVERSE_CHARGE_FIELDS, True)

--- a/india_compliance/patches/post_install/update_reverse_charge_field.py
+++ b/india_compliance/patches/post_install/update_reverse_charge_field.py
@@ -1,10 +1,5 @@
 import frappe
 
-from india_compliance.gst_india.constants.custom_fields import (
-    SALES_REVERSE_CHARGE_FIELDS,
-)
-from india_compliance.gst_india.utils import toggle_custom_fields
-
 DOCTYPES = ("Purchase Invoice", "Sales Invoice")
 
 
@@ -20,7 +15,6 @@ def execute():
         frappe.db.sql_ddl(
             "alter table `tab{0}` drop column {1}".format(doctype, column)
         )
-    set_default_gst_settings()
 
 
 def delete_old_fields():
@@ -31,16 +25,3 @@ def delete_old_fields():
             "dt": ("in", DOCTYPES),
         },
     )
-
-
-def set_default_gst_settings():
-    invoice = frappe.get_value(
-        "Sales Invoice",
-        {"is_reverse_charge": 1, "posting_date": [">", "2019-04-01"]},
-        "name",
-    )
-    if not invoice:
-        return
-
-    frappe.set_value("GST Settings", None, "enable_reverse_charge_in_sales", 1)
-    toggle_custom_fields(SALES_REVERSE_CHARGE_FIELDS, True)


### PR DESCRIPTION
- Default Settings
- Default API Settings
- Conditionally set Reverse Charge settings.
- GST Credentials required for at least one company if API Enabled (Warning).

No need for patch.
- Only one setting is overridden from previous settings. `hsn_wise_tax_breakup`

Closes: #44 