### PR TITLE
fix: remove gst category Registered Composition

### DIFF
--- a/india_compliance/gst_india/doctype/gstr_3b_report/gstr_3b_report.py
+++ b/india_compliance/gst_india/doctype/gstr_3b_report/gstr_3b_report.py
@@ -152,7 +152,6 @@ class GSTR3BReport(Document):
             FROM `tabPurchase Invoice` p , `tabPurchase Invoice Item` i
             WHERE p.docstatus = 1 and p.name = i.parent
             and p.is_opening = 'No'
-            and p.gst_category != 'Registered Composition'
             and (i.is_nil_exempt = 1 or i.is_non_gst = 1 or p.gst_category = 'Registered Composition') and
             month(p.posting_date) = %s and year(p.posting_date) = %s
             and p.company = %s and p.company_gstin = %s


### PR DESCRIPTION
Remove condition `and p.gst_category != 'Registered Composition'` from `def get_inward_nil_exempt()` in gstr_3b_report.py

Merged PR fixed: https://github.com/frappe/erpnext/pull/31236/