### PR TITLE
fix: map company address in party details

### DIFF
--- a/india_compliance/gst_india/client_scripts/transaction.js
+++ b/india_compliance/gst_india/client_scripts/transaction.js
@@ -21,6 +21,7 @@ function get_tax_template(frm) {
     const party_fields = [
         "shipping_address",
         "customer_address",
+        "company_address",
         "supplier_address",
         "shipping_address_name",
         "customer",


### PR DESCRIPTION
Async `company_address` in party_details constant of *transaction.py*

Changes as per Erpnext PR: https://github.com/frappe/erpnext/pull/31120/