### PR TITLE
fix: ignore disabled tax category

### DIFF
--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -452,7 +452,11 @@ def get_tax_template(master_doctype, company, is_inter_state, state_code):
     tax_categories = frappe.get_all(
         "Tax Category",
         fields=["name", "is_inter_state", "gst_state"],
-        filters={"is_inter_state": is_inter_state, "is_reverse_charge": 0},
+        filters={
+            "is_inter_state": is_inter_state,
+            "is_reverse_charge": 0,
+            "disabled": 0,
+        },
     )
 
     default_tax = ""


### PR DESCRIPTION
Ignore disable tax category in `def get_tax_template()` in *transaction.py*

Changes as per PR: https://github.com/frappe/erpnext/pull/30542/