### PR TITLE
fix: unset gst_state if it was already there

### DIFF
--- a/india_compliance/gst_india/overrides/address.py
+++ b/india_compliance/gst_india/overrides/address.py
@@ -34,7 +34,8 @@ def validate_state(doc):
     - Validate GST State Number with GSTIN.
     """
     if doc.country != "India":
-        doc.gst_state = doc.gst_state_number = None
+        doc.gst_state = None
+        doc.gst_state_number = None
         return
 
     if not doc.state:


### PR DESCRIPTION
Backport: https://github.com/frappe/erpnext/pull/30389 not required.
Fix: if state is already set. Unset it where country is not India.