### PR TITLE
fix(India): Incorrect taxable in GSTR-3B report

### DIFF
--- a/india_compliance/gst_india/doctype/gstr_3b_report/gstr_3b_report.py
+++ b/india_compliance/gst_india/doctype/gstr_3b_report/gstr_3b_report.py
@@ -244,13 +244,10 @@ class GSTR3BReport(Document):
             )
 
             for d in item_details:
-                if d.item_code not in self.invoice_items.get(d.parent, {}):
-                    self.invoice_items.setdefault(d.parent, {}).setdefault(
-                        d.item_code, 0.0
-                    )
-                    self.invoice_items[d.parent][d.item_code] += d.get(
-                        "taxable_value", 0
-                    ) or d.get("base_net_amount", 0)
+                self.invoice_items.setdefault(d.parent, {}).setdefault(d.item_code, 0.0)
+                self.invoice_items[d.parent][d.item_code] += d.get(
+                    "taxable_value", 0
+                ) or d.get("base_net_amount", 0)
 
                 if d.is_nil_exempt and d.item_code not in self.is_nil_exempt:
                     self.is_nil_exempt.append(d.item_code)


### PR DESCRIPTION
Remove **if** condition from function `def get_outward_items()`

Changes as per PR: https://github.com/frappe/erpnext/pull/31294