### PR TITLE
fix: update patch `is_export_with_gst` not in purchase invoice

### DIFF
--- a/india_compliance/patches/post_install/set_default_gst_settings.py
+++ b/india_compliance/patches/post_install/set_default_gst_settings.py
@@ -32,13 +32,13 @@ def enable_e_waybill_from_dn(settings):
 
 
 def enable_overseas_transactions(settings):
-    if not frappe.db.exists(
-        "Sales Invoice",
-        {"gst_category": ("in", ("Overseas", "SEZ")), **POSTING_DATE_CONDITION},
-    ):
-        return
-
-    settings["enable_overseas_transactions"] = 1
+    for doctype in ("Sales Invoice", "Purchase Invoice"):
+        if frappe.db.exists(
+            doctype,
+            {"gst_category": ("in", ("Overseas", "SEZ")), **POSTING_DATE_CONDITION},
+        ):
+            settings["enable_overseas_transactions"] = 1
+            return
 
 
 def enable_reverse_charge_in_sales(settings):
@@ -46,7 +46,6 @@ def enable_reverse_charge_in_sales(settings):
         "Sales Invoice",
         {"is_reverse_charge": 1, **POSTING_DATE_CONDITION},
     ):
-        # No reverse charge invoices in the last three years, keep setting disabled.
         return
 
     settings["enable_reverse_charge_in_sales"] = 1

--- a/india_compliance/patches/post_install/update_reverse_charge_and_export_type.py
+++ b/india_compliance/patches/post_install/update_reverse_charge_and_export_type.py
@@ -4,6 +4,10 @@ from india_compliance.gst_india.utils import delete_old_fields
 
 DOCTYPES = ("Purchase Invoice", "Sales Invoice")
 
+DOCTYPE_COLUMNS = {
+    doctype: frappe.db.get_table_columns(doctype) for doctype in DOCTYPES
+}
+
 
 def execute():
     update_field_to_check("reverse_charge", "is_reverse_charge", "Y")
@@ -11,9 +15,9 @@ def execute():
 
 
 def update_field_to_check(old_fieldname, new_fieldname, truthy_value):
-    for doctype in DOCTYPES:
-        doc_columns = frappe.db.get_table_columns(doctype)
-        if old_fieldname not in doc_columns or new_fieldname not in doc_columns:
+    for doctype, columns in DOCTYPE_COLUMNS.items():
+        # Check for new fieldname, is_export_with_gst is only applicable for Sales Invoice
+        if old_fieldname not in columns or new_fieldname not in columns:
             continue
 
         frappe.db.set_value(doctype, {old_fieldname: truthy_value}, new_fieldname, 1)


### PR DESCRIPTION
- No need to set new values in Purchase Invoice for `is_export_with_gst`.
- New field not created in Purchase Invoice.