### PR TITLE
fix: `place_of_supply` set from GSTIN instead of Address

### DIFF
--- a/india_compliance/gst_india/utils/__init__.py
+++ b/india_compliance/gst_india/utils/__init__.py
@@ -23,6 +23,16 @@ from india_compliance.gst_india.constants import (
 )
 
 
+def get_state(state_number):
+    """Get state from State Number"""
+
+    state_number = str(state_number)
+
+    for state, code in STATE_NUMBERS.items():
+        if code == state_number:
+            return state
+
+
 def load_doc(doctype, name, perm="read"):
     """Get doc, check perms and run onload method"""
     doc = frappe.get_doc(doctype, name)
@@ -229,8 +239,8 @@ def get_place_of_supply(party_details, doctype):
     :param party_details: A frappe._dict or document containing fields related to party
     """
 
-    # fallback to company gstin or supplier gstin
-    # (in retail scenarios, customer / shipping gstin may not be set)
+    # fallback to company GSTIN for sales or supplier GSTIN for purchases
+    # (in retail scenarios, customer / company GSTIN may not be set)
     if doctype in SALES_DOCTYPES:
         party_gstin = party_details.billing_address_gstin or party_details.company_gstin
     else:
@@ -240,11 +250,9 @@ def get_place_of_supply(party_details, doctype):
         return
 
     state_code = party_gstin[:2]
-    for state, code in STATE_NUMBERS.items():
-        if code != state_code:
-            continue
 
-        return f"{code}-{state}"
+    if state := get_state(state_code):
+        return f"{state_code}-{state}"
 
 
 def get_gst_accounts(

--- a/india_compliance/gst_india/utils/jinja.py
+++ b/india_compliance/gst_india/utils/jinja.py
@@ -6,7 +6,6 @@ import pyqrcode
 from barcode import Code128
 from barcode.writer import ImageWriter
 
-from india_compliance.gst_india.constants import STATE_NUMBERS
 from india_compliance.gst_india.constants.e_waybill import (
     SUB_SUPPLY_TYPES,
     TRANSPORT_MODES,
@@ -23,16 +22,6 @@ def add_spacing(string, interval):
 
     string = str(string)
     return " ".join(string[i : i + interval] for i in range(0, len(string), interval))
-
-
-def get_state(state_number):
-    """Get state from State Number"""
-
-    state_number = str(state_number)
-
-    for state, code in STATE_NUMBERS.items():
-        if code == state_number:
-            return state
 
 
 def get_sub_supply_type(code):

--- a/india_compliance/hooks.py
+++ b/india_compliance/hooks.py
@@ -151,8 +151,8 @@ regional_overrides = {
 
 jinja = {
     "methods": [
+        "india_compliance.gst_india.utils.get_state",
         "india_compliance.gst_india.utils.jinja.add_spacing",
-        "india_compliance.gst_india.utils.jinja.get_state",
         "india_compliance.gst_india.utils.jinja.get_sub_supply_type",
         "india_compliance.gst_india.utils.jinja.get_e_waybill_qr_code",
         "india_compliance.gst_india.utils.jinja.get_qr_code",


### PR DESCRIPTION
- Address is not mandatory.
- GSTIN could be fetch from party.
- Better to set POS from GSTIN.
- Address is validated to ensure match between GST State and GSTIN hence it will be same if Address is also available.