### PR TITLE
feat: validate `gst_category` for all transactions

### DIFF
--- a/india_compliance/gst_india/overrides/purchase_invoice.py
+++ b/india_compliance/gst_india/overrides/purchase_invoice.py
@@ -2,10 +2,7 @@ import frappe
 from frappe import _
 from frappe.utils import flt
 
-from india_compliance.gst_india.overrides.transaction import (
-    validate_mandatory_fields,
-    validate_transaction,
-)
+from india_compliance.gst_india.overrides.transaction import validate_transaction
 from india_compliance.gst_india.utils import get_gst_accounts_by_type
 
 
@@ -14,7 +11,6 @@ def validate(doc, method=None):
         return
 
     update_itc_totals(doc)
-    validate_mandatory_fields(doc, ("place_of_supply", "gst_category"))
     validate_supplier_gstin(doc)
 
 

--- a/india_compliance/gst_india/overrides/sales_invoice.py
+++ b/india_compliance/gst_india/overrides/sales_invoice.py
@@ -3,10 +3,7 @@ from frappe import _, bold
 from frappe.model import delete_doc
 
 from india_compliance.gst_india.constants import GST_INVOICE_NUMBER_FORMAT
-from india_compliance.gst_india.overrides.transaction import (
-    validate_mandatory_fields,
-    validate_transaction,
-)
+from india_compliance.gst_india.overrides.transaction import validate_transaction
 from india_compliance.gst_india.utils.e_invoice import validate_e_invoice_applicability
 
 
@@ -52,7 +49,6 @@ def validate(doc, method=None):
         return
 
     validate_invoice_number(doc)
-    validate_mandatory_fields(doc, ("place_of_supply", "gst_category"))
     validate_fields_and_set_status_for_e_invoice(doc)
     validate_billing_address_gstin(doc)
 

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -473,7 +473,8 @@ def get_gst_details(party_details, doctype, company):
 
     gst_details = frappe._dict()
 
-    if not party_details.gst_category:
+    party_address_field = "customer_address" if is_sales_doctype else "supplier_address"
+    if not party_details.get(party_address_field):
         party_gst_details = get_party_gst_details(party_details, is_sales_doctype)
         # updating party details to get correct place of supply
         party_details.update(party_gst_details)

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -90,21 +90,20 @@ def is_indian_registered_company(doc):
     return True
 
 
-def validate_mandatory_fields(doc, fields, message=""):
+def validate_mandatory_fields(doc, fields, message=None):
     if isinstance(fields, str):
         fields = (fields,)
 
     for field in fields:
-        if not doc.get(field):
-            frappe.throw(
-                _(
-                    "{0} is a mandatory field for creating a GST Compliant {1}. {2}"
-                ).format(
-                    bold(_(doc.meta.get_label(field))),
-                    _(doc.doctype),
-                    message,
-                )
+        if not doc.get(field) or field == "gst_category":
+            error_message = _("{0} is a mandatory field for GST Transactions").format(
+                bold(_(doc.meta.get_label(field))),
             )
+
+            if message:
+                error_message += f". {message}"
+
+            frappe.throw(error_message, title=_("Missing Required Field"))
 
 
 def get_valid_accounts(company, is_sales_transaction=False):
@@ -657,7 +656,7 @@ def validate_transaction(doc, method=None):
     set_place_of_supply(doc)
     validate_mandatory_fields(doc, ("company_gstin", "place_of_supply"))
     validate_mandatory_fields(
-        doc, "gst_category", "Please ensure it is set in Party and/or Address."
+        doc, "gst_category", _("Please ensure it is set in the Party and / or Address.")
     )
     validate_overseas_gst_category(doc)
 

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -11,6 +11,7 @@ from india_compliance.gst_india.utils import (
     get_all_gst_accounts,
     get_gst_accounts_by_type,
     get_place_of_supply,
+    validate_gst_category,
 )
 
 
@@ -480,6 +481,7 @@ def get_gst_details(party_details, doctype, company):
         party_details.update(party_gst_details)
         gst_details.update(party_gst_details)
 
+    validate_party_details(party_details, is_sales_doctype)
     gst_details.place_of_supply = get_place_of_supply(party_details, doctype)
 
     if is_sales_doctype:
@@ -530,6 +532,19 @@ def get_gst_details(party_details, doctype, company):
     gst_details.taxes = get_taxes_and_charges(master_doctype, default_tax)
 
     return gst_details
+
+
+def validate_party_details(party_details, is_sales_doctype):
+    """
+    This function validates
+    - GST Category is present in party_details
+    - GST Category is valid
+    """
+    gstin_field = "billing_address_gstin" if is_sales_doctype else "supplier_gstin"
+    if not party_details.get("gst_category"):
+        frappe.throw(_("Please enure that GST Category is set in Party and/or Address"))
+
+    validate_gst_category(party_details.gst_category, party_details.get(gstin_field))
 
 
 def get_party_gst_details(party_details, is_sales_doctype):

--- a/india_compliance/patches/post_install/update_gstin_and_gst_category.py
+++ b/india_compliance/patches/post_install/update_gstin_and_gst_category.py
@@ -104,16 +104,14 @@ def update_gstin_and_gst_category():
                     gst_category = ""
                     print_warning = True
 
-                new_gst_categories.setdefault((doctype, gst_category), []).append(
-                    party.name
-                )
+                new_gst_categories.setdefault(gst_category, []).append(address.name)
 
     for (doctype, gstin), docnames in new_gstins.items():
         frappe.db.set_value(doctype, {"name": ("in", docnames)}, "gstin", gstin)
 
-    for (doctype, gst_category), docnames in new_gst_categories.items():
+    for gst_category, docnames in new_gst_categories.items():
         frappe.db.set_value(
-            doctype, {"name": ("in", docnames)}, "gst_category", gst_category
+            "Address", {"name": ("in", docnames)}, "gst_category", gst_category
         )
 
     if print_warning:

--- a/india_compliance/public/gst_india/transaction.js
+++ b/india_compliance/public/gst_india/transaction.js
@@ -48,7 +48,7 @@ async function update_gst_details(frm) {
     if (in_list(frappe.boot.sales_doctypes, frm.doc.doctype)) {
         party_fields.push("customer_address", "billing_address_gstin");
     } else {
-        party_fields.push("supplier_gstin");
+        party_fields.push("supplier_address", "supplier_gstin");
     }
 
     const party_details = Object.fromEntries(


### PR DESCRIPTION
- ensure gstin and gst_category are set appropriately in all transactions
- fetch from party only if `address` (instead of `gst_category`) is not present.
- move mandatory fields to transaction.py as these are being set in all the transactions.
