### PR TITLE
perf: execute `create_custom_fields` only once

### DIFF
--- a/india_compliance/gst_india/setup/__init__.py
+++ b/india_compliance/gst_india/setup/__init__.py
@@ -18,13 +18,16 @@ def after_install():
     # Validation ignored for faster creation
     # Will not fail if a core field with same name already exists (!)
     # Will update a custom field if it already exists
-    for fields in (
-        CUSTOM_FIELDS,
-        SALES_REVERSE_CHARGE_FIELDS,
-        E_INVOICE_FIELDS,
-        E_WAYBILL_FIELDS,
-    ):
-        create_custom_fields(fields, ignore_validate=True)
+
+    create_custom_fields(
+        _get_custom_fields_to_create(
+            CUSTOM_FIELDS,
+            SALES_REVERSE_CHARGE_FIELDS,
+            E_INVOICE_FIELDS,
+            E_WAYBILL_FIELDS,
+        ),
+        ignore_validate=True,
+    )
 
     create_property_setters()
     create_address_template()
@@ -173,3 +176,16 @@ def show_accounts_settings_override_warning():
         "address for determining GST applicablility.",
         fg="yellow",
     )
+
+
+def _get_custom_fields_to_create(*custom_fields_list):
+    result = {}
+
+    for custom_fields in custom_fields_list:
+        for doctypes, fields in custom_fields.items():
+            if isinstance(fields, dict):
+                fields = [fields]
+
+            result.setdefault(doctypes, []).extend(fields)
+
+    return result

--- a/india_compliance/gst_india/setup/__init__.py
+++ b/india_compliance/gst_india/setup/__init__.py
@@ -1,7 +1,9 @@
 import click
 
 import frappe
-from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
+from frappe.custom.doctype.custom_field.custom_field import (
+    create_custom_fields as _create_custom_fields,
+)
 from frappe.utils import now_datetime, nowdate
 
 from india_compliance.gst_india.constants.custom_fields import (
@@ -15,11 +17,19 @@ from india_compliance.gst_india.utils import get_data_file_path, toggle_custom_f
 
 
 def after_install():
+    create_custom_fields()
+    create_property_setters()
+    create_address_template()
+    set_default_gst_settings()
+    set_default_accounts_settings()
+    create_hsn_codes()
+
+
+def create_custom_fields():
     # Validation ignored for faster creation
     # Will not fail if a core field with same name already exists (!)
     # Will update a custom field if it already exists
-
-    create_custom_fields(
+    _create_custom_fields(
         _get_custom_fields_to_create(
             CUSTOM_FIELDS,
             SALES_REVERSE_CHARGE_FIELDS,
@@ -28,12 +38,6 @@ def after_install():
         ),
         ignore_validate=True,
     )
-
-    create_property_setters()
-    create_address_template()
-    set_default_gst_settings()
-    set_default_accounts_settings()
-    create_hsn_codes()
 
 
 def create_property_setters():


### PR DESCRIPTION
This will help reap the perf benefits of https://github.com/frappe/frappe/pull/17826

We could also create custom fields for income tax together with these - but that's a bigger change 😅 