### PR TITLE
fix: disable IC account if secret set in conf

### DIFF
--- a/india_compliance/install.py
+++ b/india_compliance/install.py
@@ -39,6 +39,7 @@ def after_install():
 
         print("Setting up GST...")
         setup_gst()
+        disable_ic_account_page()
 
         print("Patching Existing Data...")
         run_post_install_patches()
@@ -67,3 +68,16 @@ def run_post_install_patches():
 
     finally:
         frappe.flags.in_patch = False
+
+
+def disable_ic_account_page():
+    """
+    Disable the India Compliance Account Page if API secret is set in frappe.conf
+    """
+
+    if not frappe.conf.ic_api_secret or frappe.db.exists(
+        "Custom Role", {"page": "india-compliance-account"}
+    ):
+        return
+
+    frappe.get_doc(doctype="Custom Role", page="india-compliance-account").insert()


### PR DESCRIPTION
This will add a `Custom Role` to disable IC account if API secret is set in conf when app is installed.

If API secret is set in conf after install is complete, IC account can be disabled by running following command:
```
bench execute india_compliance.install.disable_ic_account_page
```

We can add more utils to simplify this in future if reqd.