### PR TITLE
feat: delete e-Waybill on cancel

### DIFF
--- a/india_compliance/gst_india/client_scripts/e_waybill_actions.js
+++ b/india_compliance/gst_india/client_scripts/e_waybill_actions.js
@@ -19,6 +19,7 @@ function setup_e_waybill_actions(doctype) {
                     message: __("e-Waybill PDF attached successfully"),
                 });
             });
+            frappe.realtime.on("reload_doc", () => frm.reload_doc());
         },
         refresh(frm) {
             if (

--- a/india_compliance/gst_india/print_format/e_waybill/e_waybill.css
+++ b/india_compliance/gst_india/print_format/e_waybill/e_waybill.css
@@ -73,3 +73,18 @@
     width: 95px !important;
     image-rendering: -webkit-optimize-contrast;
 }
+
+.print-format .watermark {
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    font-size: 120px;
+    font-weight: 500px;
+    display: grid;
+    justify-content: center;
+    align-content: center;
+    opacity: 0.1;
+    transform: rotate(-45deg);
+}

--- a/india_compliance/gst_india/print_format/e_waybill/e_waybill.css
+++ b/india_compliance/gst_india/print_format/e_waybill/e_waybill.css
@@ -11,12 +11,12 @@
     }
 }
 
-.print-format tbody > tr > td, .print-format tbody > tr > th {
+.print-format tbody > tr > td,
+.print-format tbody > tr > th {
     padding: 6px !important;
     border-top: None;
     color: black;
 }
-
 
 .print-format h1.title {
     font-size: 18px;
@@ -47,16 +47,15 @@
     font-weight: bold;
 }
 
-.print-format .vehicle-info td, .print-format .vehicle-info th {
+.print-format .vehicle-info td,
+.print-format .vehicle-info th {
     border: 0px !important;
     border-top: 1px solid black !important;
 }
 
-
-
 .print-format table.table {
     width: 520px;
-    margin: 15px
+    margin: 15px;
 }
 
 .print-format .ewb-no-span {
@@ -68,23 +67,9 @@
     margin: 8px 0 16px;
 }
 
-.print-format table td img.barcode, .print-format table td img.qr-code {
+.print-format table td img.barcode,
+.print-format table td img.qr-code {
     margin-top: 5px;
     width: 95px !important;
     image-rendering: -webkit-optimize-contrast;
-}
-
-.print-format .watermark {
-    position: fixed;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    font-size: 120px;
-    font-weight: 500px;
-    display: grid;
-    justify-content: center;
-    align-content: center;
-    opacity: 0.1;
-    transform: rotate(-45deg);
 }

--- a/india_compliance/gst_india/print_format/e_waybill/e_waybill.html
+++ b/india_compliance/gst_india/print_format/e_waybill/e_waybill.html
@@ -6,6 +6,9 @@
 
 <html lang="en">
     <body>
+        {% if doc.is_cancelled %}
+        <div class="watermark">Cancelled</div>
+        {% endif %}
         <div class="page-layout">
             <table class="table borderless">
                 <tbody>

--- a/india_compliance/gst_india/print_format/e_waybill/e_waybill.html
+++ b/india_compliance/gst_india/print_format/e_waybill/e_waybill.html
@@ -6,9 +6,6 @@
 
 <html lang="en">
     <body>
-        {% if doc.is_cancelled %}
-        <div class="watermark">Cancelled</div>
-        {% endif %}
         <div class="page-layout">
             <table class="table borderless">
                 <tbody>


### PR DESCRIPTION
On cancel of e-Waybill, delete any existing attachments for old e-Waybills as they are not needed/meant to be reused.
For historical references, logs are available and can be printed again if needed from there.

Possible TODOs:

* [x] Watermark e-Waybill as cancelled in print format (HTML).

![image](https://user-images.githubusercontent.com/10496564/188783375-594efd73-354a-487c-be05-30a7382a7613.png)

This is similar to what govt does to ensure it is not misused.