### PR TITLE
fix(e-Waybill): set correct addresses for returns

### DIFF
--- a/india_compliance/gst_india/constants/e_waybill.py
+++ b/india_compliance/gst_india/constants/e_waybill.py
@@ -27,8 +27,8 @@ UPDATE_VEHICLE_REASON_CODES = {
 }
 
 SUPPLY_TYPES = {
-    "Inward": "I",
-    "Outward": "O",
+    "I": "Inward",
+    "O": "Outward",
 }
 
 SUB_SUPPLY_TYPES = {

--- a/india_compliance/gst_india/constants/e_waybill.py
+++ b/india_compliance/gst_india/constants/e_waybill.py
@@ -26,6 +26,11 @@ UPDATE_VEHICLE_REASON_CODES = {
     "Others": "3",
 }
 
+SUPPLY_TYPES = {
+    "Inward": "I",
+    "Outward": "O",
+}
+
 SUB_SUPPLY_TYPES = {
     "Supply": 1,
     "Import": 2,

--- a/india_compliance/gst_india/print_format/e_waybill/e_waybill.html
+++ b/india_compliance/gst_india/print_format/e_waybill/e_waybill.html
@@ -176,7 +176,7 @@
                         <td>Reason for Transportation</td>
                         <td>
                             <span>
-                                <strong>Outward - {{ get_sub_supply_type(data.subSupplyType) }} </strong>
+                                <strong>{{ get_supply_type(data.supplyType) }} - {{ get_sub_supply_type(data.subSupplyType) }} </strong>
                             </span>
                         </td>
                     </tr>

--- a/india_compliance/gst_india/utils/e_invoice.py
+++ b/india_compliance/gst_india/utils/e_invoice.py
@@ -89,7 +89,7 @@ def generate_e_invoice(docname, throw=True):
     )
 
     if result.EwbNo:
-        log_and_process_e_waybill_generation(doc, result)
+        log_and_process_e_waybill_generation(doc, result, with_irn=True)
 
     frappe.msgprint(
         _("e-Invoice generated successfully"),

--- a/india_compliance/gst_india/utils/jinja.py
+++ b/india_compliance/gst_india/utils/jinja.py
@@ -26,9 +26,7 @@ def add_spacing(string, interval):
 
 
 def get_supply_type(code):
-    for supply_type, _code in SUPPLY_TYPES.items():
-        if _code == code:
-            return supply_type
+    return SUPPLY_TYPES[code]
 
 
 def get_sub_supply_type(code):

--- a/india_compliance/gst_india/utils/jinja.py
+++ b/india_compliance/gst_india/utils/jinja.py
@@ -8,6 +8,7 @@ from barcode.writer import ImageWriter
 
 from india_compliance.gst_india.constants.e_waybill import (
     SUB_SUPPLY_TYPES,
+    SUPPLY_TYPES,
     TRANSPORT_MODES,
     TRANSPORT_TYPES,
 )
@@ -22,6 +23,12 @@ def add_spacing(string, interval):
 
     string = str(string)
     return " ".join(string[i : i + interval] for i in range(0, len(string), interval))
+
+
+def get_supply_type(code):
+    for supply_type, _code in SUPPLY_TYPES.items():
+        if _code == code:
+            return supply_type
 
 
 def get_sub_supply_type(code):

--- a/india_compliance/gst_india/utils/transaction_data.py
+++ b/india_compliance/gst_india/utils/transaction_data.py
@@ -142,15 +142,17 @@ class GSTTransactionData:
                     "vehicle_type": VEHICLE_TYPES.get(self.doc.gst_vehicle_type) or "R",
                     "vehicle_no": self.sanitize_value(self.doc.vehicle_no, 1),
                     "lr_no": self.sanitize_value(self.doc.lr_no, 2, max_length=15),
-                    "lr_date": format_date(self.doc.lr_date, self.DATE_FORMAT)
-                    if self.doc.lr_no
-                    else "",
+                    "lr_date": (
+                        format_date(self.doc.lr_date, self.DATE_FORMAT)
+                        if self.doc.lr_no
+                        else ""
+                    ),
                     "gst_transporter_id": self.doc.gst_transporter_id or "",
-                    "transporter_name": self.sanitize_value(
-                        self.doc.transporter_name, 3, max_length=25
-                    )
-                    if self.doc.transporter_name
-                    else "",
+                    "transporter_name": (
+                        self.sanitize_value(self.doc.transporter_name, 3, max_length=25)
+                        if self.doc.transporter_name
+                        else ""
+                    ),
                 }
             )
 

--- a/india_compliance/hooks.py
+++ b/india_compliance/hooks.py
@@ -145,6 +145,7 @@ jinja = {
     "methods": [
         "india_compliance.gst_india.utils.get_state",
         "india_compliance.gst_india.utils.jinja.add_spacing",
+        "india_compliance.gst_india.utils.jinja.get_supply_type",
         "india_compliance.gst_india.utils.jinja.get_sub_supply_type",
         "india_compliance.gst_india.utils.jinja.get_e_waybill_qr_code",
         "india_compliance.gst_india.utils.jinja.get_qr_code",


### PR DESCRIPTION
Fixes:
- Print format to incorporate Inward Supply for e-Waybill
![image](https://user-images.githubusercontent.com/10496564/188846389-6fa26686-557d-4137-8458-1bd5bba83786.png)

- Correct address for e-Waybill for sales return
- Not to generate e-Waybill using IRN for credit/debit note