### PR TITLE
fix: check e-Invoice applicability for e-Waybill

### DIFF
--- a/india_compliance/gst_india/client_scripts/e_waybill_actions.js
+++ b/india_compliance/gst_india/client_scripts/e_waybill_actions.js
@@ -120,7 +120,7 @@ function setup_e_waybill_actions(doctype) {
                 frm.doc.is_debit_note ||
                 !ic.is_api_enabled() ||
                 !gst_settings.auto_generate_e_waybill ||
-                gst_settings.enable_e_invoice ||
+                is_e_invoice_applicable(frm) ||
                 !is_e_waybill_applicable(frm)
             )
                 return;

--- a/india_compliance/gst_india/client_scripts/e_waybill_actions.js
+++ b/india_compliance/gst_india/client_scripts/e_waybill_actions.js
@@ -361,7 +361,7 @@ function show_generate_e_waybill_dialog(frm) {
     // Alert if e-Invoice hasn't been generated
     if (
         frm.doctype === "Sales Invoice" &&
-        gst_settings.enable_e_invoice &&
+        is_e_invoice_applicable(frm) &&
         !frm.doc.irn
     ) {
         $(`

--- a/india_compliance/gst_india/overrides/sales_invoice.py
+++ b/india_compliance/gst_india/overrides/sales_invoice.py
@@ -108,13 +108,10 @@ def on_submit(doc, method=None):
     if not is_api_enabled(gst_settings):
         return
 
-    if gst_settings.enable_e_invoice:
-        if (
-            not gst_settings.auto_generate_e_invoice
-            or not validate_e_invoice_applicability(doc, gst_settings, throw=False)
-        ):
-            return
-
+    if (
+        validate_e_invoice_applicability(doc, gst_settings, throw=False)
+        and gst_settings.auto_generate_e_invoice
+    ):
         frappe.enqueue(
             "india_compliance.gst_india.utils.e_invoice.generate_e_invoice",
             enqueue_after_commit=True,
@@ -125,7 +122,7 @@ def on_submit(doc, method=None):
 
         return
 
-    if (
+    elif (
         not gst_settings.enable_e_waybill
         or not gst_settings.auto_generate_e_waybill
         or doc.ewaybill

--- a/india_compliance/gst_india/utils/e_invoice.py
+++ b/india_compliance/gst_india/utils/e_invoice.py
@@ -183,6 +183,9 @@ def validate_e_invoice_applicability(doc, gst_settings=None, throw=True):
     if not gst_settings:
         gst_settings = frappe.get_cached_doc("GST Settings")
 
+    if not gst_settings.enable_e_invoice:
+        return _throw(_("e-Invoice is not enabled in GST Settings"))
+
     if getdate(gst_settings.e_invoice_applicable_from) > getdate(doc.posting_date):
         return _throw(
             _(

--- a/india_compliance/hooks.py
+++ b/india_compliance/hooks.py
@@ -28,8 +28,8 @@ doctype_js = {
     "Journal Entry": "gst_india/client_scripts/journal_entry.js",
     "Payment Entry": "gst_india/client_scripts/payment_entry.js",
     "Sales Invoice": [
-        "gst_india/client_scripts/e_waybill_actions.js",
         "gst_india/client_scripts/e_invoice_actions.js",
+        "gst_india/client_scripts/e_waybill_actions.js",
         "gst_india/client_scripts/sales_invoice.js",
     ],
     "Supplier": "gst_india/client_scripts/supplier.js",


### PR DESCRIPTION
- Now, it will only show if an e-Invoice is applicable and not created.
- e-Waybill will be autogenerated if e-Invoice is not applicable
- Have changed the sequence of JS files in hooks so that functions of e-Invoice are accessible in e-Waybill js

Closes: #261 

Also Closes: #260 