### PR TITLE
fix(ui): Show tax related fields under Tax tab in Customer/Supplier

### DIFF
--- a/india_compliance/gst_india/constants/custom_fields.py
+++ b/india_compliance/gst_india/constants/custom_fields.py
@@ -13,7 +13,7 @@ party_fields = [
         "fieldname": "tax_details_section",
         "label": "Tax Details",
         "fieldtype": "Section Break",
-        "insert_after": "companies",
+        "insert_after": "tax_withholding_category",
     },
     {
         "fieldname": "gstin",


### PR DESCRIPTION
Depends on https://github.com/frappe/erpnext/pull/32912
