### PR TITLE
Revert "fix(ui): Show tax related fields under Tax tab in Customer/Supplier"

### DIFF
--- a/india_compliance/gst_india/constants/custom_fields.py
+++ b/india_compliance/gst_india/constants/custom_fields.py
@@ -13,7 +13,7 @@ party_fields = [
         "fieldname": "tax_details_section",
         "label": "Tax Details",
         "fieldtype": "Section Break",
-        "insert_after": "tax_withholding_category",
+        "insert_after": "companies",
     },
     {
         "fieldname": "gstin",


### PR DESCRIPTION
Reverts resilient-tech/india-compliance#328

Original PR wasn't merged. Plus this needs a patch for existing users as well. Will do it manually after original PR is merged.