### PR TITLE
fix: hsn summary calculation

### DIFF
--- a/india_compliance/gst_india/report/hsn_wise_summary_of_outward_supplies/hsn_wise_summary_of_outward_supplies.py
+++ b/india_compliance/gst_india/report/hsn_wise_summary_of_outward_supplies/hsn_wise_summary_of_outward_supplies.py
@@ -40,7 +40,7 @@ def _execute(filters=None):
     data = []
     added_item = []
     for d in item_list:
-        if (d.parent, d.item_code) not in added_item:
+        if (d.parent, d.gst_hsn_code, d.item_code) not in added_item:
             row = [d.gst_hsn_code, d.description, d.stock_uom, d.stock_qty]
             total_tax = 0
             tax_rate = 0
@@ -56,7 +56,7 @@ def _execute(filters=None):
                 row += [item_tax.get("tax_amount", 0)]
 
             data.append(row)
-            added_item.append((d.parent, d.item_code))
+            added_item.append((d.parent, d.gst_hsn_code, d.item_code))
     if data:
         data = get_merged_data(columns, data)  # merge same hsn code data
     return columns, data
@@ -155,11 +155,9 @@ def get_items(filters):
         GROUP BY
             `tabSales Invoice Item`.parent,
             `tabSales Invoice Item`.item_code,
-            `tabSales Invoice Item`.gst_hsn_code,
-            `tabSales Invoice Item`.uom
+            `tabSales Invoice Item`.gst_hsn_code
         ORDER BY
-            `tabSales Invoice Item`.gst_hsn_code,
-            `tabSales Invoice Item`.uom
+            `tabSales Invoice Item`.gst_hsn_code
         """,
         filters,
         as_dict=1,

--- a/india_compliance/gst_india/utils/tests.py
+++ b/india_compliance/gst_india/utils/tests.py
@@ -91,6 +91,7 @@ def append_item(transaction, data=None, company_abbr="_TIRC"):
         {
             "item_code": data.item_code or "_Test Trading Goods 1",
             "qty": data.qty or 1,
+            "uom": data.uom,
             "rate": data.rate or 100,
             "cost_center": f"Main - {company_abbr}",
             "is_nil_exempt": data.is_nil_exempt,


### PR DESCRIPTION
**Problem:**
If you raise a GST invoice with the same item multiple times in the invoice with different UOMs, the report only shows data of 1 uom and skips the rest.

Also, if you add the same item twice in the invoice with different HSN Code(eg: Service items with same name and different HSN code), the report only shows data of either one.

**Cause:**
HSN wise Summary report grouped data in the SQL query by the following 4 parameters:
1. Parent, ie, Sales Invoice ID
2. HSN Code
3. Item Code
4. UOM

And in the `_execute` function, we grouped it by:
1. Parent
2. Item Code

[And then added only 1 matching data to the report.](https://github.com/resilient-tech/india-compliance/blob/next/india_compliance/gst_india/report/hsn_wise_summary_of_outward_supplies/hsn_wise_summary_of_outward_supplies.py#L43)

This caused issue as only 1 entry from the 1st group was considered by the report.

**Solution:**
This PR changed the grouping to:
SQL:
1. Parent
2. HSN Code
3. Item Code

`_execute` function:
1. Parent
2. HSN Code
3. Item Code

Also re-wrote the test case to accommodate this scenario.