### PR TITLE
fix: Taxable value for operating state in GSTR-1 report

### DIFF
--- a/india_compliance/gst_india/report/gstr_1/gstr_1.py
+++ b/india_compliance/gst_india/report/gstr_1/gstr_1.py
@@ -199,7 +199,7 @@ class Gstr1Report(object):
                     row["rate"] = rate
                     row["taxable_value"] += sum(
                         [
-                            abs(net_amount)
+                            net_amount
                             for item_code, net_amount in self.invoice_items.get(
                                 inv
                             ).items()
@@ -342,7 +342,7 @@ class Gstr1Report(object):
         elif self.filters.get("type_of_business") == "B2C Small":
             conditions += """ AND (
 				SUBSTR(place_of_supply, 1, 2) = SUBSTR(company_gstin, 1, 2)
-					OR grand_total <= {0}) and is_return != 1 AND gst_category ='Unregistered' """.format(
+					OR grand_total <= {0} OR is_return != 1) AND gst_category ='Unregistered' """.format(
                 B2C_LIMIT
             )
 


### PR DESCRIPTION
Credit Notes for states other than the operating state (Company Registered State) are reported separately under (9B) section in the GSTR-1 report. 

But Credit/Debit notes (B2C) having the same place of supply as the operating state (Intra-State) are not yet reported, which leads to overall incorrect taxable value