### PR TITLE
ci: fix flake8 URL

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,8 +25,8 @@ repos:
       hooks:
           - id: isort
 
-    - repo: https://gitlab.com/pycqa/flake8
-      rev: 3.9.2
+    - repo: https://github.com/PyCQA/flake8
+      rev: 5.0.4
       hooks:
           - id: flake8
             additional_dependencies: [flake8-isort, flake8-bugbear]


### PR DESCRIPTION
This PR fixes Linter failing issue at GitHub ci due to flake8 Gitlab URL.

![image](https://user-images.githubusercontent.com/54097382/202372295-80d450b2-79a9-42fa-afd7-6f5c68af659b.png)
