### PR TITLE
fix: setup of ewaybill info for delivery note on onload event

### DIFF
--- a/india_compliance/gst_india/overrides/delivery_note.py
+++ b/india_compliance/gst_india/overrides/delivery_note.py
@@ -12,7 +12,11 @@ def onload(doc, method=None):
 
     gst_settings = frappe.get_cached_doc("GST Settings")
 
-    if not (is_api_enabled(gst_settings) or gst_settings.enable_e_waybill_from_dn):
+    if not (
+        is_api_enabled(gst_settings)
+        and gst_settings.enable_e_waybill
+        and gst_settings.enable_e_waybill_from_dn
+    ):
         return
 
     doc.set_onload(

--- a/india_compliance/gst_india/overrides/delivery_note.py
+++ b/india_compliance/gst_india/overrides/delivery_note.py
@@ -7,33 +7,23 @@ from india_compliance.gst_india.utils import is_api_enabled
 
 
 def onload(doc, method=None):
+    gst_settings = frappe.get_cached_doc("GST Settings")
+
+    if not (is_api_enabled(gst_settings) or gst_settings.enable_e_waybill_from_dn):
+        return
+
     if not doc.get("ewaybill"):
         return
 
-    gst_settings = frappe.get_cached_value(
-        "GST Settings",
-        "GST Settings",
-        ("enable_api", "enable_e_waybill", "enable_e_waybill_from_dn", "api_secret"),
-        as_dict=1,
+    doc.set_onload(
+        "e_waybill_info",
+        frappe.get_value(
+            "e-Waybill Log",
+            doc.ewaybill,
+            ("created_on", "valid_upto"),
+            as_dict=True,
+        ),
     )
-
-    if not is_api_enabled(gst_settings):
-        return
-
-    if (
-        gst_settings.enable_e_waybill
-        and gst_settings.enable_e_waybill_from_dn
-        and doc.ewaybill
-    ):
-        doc.set_onload(
-            "e_waybill_info",
-            frappe.get_value(
-                "e-Waybill Log",
-                doc.ewaybill,
-                ("created_on", "valid_upto"),
-                as_dict=True,
-            ),
-        )
 
 
 def get_dashboard_data(data):

--- a/india_compliance/gst_india/overrides/delivery_note.py
+++ b/india_compliance/gst_india/overrides/delivery_note.py
@@ -1,6 +1,39 @@
+import frappe
+
 from india_compliance.gst_india.overrides.sales_invoice import (
     update_dashboard_with_gst_logs,
 )
+from india_compliance.gst_india.utils import is_api_enabled
+
+
+def onload(doc, method=None):
+    if not doc.get("ewaybill"):
+        return
+
+    gst_settings = frappe.get_cached_value(
+        "GST Settings",
+        "GST Settings",
+        ("enable_api", "enable_e_waybill", "enable_e_waybill_from_dn", "api_secret"),
+        as_dict=1,
+    )
+
+    if not is_api_enabled(gst_settings):
+        return
+
+    if (
+        gst_settings.enable_e_waybill
+        and gst_settings.enable_e_waybill_from_dn
+        and doc.ewaybill
+    ):
+        doc.set_onload(
+            "e_waybill_info",
+            frappe.get_value(
+                "e-Waybill Log",
+                doc.ewaybill,
+                ("created_on", "valid_upto"),
+                as_dict=True,
+            ),
+        )
 
 
 def get_dashboard_data(data):

--- a/india_compliance/gst_india/overrides/delivery_note.py
+++ b/india_compliance/gst_india/overrides/delivery_note.py
@@ -7,12 +7,12 @@ from india_compliance.gst_india.utils import is_api_enabled
 
 
 def onload(doc, method=None):
+    if not doc.get("ewaybill"):
+        return
+
     gst_settings = frappe.get_cached_doc("GST Settings")
 
     if not (is_api_enabled(gst_settings) or gst_settings.enable_e_waybill_from_dn):
-        return
-
-    if not doc.get("ewaybill"):
         return
 
     doc.set_onload(

--- a/india_compliance/gst_india/overrides/sales_invoice.py
+++ b/india_compliance/gst_india/overrides/sales_invoice.py
@@ -1,6 +1,5 @@
 import frappe
 from frappe import _, bold
-from frappe.model import delete_doc
 
 from india_compliance.gst_india.constants import GST_INVOICE_NUMBER_FORMAT
 from india_compliance.gst_india.overrides.transaction import validate_transaction
@@ -146,15 +145,6 @@ def on_submit(doc, method=None):
         doctype=doc.doctype,
         docname=doc.name,
     )
-
-
-def ignore_logs_on_trash(doc, method=None):
-    # TODO: design better way to achieve this
-    if "e-Waybill Log" not in delete_doc.doctypes_to_skip:
-        delete_doc.doctypes_to_skip += (
-            "e-Waybill Log",
-            "e-Invoice Log",
-        )
 
 
 def get_dashboard_data(data):

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -2,6 +2,7 @@ import json
 
 import frappe
 from frappe import _, bold
+from frappe.model import delete_doc
 from frappe.utils import cint, flt
 from erpnext.controllers.accounts_controller import get_taxes_and_charges
 
@@ -723,3 +724,12 @@ def validate_transaction(doc, method=None):
 
     valid_accounts = validate_gst_accounts(doc, is_sales_transaction) or ()
     update_taxable_values(doc, valid_accounts)
+
+
+def ignore_logs_on_trash(doc, method=None):
+    # TODO: design better way to achieve this
+    if "e-Waybill Log" not in delete_doc.doctypes_to_skip:
+        delete_doc.doctypes_to_skip += (
+            "e-Waybill Log",
+            "e-Invoice Log",
+        )

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -70,7 +70,7 @@ def _generate_e_waybill(doc, throw=True):
         # Via e-Invoice API if not Return or Debit Note
         # Handles following error when generating e-Waybill using IRN:
         # 4010: E-way Bill cannot generated for Debit Note, Credit Note and Services
-        with_irn = doc.irn and not (doc.is_return or doc.is_debit_note)
+        with_irn = doc.get("irn") and not (doc.is_return or doc.is_debit_note)
         data = EWaybillData(doc).get_data(with_irn=with_irn)
 
     except frappe.ValidationError as e:
@@ -157,7 +157,7 @@ def _cancel_e_waybill(doc, values):
         # if e-Waybill has been created using IRN
         if (
             frappe.conf.ic_api_sandbox_mode
-            and doc.irn
+            and doc.get("irn")
             and not (doc.is_return or doc.is_debit_note)
         )
         else EWaybillAPI

--- a/india_compliance/hooks.py
+++ b/india_compliance/hooks.py
@@ -64,6 +64,10 @@ doc_events = {
         ),
     },
     "Delivery Note": {
+        "on_trash": (
+            "india_compliance.gst_india.overrides.transaction.ignore_logs_on_trash"
+        ),
+        "onload": "india_compliance.gst_india.overrides.delivery_note.onload",
         "validate": (
             "india_compliance.gst_india.overrides.transaction.validate_transaction"
         ),
@@ -89,7 +93,7 @@ doc_events = {
     },
     "Sales Invoice": {
         "on_trash": (
-            "india_compliance.gst_india.overrides.sales_invoice.ignore_logs_on_trash"
+            "india_compliance.gst_india.overrides.transaction.ignore_logs_on_trash"
         ),
         "onload": "india_compliance.gst_india.overrides.sales_invoice.onload",
         "validate": "india_compliance.gst_india.overrides.sales_invoice.validate",


### PR DESCRIPTION
Before `e_waybill_info` was not set on onload of Delivery Note. So further e_waybill actions were not applicable.

This fix will set created_on and valid_upto data for ewaybill in `e_waybill_info` on `onload` event of Delivery Note.