### PR TITLE
fix: Rounding Adjustment precision after adjusting other charges

### DIFF
--- a/india_compliance/gst_india/utils/transaction_data.py
+++ b/india_compliance/gst_india/utils/transaction_data.py
@@ -95,6 +95,9 @@ class GSTTransactionData:
             # other charges cannot be negative
             # handle cases where user has higher precision than 2
             self.transaction_details.rounding_adjustment += other_charges
+            self.transaction_details.rounding_adjustment = self.rounded(
+                self.transaction_details.rounding_adjustment
+            )
         else:
             self.transaction_details.other_charges = other_charges
 

--- a/india_compliance/gst_india/utils/transaction_data.py
+++ b/india_compliance/gst_india/utils/transaction_data.py
@@ -87,19 +87,16 @@ class GSTTransactionData:
         for total in ["base_total", "rounding_adjustment", *tax_totals]:
             current_total += self.transaction_details.get(total)
 
-        other_charges = self.rounded(
-            (self.transaction_details.base_grand_total - current_total)
-        )
+        other_charges = self.transaction_details.base_grand_total - current_total
 
-        if -0.1 < other_charges < 0:
+        if 0 > other_charges > -0.1:
             # other charges cannot be negative
             # handle cases where user has higher precision than 2
-            self.transaction_details.rounding_adjustment += other_charges
             self.transaction_details.rounding_adjustment = self.rounded(
-                self.transaction_details.rounding_adjustment
+                self.transaction_details.rounding_adjustment + other_charges
             )
         else:
-            self.transaction_details.other_charges = other_charges
+            self.transaction_details.other_charges = self.rounded(other_charges)
 
     def validate_mode_of_transport(self, throw=True):
         def _throw(error):


### PR DESCRIPTION
<img width="578" alt="image" src="https://user-images.githubusercontent.com/42651287/204709510-db3aa2ac-88c9-4e7f-a66b-b1cae556a218.png">

<img width="436" alt="image" src="https://user-images.githubusercontent.com/42651287/204709576-ff7fabf9-cb35-4408-886e-d398d548b2bf.png">

When other_charges are rounded to `0.01` and rounding_adjustment is `0.03` the final `RndOffAmt ` is calculated as `0.019999999999999997`

<img width="264" alt="image" src="https://user-images.githubusercontent.com/42651287/204709735-20495789-739d-4f87-9572-f3135292de45.png">
