### PR TITLE
fix: `_dict` api changes for e-Invoice print format as per frappe

### DIFF
--- a/india_compliance/gst_india/print_format/e_invoice/e_invoice.html
+++ b/india_compliance/gst_india/print_format/e_invoice/e_invoice.html
@@ -51,7 +51,7 @@
 
 {% else %}
 
-{%- set invoice_data = _dict(json.loads(e_invoice_log.invoice_data)) -%}
+{%- set invoice_data = frappe.as_dict(json.loads(e_invoice_log.invoice_data)) -%}
 
 {% macro get_address_html(address) %}
 {% for field in ("Gstin", "LglNm", "Nm", "Addr1", "Addr2", "Loc") %}


### PR DESCRIPTION
## Issue
```
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 56, in application
    response = frappe.api.handle()
  File "apps/frappe/frappe/api.py", line 53, in handle
    return _RESTAPIHandler(call, doctype, name).get_response()
  File "apps/frappe/frappe/api.py", line 69, in get_response
    return self.handle_method()
  File "apps/frappe/frappe/api.py", line 79, in handle_method
    return frappe.handler.handle()
  File "apps/frappe/frappe/handler.py", line 45, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 83, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "apps/frappe/frappe/__init__.py", line 1586, in call
    return fn(*args, **newargs)
  File "apps/frappe/frappe/www/printview.py", line 294, in get_html_and_style
    html = get_rendered_template(
  File "apps/frappe/frappe/www/printview.py", line 207, in get_rendered_template
    html = template.render(args, filters={"len": len})
  File "env/lib/python3.10/site-packages/jinja2/environment.py", line 1301, in render
    self.environment.handle_exception()
  File "env/lib/python3.10/site-packages/jinja2/environment.py", line 936, in handle_exception
    raise rewrite_traceback_stack(source=source)
  File "<template>", line 54, in top-level template code
  File "env/lib/python3.10/site-packages/jinja2/sandbox.py", line 391, in call
    if not __self.is_safe_callable(__obj):
  File "env/lib/python3.10/site-packages/jinja2/sandbox.py", line 275, in is_safe_callable
    getattr(obj, "unsafe_callable", False) or getattr(obj, "alters_data", False)
jinja2.exceptions.UndefinedError: '_dict' is undefined
```

Backport Depends on: https://github.com/frappe/frappe/pull/19010