### PR TITLE
fix: Use country as a fallback for address lines

### DIFF
--- a/india_compliance/gst_india/overrides/test_transaction_data.py
+++ b/india_compliance/gst_india/overrides/test_transaction_data.py
@@ -98,7 +98,7 @@ class TestTransactionData(FrappeTestCase):
                 "state_number": "24",
                 "address_title": "Test Registered Customer",
                 "address_line1": "Test Address - 3",
-                "address_line2": None,
+                "address_line2": "India",
                 "city": "Test City",
                 "pincode": 380015,
             },

--- a/india_compliance/gst_india/utils/transaction_data.py
+++ b/india_compliance/gst_india/utils/transaction_data.py
@@ -317,9 +317,12 @@ class GSTTransactionData:
                 "address_title": self.sanitize_value(address.address_title, 2),
                 "address_line1": self.sanitize_value(
                     address.address_line1, 3, min_length=1
-                ),
-                "address_line2": self.sanitize_value(address.address_line2, 3),
-                "city": self.sanitize_value(address.city, 3, max_length=50),
+                )
+                or address.country,
+                "address_line2": self.sanitize_value(address.address_line2, 3)
+                or address.country,
+                "city": self.sanitize_value(address.city, 3, max_length=50)
+                or address.country,
                 "pincode": int(address.pincode),
             }
         )


### PR DESCRIPTION
Since "Address Line 2" is not mandatory in the Address master many times users don't update this and e-Invoice generation leads to the below error.

<img width="1363" alt="Screenshot 2022-12-07 at 11 14 17 PM" src="https://user-images.githubusercontent.com/42651287/206372962-51dd6466-58e5-479e-a1e8-2d987c534cf1.png">

Added this as a fallback for "Address Line 1" and "City" fields as well as these are open data fields and post sanitization they may not satisfy the required conditions

Using country since its a Link/Auto Complete field and there and there are fewer changes of mistakes in this field

Integration Request Dump

```
{"name":"8e089407bb","owner":"Administrator","creation":"2022-12-08 17:18:21.302710","modified":"2022-12-08 17:18:21.302710","modified_by":"Administrator","docstatus":0,"idx":0,"request_id":"9013dd31-2ebb-4d2b-9282-7a767e7fb030","integration_request_service":"India Compliance API","is_remote_request":0,"status":"Failed","url":"https://asp.resilient.tech/test/ei/api/invoice","request_headers":"{\n    \"gstin\": \"01AMBPG7773M002\",\n    \"password\": \"*****\",\n    \"requestid\": \"17c73ecd8709\",\n    \"user_name\": \"adqgspjkusr1\",\n    \"x-api-key\": \"*****\"\n}","data":"{\n    \"BuyerDtls\": {\n        \"Addr1\": \"28, \",\n        \"Gstin\": \"URP\",\n        \"LglNm\": \"Lei Pei\",\n        \"Pin\": 999999,\n        \"Pos\": \"96\",\n        \"Stcd\": \"96\",\n        \"TrdNm\": \"Lei Pei\"\n    },\n    \"DispDtls\": {\n        \"Addr1\": \"23/D, Paper Box Industrial Estate\",\n        \"Addr2\": \"MC Road, Andheri East\",\n        \"Loc\": \"Bangalore\",\n        \"Nm\": \"Banglaore\",\n        \"Pin\": 193501,\n        \"Stcd\": \"01\"\n    },\n    \"DocDtls\": {\n        \"Dt\": \"08/12/2022\",\n        \"No\": \"2FKWqS\",\n        \"Typ\": \"INV\"\n    },\n    \"EwbDtls\": {\n        \"Distance\": 0\n    },\n    \"ItemList\": [\n        {\n            \"AssAmt\": 1000.0,\n            \"CesAmt\": 0,\n            \"CesNonAdvlAmt\": 0,\n            \"CesRt\": 0,\n            \"CgstAmt\": 0,\n            \"Discount\": 0,\n            \"GstRt\": 0.0,\n            \"HsnCd\": \"999800\",\n            \"IgstAmt\": 0,\n            \"IsServc\": \"Y\",\n            \"PrdDesc\": \"Test Item 1\",\n            \"Qty\": 1.0,\n            \"SgstAmt\": 0,\n            \"SlNo\": \"1\",\n            \"TotAmt\": 1000.0,\n            \"TotItemVal\": 1000.0,\n            \"Unit\": \"NOS\",\n            \"UnitPrice\": 999.997\n        }\n    ],\n    \"PayDtls\": {\n        \"CrDay\": 90,\n        \"PaidAmt\": 0,\n        \"PayTerm\": \"30-50-20\",\n        \"PaymtDue\": 12.15\n    },\n    \"SellerDtls\": {\n        \"Addr1\": \"23/D, Paper Box Industrial Estate\",\n        \"Addr2\": \"MC Road, Andheri East\",\n        \"Gstin\": \"01AMBPG7773M002\",\n        \"LglNm\": \"Gadget Technologies Pvt. Ltd.\",\n        \"Loc\": \"Bangalore\",\n        \"Pin\": 193501,\n        \"Stcd\": \"01\",\n        \"TrdNm\": \"Banglaore\"\n    },\n    \"ShipDtls\": {\n        \"Addr1\": \"28, \",\n        \"Gstin\": \"URP\",\n        \"LglNm\": \"Lei Pei\",\n        \"Pin\": 999999,\n        \"Stcd\": \"96\",\n        \"TrdNm\": \"Lei Pei\"\n    },\n    \"TranDtls\": {\n        \"RegRev\": \"N\",\n        \"SupTyp\": \"EXPWOP\",\n        \"TaxSch\": \"GST\"\n    },\n    \"ValDtls\": {\n        \"AssVal\": 1000.0,\n        \"CesVal\": 0,\n        \"CgstVal\": 0,\n        \"Discount\": 0,\n        \"IgstVal\": 0,\n        \"OthChrg\": 0.31,\n        \"RndOffAmt\": 0.0,\n        \"SgstVal\": 0,\n        \"TotInvVal\": 1000.31,\n        \"TotInvValFc\": 12.15\n    },\n    \"Version\": \"1.1\"\n}","output":"{\n    \"message\": \"5002 : The Location field is required., 5002 : The Location field is required.\",\n    \"success\": false\n}","error":"5002 : The Location field is required., 5002 : The Location field is required.","reference_doctype":"Sales Invoice","reference_docname":"SINV-22-00022","doctype":"Integration Request","__last_sync_on":"2022-12-08T11:48:27.808Z"}
```

Sample Address

<img width="1341" alt="image" src="https://user-images.githubusercontent.com/42651287/206439607-4844df36-e007-47b3-af9d-957ed6d5e4ed.png">
