### PR TITLE
fix: get state from gst state number

### DIFF
--- a/india_compliance/gst_india/utils/__init__.py
+++ b/india_compliance/gst_india/utils/__init__.py
@@ -26,7 +26,7 @@ from india_compliance.gst_india.constants import (
 def get_state(state_number):
     """Get state from State Number"""
 
-    state_number = str(state_number)
+    state_number = str(state_number).zfill(2)
 
     for state, code in STATE_NUMBERS.items():
         if code == state_number:


### PR DESCRIPTION
**Issue**

`get_state()` function returns false because of condition mismatch like `'8' == '08'` in cases of GST State Number is a single Integer value (e.g. 8 for Rajasthan).

**Before**
![image](https://user-images.githubusercontent.com/54097382/207253274-605a6d02-4eda-42c2-9c9e-9a3d827dbf55.png)


**After**

![image](https://user-images.githubusercontent.com/54097382/207254075-330f8ae1-7dfe-4cb0-8994-0a12542494d7.png)



