### PR TITLE
fix: Ignore company related GST settings on clearing transactions

### DIFF
--- a/india_compliance/hooks.py
+++ b/india_compliance/hooks.py
@@ -170,6 +170,10 @@ override_doctype_dashboards = {
     ),
 }
 
+
+# DocTypes to be ignored while clearing transactions
+company_data_to_be_ignored = ["GST Account", "GST Credential"]
+
 # Includes in <head>
 # ------------------
 


### PR DESCRIPTION
Depends On: https://github.com/frappe/erpnext/pull/33362

GST Accounts and GST credentials get deleted while clearing transactions. These are not transactions and should be ignored 