### PR TITLE
fix: handle error 2283 on `get_e_invoice_by_irn`

### DIFF
--- a/india_compliance/gst_india/print_format/e_invoice/e_invoice.html
+++ b/india_compliance/gst_india/print_format/e_invoice/e_invoice.html
@@ -51,6 +51,14 @@
 
 {% else %}
 
+{% if not e_invoice_log.invoice_data %}
+
+<div class="text-center no-preview-available">
+	Invoice Data is unavailable in the {{ frappe.utils.get_link_to_form("e-Invoice Log", doc.irn, "e-Invoice Log") }} to generate print preview.
+</div>
+
+{% else %}
+
 {%- set invoice_data = _dict(json.loads(e_invoice_log.invoice_data)) -%}
 
 {% macro get_address_html(address) %}
@@ -233,5 +241,6 @@
 </div>
 </div>
 
+{% endif %}
 {% endif %}
 {% endif %}

--- a/india_compliance/gst_india/utils/e_invoice.py
+++ b/india_compliance/gst_india/utils/e_invoice.py
@@ -47,7 +47,10 @@ def generate_e_invoice(docname, throw=True):
 
         # Handle Duplicate IRN
         if result.InfCd == "DUPIRN":
-            result = api.get_e_invoice_by_irn(result.Desc.get("Irn"))
+            response = api.get_e_invoice_by_irn(result.Desc.get("Irn"))
+
+            # Handle: IRN details cannot be provided as it is generated more than 2 days ago
+            result = result.Desc if "2283" in response.get("message", "") else response
 
     except frappe.ValidationError as e:
         if throw:
@@ -71,9 +74,14 @@ def generate_e_invoice(docname, throw=True):
         }
     )
 
-    decoded_invoice = frappe.parse_json(
-        jwt.decode(result.SignedInvoice, options={"verify_signature": False})["data"]
-    )
+    invoice_data = None
+    if result.get("SignedInvoice"):
+        decoded_invoice = frappe.parse_json(
+            jwt.decode(result.SignedInvoice, options={"verify_signature": False})[
+                "data"
+            ]
+        )
+        invoice_data = frappe.as_json(decoded_invoice, indent=4)
 
     log_e_invoice(
         doc,
@@ -82,9 +90,9 @@ def generate_e_invoice(docname, throw=True):
             "sales_invoice": docname,
             "acknowledgement_number": result.AckNo,
             "acknowledged_on": parse_datetime(result.AckDt),
-            "signed_invoice": result.SignedInvoice,
-            "signed_qr_code": result.SignedQRCode,
-            "invoice_data": frappe.as_json(decoded_invoice, indent=4),
+            "signed_invoice": result.get("SignedInvoice"),
+            "signed_qr_code": result.get("SignedQRCode"),
+            "invoice_data": invoice_data,
         },
     )
 


### PR DESCRIPTION
### Error Response
`2283 : IRN details cannot be provided as it is generated more than 2 days ago`

### Error Reason
IRN was already generated. However, its details are fetch after 2 days of generation.
NIC doesn't store older data and hence cannot be retrieved.

### Solution
Set available IRN details in the Sales Invoice and create log for Ack No and Date

### Print preview where data is missing
![image](https://user-images.githubusercontent.com/10496564/208286625-cf31b5c3-0497-4c85-ab0a-3ac899d73544.png)

### e-Invoice log preview
![image](https://user-images.githubusercontent.com/10496564/208286658-89f1fc38-43dd-44d5-87a6-bd76b90d0ea5.png)

