### PR TITLE
fix: IRN not visible for Registered Composition

### DIFF
--- a/india_compliance/gst_india/constants/custom_fields.py
+++ b/india_compliance/gst_india/constants/custom_fields.py
@@ -600,10 +600,7 @@ E_INVOICE_FIELDS = {
             "insert_after": "customer",
             "no_copy": 1,
             "print_hide": 1,
-            "depends_on": (
-                'eval:in_list(["Registered Regular", "SEZ", "Overseas", "Deemed'
-                ' Export"], doc.gst_category)'
-            ),
+            "depends_on": 'eval:doc.gst_category != "Unregistered"',
             "translatable": 0,
         },
         {

--- a/india_compliance/patches.txt
+++ b/india_compliance/patches.txt
@@ -3,7 +3,7 @@
 
 [post_model_sync]
 india_compliance.patches.v14.set_default_for_overridden_accounts_setting
-execute:from india_compliance.gst_india.setup import create_custom_fields; create_custom_fields() #2
+execute:from india_compliance.gst_india.setup import create_custom_fields; create_custom_fields() #3
 execute:from india_compliance.gst_india.setup import create_property_setters; create_property_setters()
 india_compliance.patches.post_install.update_custom_role_for_e_invoice_summary
 india_compliance.patches.v14.remove_ecommerce_gstin_from_purchase_invoice


### PR DESCRIPTION
e-Invoice is applicable for all GST Categories except Unregistered.

### Issue
Currently, IRN is not visible for Registered Composition even though it's getting generated.

Reference
https://github.com/resilient-tech/india-compliance/blob/next/india_compliance/gst_india/client_scripts/e_invoice_actions.js#L165