### PR TITLE
fix: removed custom field and property setters after uninstall app

### DIFF
--- a/india_compliance/gst_india/setup/__init__.py
+++ b/india_compliance/gst_india/setup/__init__.py
@@ -30,7 +30,7 @@ def create_custom_fields():
     # Will not fail if a core field with same name already exists (!)
     # Will update a custom field if it already exists
     _create_custom_fields(
-        _get_custom_fields_to_create(
+        _get_custom_fields_map(
             CUSTOM_FIELDS,
             SALES_REVERSE_CHARGE_FIELDS,
             E_INVOICE_FIELDS,
@@ -184,7 +184,7 @@ def show_accounts_settings_override_warning():
     )
 
 
-def _get_custom_fields_to_create(*custom_fields_list):
+def _get_custom_fields_map(*custom_fields_list):
     result = {}
 
     for custom_fields in custom_fields_list:

--- a/india_compliance/gst_india/setup/__init__.py
+++ b/india_compliance/gst_india/setup/__init__.py
@@ -14,6 +14,9 @@ from india_compliance.gst_india.constants.custom_fields import (
 )
 from india_compliance.gst_india.setup.property_setters import get_property_setters
 from india_compliance.gst_india.utils import get_data_file_path, toggle_custom_fields
+from india_compliance.patches.post_install.update_e_invoice_fields_and_logs import (
+    delete_custom_fields as _delete_custom_fields,
+)
 
 
 def after_install():
@@ -23,6 +26,11 @@ def after_install():
     set_default_gst_settings()
     set_default_accounts_settings()
     create_hsn_codes()
+
+
+def after_uninstall():
+    delete_custom_fields()
+    delete_property_setters()
 
 
 def create_custom_fields():
@@ -43,6 +51,25 @@ def create_custom_fields():
 def create_property_setters():
     for property_setter in get_property_setters():
         frappe.make_property_setter(property_setter)
+
+
+def delete_custom_fields():
+    _delete_custom_fields(
+        _get_custom_fields_map(
+            CUSTOM_FIELDS,
+            SALES_REVERSE_CHARGE_FIELDS,
+            E_INVOICE_FIELDS,
+            E_WAYBILL_FIELDS,
+        )
+    )
+
+
+def delete_property_setters():
+    for property_setter in get_property_setters():
+        keys_to_update = ["doc_type", "field_name", "property", "value"]
+        # Update the keys to match with the property setter fields
+        filters = dict(zip(keys_to_update, list(property_setter.values())))
+        frappe.db.delete("Property Setter", filters)
 
 
 def create_address_template():

--- a/india_compliance/gst_india/setup/__init__.py
+++ b/india_compliance/gst_india/setup/__init__.py
@@ -28,7 +28,7 @@ def after_install():
     create_hsn_codes()
 
 
-def after_uninstall():
+def before_uninstall():
     delete_custom_fields()
     delete_property_setters()
 

--- a/india_compliance/hooks.py
+++ b/india_compliance/hooks.py
@@ -14,7 +14,7 @@ after_install = "india_compliance.install.after_install"
 before_tests = "india_compliance.tests.before_tests"
 boot_session = "india_compliance.boot.set_bootinfo"
 
-after_uninstall = "india_compliance.uninstall.after_uninstall"
+before_uninstall = "india_compliance.uninstall.before_uninstall"
 
 app_include_js = "gst_india.bundle.js"
 

--- a/india_compliance/hooks.py
+++ b/india_compliance/hooks.py
@@ -14,6 +14,8 @@ after_install = "india_compliance.install.after_install"
 before_tests = "india_compliance.tests.before_tests"
 boot_session = "india_compliance.boot.set_bootinfo"
 
+after_uninstall = "india_compliance.uninstall.after_uninstall"
+
 app_include_js = "gst_india.bundle.js"
 
 doctype_js = {

--- a/india_compliance/income_tax_india/setup.py
+++ b/india_compliance/income_tax_india/setup.py
@@ -1,7 +1,14 @@
 from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
 
 from india_compliance.income_tax_india.constants.custom_fields import CUSTOM_FIELDS
+from india_compliance.patches.post_install.update_e_invoice_fields_and_logs import (
+    delete_custom_fields,
+)
 
 
 def after_install():
     create_custom_fields(CUSTOM_FIELDS, update=True)
+
+
+def after_uninstall():
+    delete_custom_fields(CUSTOM_FIELDS)

--- a/india_compliance/income_tax_india/setup.py
+++ b/india_compliance/income_tax_india/setup.py
@@ -10,5 +10,5 @@ def after_install():
     create_custom_fields(CUSTOM_FIELDS, update=True)
 
 
-def after_uninstall():
+def before_uninstall():
     delete_custom_fields(CUSTOM_FIELDS)

--- a/india_compliance/uninstall.py
+++ b/india_compliance/uninstall.py
@@ -1,0 +1,37 @@
+import frappe
+
+from india_compliance.gst_india.constants.custom_fields import (
+    CUSTOM_FIELDS,
+    E_INVOICE_FIELDS,
+    E_WAYBILL_FIELDS,
+    SALES_REVERSE_CHARGE_FIELDS,
+)
+from india_compliance.gst_india.setup import _get_custom_fields_map
+from india_compliance.gst_india.setup.property_setters import get_property_setters
+from india_compliance.patches.post_install.update_e_invoice_fields_and_logs import (
+    delete_custom_fields as _delete_custom_fields,
+)
+
+
+def after_uninstall():
+    delete_custom_fields()
+    delete_property_setters()
+
+
+def delete_custom_fields():
+    _delete_custom_fields(
+        _get_custom_fields_map(
+            CUSTOM_FIELDS,
+            SALES_REVERSE_CHARGE_FIELDS,
+            E_INVOICE_FIELDS,
+            E_WAYBILL_FIELDS,
+        ),
+        ignore_validate=True,
+    )
+
+
+def delete_property_setters():
+    for property_setter in get_property_setters():
+        keys_to_update = ["doc_type", "field_name", "property", "value"]
+        filters = dict(zip(keys_to_update, list(property_setter.values())))
+        frappe.db.delete("Property Setter", filters)

--- a/india_compliance/uninstall.py
+++ b/india_compliance/uninstall.py
@@ -1,19 +1,19 @@
 import click
 
 from india_compliance.gst_india.constants import BUG_REPORT_URL
-from india_compliance.gst_india.setup import after_uninstall as remove_gst_custom_fields
+from india_compliance.gst_india.setup import before_uninstall as remove_gst
 from india_compliance.income_tax_india.setup import (
-    after_uninstall as remove_income_tax_fields,
+    before_uninstall as remove_income_tax,
 )
 
 
-def after_uninstall():
+def before_uninstall():
     try:
         print("Removing Income Tax customizations...")
-        remove_income_tax_fields()
+        remove_income_tax()
 
         print("Removing GST customizations...")
-        remove_gst_custom_fields()
+        remove_gst()
 
     except Exception as e:
         click.secho(


### PR DESCRIPTION
Property Setters and Custom Fields will be removed on uninstall of the IC app.

Closes: #409