### PR TITLE
feat: allow configuring Sandbox Mode in GST Settings

### DIFF
--- a/.github/helper/site_config.json
+++ b/.github/helper/site_config.json
@@ -13,6 +13,5 @@
  "host_name": "http://test_site:8000",
  "install_apps": ["erpnext"],
  "ic_api_secret": "*****",
- "ic_api_sandbox_mode": 1,
  "throttle_user_limit": 100
 }

--- a/india_compliance/gst_india/api_classes/base.py
+++ b/india_compliance/gst_india/api_classes/base.py
@@ -26,7 +26,7 @@ class BaseAPI:
                 )
             )
 
-        self.sandbox_mode = frappe.conf.ic_api_sandbox_mode
+        self.sandbox_mode = self.settings.sandbox_mode
         self.default_headers = {
             "x-api-key": (
                 (self.settings.api_secret and self.settings.get_password("api_secret"))

--- a/india_compliance/gst_india/doctype/gst_settings/gst_settings.json
+++ b/india_compliance/gst_india/doctype/gst_settings/gst_settings.json
@@ -6,7 +6,6 @@
  "engine": "InnoDB",
  "field_order": [
   "general_tab",
-  "enable_api",
   "hsn_wise_tax_breakup",
   "enable_reverse_charge_in_sales",
   "enable_overseas_transactions",
@@ -14,6 +13,10 @@
   "column_break_4",
   "validate_hsn_code",
   "min_hsn_digits",
+  "api_section",
+  "enable_api",
+  "column_break_rk3h",
+  "sandbox_mode",
   "e_waybill_section",
   "enable_e_waybill",
   "enable_e_waybill_from_dn",
@@ -225,12 +228,29 @@
    "fieldname": "autofill_party_info",
    "fieldtype": "Check",
    "label": "Autofill Party Information based on GSTIN"
+  },
+  {
+   "fieldname": "api_section",
+   "fieldtype": "Section Break",
+   "label": "API"
+  },
+  {
+   "fieldname": "column_break_rk3h",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval: ic.is_api_enabled(doc)",
+   "description": "Enable this to explore GST API features in a test environment. API actions executed in sandbox mode won't affect your actual business data on the GST portal.",
+   "fieldname": "sandbox_mode",
+   "fieldtype": "Check",
+   "label": "Use API in Sandbox Mode?"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2022-09-07 09:49:38.261631",
+ "modified": "2023-01-03 02:39:59.034386",
  "modified_by": "Administrator",
  "module": "GST India",
  "name": "GST Settings",

--- a/india_compliance/gst_india/setup/__init__.py
+++ b/india_compliance/gst_india/setup/__init__.py
@@ -128,23 +128,26 @@ def create_hsn_codes():
 
 def set_default_gst_settings():
     settings = frappe.get_doc("GST Settings")
-    settings.db_set(
-        {
-            "hsn_wise_tax_breakup": 1,
-            "enable_reverse_charge_in_sales": 0,
-            "validate_hsn_code": 1,
-            "min_hsn_digits": 6,
-            "enable_e_waybill": 1,
-            "e_waybill_threshold": 50000,
-            # Default API Settings
-            "fetch_e_waybill_data": 1,
-            "attach_e_waybill_print": 1,
-            "auto_generate_e_waybill": 1,
-            "auto_generate_e_invoice": 1,
-            "e_invoice_applicable_from": nowdate(),
-            "auto_fill_party_info": 1,
-        }
-    )
+    default_settings = {
+        "hsn_wise_tax_breakup": 1,
+        "enable_reverse_charge_in_sales": 0,
+        "validate_hsn_code": 1,
+        "min_hsn_digits": 6,
+        "enable_e_waybill": 1,
+        "e_waybill_threshold": 50000,
+        # Default API Settings
+        "fetch_e_waybill_data": 1,
+        "attach_e_waybill_print": 1,
+        "auto_generate_e_waybill": 1,
+        "auto_generate_e_invoice": 1,
+        "e_invoice_applicable_from": nowdate(),
+        "auto_fill_party_info": 1,
+    }
+
+    if frappe.conf.developer_mode:
+        default_settings["sandbox_mode"] = 1
+
+    settings.db_set(default_settings)
 
     # Hide the fields as not enabled by default
     for fields in (E_INVOICE_FIELDS, SALES_REVERSE_CHARGE_FIELDS):

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -149,20 +149,20 @@ def cancel_e_waybill(*, doctype, docname, values):
 def _cancel_e_waybill(doc, values):
     """Separate function, since called in backend from e-invoice utils"""
 
-    data = EWaybillData(doc).get_e_waybill_cancel_data(values)
+    e_waybill_data = EWaybillData(doc)
     api = (
         EInvoiceAPI
         # Use EInvoiceAPI only for sandbox environment
         # if e-Waybill has been created using IRN
         if (
-            frappe.conf.ic_api_sandbox_mode
+            e_waybill_data.sandbox_mode
             and doc.get("irn")
             and not (doc.is_return or doc.is_debit_note)
         )
         else EWaybillAPI
     )
 
-    result = api(doc).cancel_e_waybill(data)
+    result = api(doc).cancel_e_waybill(e_waybill_data.get_data_for_cancellation(values))
 
     log_and_process_e_waybill(
         doc,
@@ -500,7 +500,7 @@ class EWaybillData(GSTTransactionData):
 
         return self.get_transaction_data()
 
-    def get_e_waybill_cancel_data(self, values):
+    def get_data_for_cancellation(self, values):
         self.validate_if_e_waybill_is_set()
         self.validate_if_ewaybill_can_be_cancelled()
 

--- a/india_compliance/gst_india/utils/test_e_invoice.py
+++ b/india_compliance/gst_india/utils/test_e_invoice.py
@@ -382,7 +382,7 @@ class TestEInvoice(FrappeTestCase):
         # Assert for Mock request data
         self.assertDictEqual(
             cancel_e_waybill.get("request_data"),
-            EWaybillData(doc).get_e_waybill_cancel_data(values),
+            EWaybillData(doc).get_data_for_cancellation(values),
         )
 
         # Prepared e_invoice cancel data

--- a/india_compliance/gst_india/utils/transaction_data.py
+++ b/india_compliance/gst_india/utils/transaction_data.py
@@ -24,8 +24,8 @@ class GSTTransactionData:
 
     def __init__(self, doc):
         self.doc = doc
-        self.sandbox_mode = frappe.conf.ic_api_sandbox_mode
         self.settings = frappe.get_cached_doc("GST Settings")
+        self.sandbox_mode = self.settings.sandbox_mode
         self.transaction_details = frappe._dict()
 
         # "CGST Account - TC": "cgst_account"

--- a/india_compliance/patches.txt
+++ b/india_compliance/patches.txt
@@ -7,3 +7,4 @@ execute:from india_compliance.gst_india.setup import create_custom_fields; creat
 execute:from india_compliance.gst_india.setup import create_property_setters; create_property_setters()
 india_compliance.patches.post_install.update_custom_role_for_e_invoice_summary
 india_compliance.patches.v14.remove_ecommerce_gstin_from_purchase_invoice
+india_compliance.patches.v14.set_sandbox_mode_in_gst_settings

--- a/india_compliance/patches/v14/set_sandbox_mode_in_gst_settings.py
+++ b/india_compliance/patches/v14/set_sandbox_mode_in_gst_settings.py
@@ -1,0 +1,6 @@
+import frappe
+
+
+def execute():
+    if frappe.conf.ic_api_sandbox_mode:
+        frappe.db.set_single_value("GST Settings", "sandbox_mode", 1)

--- a/india_compliance/tests/__init__.py
+++ b/india_compliance/tests/__init__.py
@@ -44,10 +44,15 @@ def before_tests():
 
 
 def set_default_settings_for_tests():
+    # e.g. set "All Customer Groups" as the default Customer Group
     for key in ("Customer Group", "Supplier Group", "Item Group", "Territory"):
         frappe.db.set_default(frappe.scrub(key), get_root_of(key))
 
+    # Allow Negative Stock
     frappe.db.set_single_value("Stock Settings", "allow_negative_stock", 1)
+
+    # Enable Sandbox Mode in GST Settings
+    frappe.db.set_single_value("GST Settings", "sandbox_mode", 1)
 
 
 def create_test_records():


### PR DESCRIPTION
New **API** section:

![Screenshot-2023-01-03-130234](https://user-images.githubusercontent.com/16315650/210318639-8ae455c1-e45e-4960-a960-4db7863fe4c8.png)


## Other Changes

- remove older conf
- minor refactor: `get_e_waybill_cancel_data` => `get_data_for_cancellation`
- set sandbox mode in GST settings during installation if `developer_mode` is set (?)
- patch to migrate existing site config to GST settings
- minor change for tests