### PR TITLE
fix: Unable to download GSTIN wise GSTR-1 JSON

### DIFF
--- a/india_compliance/gst_india/report/gstr_1/gstr_1.py
+++ b/india_compliance/gst_india/report/gstr_1/gstr_1.py
@@ -909,7 +909,7 @@ def get_json(filters, report_name, data):
 
     filters = json.loads(filters)
     report_data = json.loads(data)
-    gstin = get_company_gstin_number(
+    gstin = filters.get("company_gstin") or get_company_gstin_number(
         filters.get("company"), filters.get("company_address")
     )
 


### PR DESCRIPTION
In a multi-company setup where the company has multiple GSTINs and address user has to download GSTIN wise JSON file and upload it but the system only adds the default one in the JSON which leads to an error while uploading the JSON

<img width="832" alt="image" src="https://user-images.githubusercontent.com/42651287/211748589-683f9de0-b84c-4d8c-b5eb-0c7d2c72a52d.png">
 