### PR TITLE
fix: hsn field in new item quick entry

### DIFF
--- a/india_compliance/gst_india/constants/custom_fields.py
+++ b/india_compliance/gst_india/constants/custom_fields.py
@@ -554,6 +554,7 @@ CUSTOM_FIELDS = {
             "fieldtype": "Link",
             "options": "GST HSN Code",
             "insert_after": "item_group",
+            "allow_in_quick_entry": 1,
         },
         {
             "fieldname": "is_nil_exempt",

--- a/india_compliance/patches.txt
+++ b/india_compliance/patches.txt
@@ -3,7 +3,7 @@
 
 [post_model_sync]
 india_compliance.patches.v14.set_default_for_overridden_accounts_setting
-execute:from india_compliance.gst_india.setup import create_custom_fields; create_custom_fields() #4
+execute:from india_compliance.gst_india.setup import create_custom_fields; create_custom_fields() #5
 execute:from india_compliance.gst_india.setup import create_property_setters; create_property_setters()
 india_compliance.patches.post_install.update_custom_role_for_e_invoice_summary
 india_compliance.patches.v14.remove_ecommerce_gstin_from_purchase_invoice


### PR DESCRIPTION
HSN is required before creating new item if not an asset

- Before

![12](https://user-images.githubusercontent.com/108322669/212039557-8f8661df-5513-46ee-9c94-48ff640b0e6a.gif)

- After

![2](https://user-images.githubusercontent.com/108322669/212039672-9181daac-0743-4c7a-a5dd-baad60fc48bb.png)

