### PR TITLE
fix: Reverse charge application in purchase invoices

### DIFF
--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -529,7 +529,7 @@ def get_gst_details(party_details, doctype, company):
         destination_gstin = party_details.company_gstin
 
     if party_details.get("tax_category"):
-        party_details.is_reverse_charge = get_reverse_charge_by_tax_category(
+        gst_details.is_reverse_charge = get_reverse_charge_by_tax_category(
             party_details.tax_category
         )
 


### PR DESCRIPTION
- Fixed validation for reverse charge (check comments for more details on this)
- Appropriate Purchase Taxes and Charges template was not fetched based on the tax category as `party_details.is_reverse_charge` was never set as 1