### PR TITLE
fix: Negative credit days error while generating e-Invoice

### DIFF
--- a/india_compliance/gst_india/utils/e_invoice.py
+++ b/india_compliance/gst_india/utils/e_invoice.py
@@ -323,7 +323,9 @@ class EInvoiceData(GSTTransactionData):
         credit_days = 0
         paid_amount = 0
 
-        if self.doc.due_date:
+        if self.doc.due_date and getdate(self.doc.due_date) > getdate(
+            self.doc.posting_date
+        ):
             credit_days = (
                 getdate(self.doc.due_date) - getdate(self.doc.posting_date)
             ).days


### PR DESCRIPTION
Many users apply payment terms on orders and not invoices. ERPNext has a provision to fetch the payment terms from the order and not recalculate them during invoicing again. In such cases, the payment due date can be before the invoice posting date. This leads to an error while generating e-Invoice for such invoices as negative credit days are calculated

<img width="1320" alt="image" src="https://user-images.githubusercontent.com/42651287/212809115-52662c21-9dd1-40b3-be27-0aea99164daf.png">
