### PR TITLE
fix: `account_type` mandatory error while installing IC

### DIFF
--- a/india_compliance/gst_india/overrides/company.py
+++ b/india_compliance/gst_india/overrides/company.py
@@ -15,6 +15,7 @@ def delete_gst_settings_for_company(doc, method=None):
         row for row in gst_settings.get("gst_accounts", []) if row.company != doc.name
     ]
 
+    gst_settings.flags.ignore_mandatory = True
     gst_settings.save()
 
 
@@ -93,6 +94,10 @@ def update_gst_settings(company):
         gst_settings,
         "Reverse Charge",
     )
+
+    # Ignore mandatory during install, some values may not be set by post install patch
+    if frappe.flags.in_install:
+        gst_settings.flags.ignore_mandatory = True
 
     gst_settings.save()
 


### PR DESCRIPTION
This PR is to fix the Mandatory error while installing the IC app.
```
An error occurred while installing india_compliance: [GST Settings, GST Settings]: account_type
Traceback (most recent call last):
  File "apps/frappe/frappe/commands/site.py", line 413, in install_app
    _install_app(app, verbose=context.verbose, force=force)
  File "apps/frappe/frappe/installer.py", line 304, in install_app
    frappe.get_attr(after_install)()
  File "apps/india_compliance/india_compliance/install.py", line 55, in after_install
    raise e
  File "apps/india_compliance/india_compliance/install.py", line 46, in after_install
    run_post_install_patches()
  File "apps/india_compliance/india_compliance/install.py", line 68, in run_post_install_patches
    frappe.get_attr(f"india_compliance.patches.post_install.{patch}.execute")()
  File "apps/india_compliance/india_compliance/patches/post_install/create_company_fixtures.py", line 22, in execute
    make_default_tax_templates(company, "India")
  File "apps/india_compliance/india_compliance/gst_india/overrides/company.py", line 42, in make_default_tax_templates
    update_gst_settings(company)
  File "apps/india_compliance/india_compliance/gst_india/overrides/company.py", line 97, in update_gst_settings
    gst_settings.save()
  File "apps/frappe/frappe/model/document.py", line 305, in save
    return self._save(*args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 342, in _save
    self._validate()
  File "apps/frappe/frappe/model/document.py", line 528, in _validate
    self._validate_mandatory()
  File "apps/frappe/frappe/model/document.py", line 858, in _validate_mandatory
    raise frappe.MandatoryError(
frappe.exceptions.MandatoryError: [GST Settings, GST Settings]: account_type
```