### PR TITLE
fix: wrong item wise tax calculation

### DIFF
--- a/india_compliance/gst_india/utils/transaction_data.py
+++ b/india_compliance/gst_india/utils/transaction_data.py
@@ -250,17 +250,15 @@ class GSTTransactionData:
                 continue
 
             tax_rate = self.rounded(item_tax[0], 3)
-            tax_amount = abs(self.rounded(item_tax[1]))
 
             # considers senarios where same item is there multiple times
-            if row.charge_type != "Actual":
-                tax_amount = abs(
-                    self.rounded(
-                        tax_rate * item.qty
-                        if row.charge_type == "On Item Quantity"
-                        else tax_rate * item.taxable_value / 100
-                    ),
-                )
+            tax_amount = abs(
+                self.rounded(
+                    tax_rate * item.qty
+                    if row.charge_type == "On Item Quantity"
+                    else tax_rate * item.taxable_value / 100
+                ),
+            )
 
             item_details.update(
                 {

--- a/india_compliance/gst_india/utils/transaction_data.py
+++ b/india_compliance/gst_india/utils/transaction_data.py
@@ -243,14 +243,14 @@ class GSTTransactionData:
 
             # Remove '_account' from 'cgst_account'
             tax = self.gst_accounts[row.account_head][:-8]
-            tax_rate = frappe.parse_json(row.item_wise_tax_detail).get(
+            item_tax = frappe.parse_json(row.item_wise_tax_detail).get(
                 item.item_code or item.item_name
             )
-            if not tax_rate:
+            if not item_tax:
                 continue
 
-            tax_rate = self.rounded(tax_rate[0], 3)
-            tax_amount = abs(self.rounded(tax_rate[1]))
+            tax_rate = self.rounded(item_tax[0], 3)
+            tax_amount = abs(self.rounded(item_tax[1]))
 
             # considers senarios where same item is there multiple times
             if row.charge_type != "Actual":


### PR DESCRIPTION
Tax calculation goes wrong if the same tax account is repeated in the tax table.


https://github.com/frappe/ecommerce_integrations/blob/32a62fc199699af55077903eee14b09d935dff5a/ecommerce_integrations/shopify/order.py#L188-L211


Shopify orders, when synced, would have a manually calculated tax table, as seen in the above code.