### PR TITLE
fix: better help info when using GSTIN autofill in sandbox mode

### DIFF
--- a/india_compliance/gst_india/utils/gstin_info.py
+++ b/india_compliance/gst_india/utils/gstin_info.py
@@ -28,10 +28,14 @@ def get_gstin_info(gstin):
         frappe.throw(_("Not allowed"), frappe.PermissionError)
 
     validate_gstin(gstin)
-    response = PublicAPI().get_gstin_info(gstin)
+    public_api = PublicAPI()
+    response = public_api.get_gstin_info(gstin)
     business_name = (
         response.tradeNam if response.ctb == "Proprietorship" else response.lgnm
     )
+
+    if public_api.sandbox_mode:
+        business_name = "Resilient Tech"
 
     gstin_info = frappe._dict(
         gstin=response.gstin,

--- a/india_compliance/public/js/quick_entry.js
+++ b/india_compliance/public/js/quick_entry.js
@@ -1,7 +1,3 @@
-const GSTIN_FIELD_DESCRIPTION = __(
-    "Autofill party information by entering their GSTIN"
-);
-
 class GSTQuickEntryForm extends frappe.ui.form.QuickEntryForm {
     constructor(...args) {
         super(...args);
@@ -22,10 +18,10 @@ class GSTQuickEntryForm extends frappe.ui.form.QuickEntryForm {
                 fieldtype: "Section Break",
                 description: this.api_enabled
                     ? __(
-                          `When you enter a GSTIN, the permanent address linked to it is
-                        auto-filled by default.<br>
+                        `When you enter a GSTIN, the permanent address linked to it is
+                        autofilled by default.<br>
                         Change the Pincode to autofill other addresses.`
-                      )
+                    )
                     : "",
                 collapsible: 0,
             },
@@ -85,7 +81,7 @@ class GSTQuickEntryForm extends frappe.ui.form.QuickEntryForm {
                 label: "GSTIN",
                 fieldname: "_gstin",
                 fieldtype: "Autocomplete",
-                description: this.api_enabled ? GSTIN_FIELD_DESCRIPTION : "",
+                description: this.api_enabled ? get_gstin_description() : "",
                 ignore_validation: true,
                 onchange: () => {
                     const d = this.dialog;
@@ -280,7 +276,16 @@ async function autofill_fields(dialog) {
         pincode_field.set_data([]);
         pincode_field.df.onchange = null;
 
-        gstin_field.set_description(GSTIN_FIELD_DESCRIPTION);
+        gstin_field.set_description(get_gstin_description());
+        return;
+    }
+
+    if (gst_settings.sandbox_mode && gstin !== "33GSPTN9771G3ZP") {
+        frappe.show_alert({
+            message: __("Skipping data retrieval for GSTIN restricted in Sandbox Mode"),
+        });
+
+        gstin_field.set_description("");
         return;
     }
 
@@ -293,6 +298,11 @@ async function autofill_fields(dialog) {
 }
 
 function set_gstin_description(gstin_field, status) {
+    if (!status) {
+        gstin_field.set_description("");
+        return;
+    }
+
     const STATUS_COLORS = { Active: "green", Cancelled: "red" };
 
     gstin_field.set_description(
@@ -366,5 +376,16 @@ function autofill_address(doc, { all_addresses }) {
     update_address_info(
         doc,
         all_addresses.find(address => address.pincode == pincode)
+    );
+}
+
+function get_gstin_description() {
+    if (!gst_settings.sandbox_mode) {
+        return __("Autofill party information by entering their GSTIN");
+    }
+
+    return __(
+        `To test the feature to autofill party information in Sandbox Mode,
+        use the following GSTIN: <br><strong>33GSPTN9771G3ZP</strong>`
     );
 }


### PR DESCRIPTION
## Issue
- Public API call in sandbox mode shows error.

## Solution
- No API call will be made in sandbox mode if other than allowed gstin is use
- Alert will be shown
## Screenshot
### Before
![image](https://user-images.githubusercontent.com/108322669/227553370-5d5baad6-2a17-44c5-925b-73684536ac05.png)
### After
![image](https://user-images.githubusercontent.com/16315650/229456687-a9ca7e6f-d68e-4bb1-8bfa-bf67a20e3da4.png)

![image](https://user-images.githubusercontent.com/16315650/229456799-fc9779d5-5a93-4ac6-871e-42e8a85d1129.png)

