### PR TITLE
fix: split e-invoice and e-waybill credentials

### DIFF
--- a/india_compliance/gst_india/api_classes/e_invoice.py
+++ b/india_compliance/gst_india/api_classes/e_invoice.py
@@ -38,7 +38,7 @@ class EInvoiceAPI(BaseAPI):
             frappe.throw(_("Company GSTIN is required to use the e-Invoice API"))
 
         else:
-            self.fetch_credentials(company_gstin, "e-Waybill / e-Invoice")
+            self.fetch_credentials(company_gstin, "e-Invoice")
 
         self.default_headers.update(
             {

--- a/india_compliance/gst_india/api_classes/e_waybill.py
+++ b/india_compliance/gst_india/api_classes/e_waybill.py
@@ -32,7 +32,7 @@ class EWaybillAPI(BaseAPI):
             frappe.throw(_("Company GSTIN is required to use the e-Waybill API"))
 
         else:
-            self.fetch_credentials(company_gstin, "e-Waybill / e-Invoice")
+            self.fetch_credentials(company_gstin, "e-Waybill")
 
         self.default_headers.update(
             {

--- a/india_compliance/gst_india/doctype/gst_credential/gst_credential.json
+++ b/india_compliance/gst_india/doctype/gst_credential/gst_credential.json
@@ -22,12 +22,12 @@
    "reqd": 1
   },
   {
-   "default": "e-Waybill / e-Invoice",
+   "default": "e-Waybill",
    "fieldname": "service",
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Service",
-   "options": "e-Waybill / e-Invoice\nReturns",
+   "options": "e-Waybill\ne-Invoice\nReturns",
    "reqd": 1
   },
   {
@@ -53,7 +53,7 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2022-07-24 02:04:03.084096",
+ "modified": "2023-03-28 17:50:06.517360",
  "modified_by": "Administrator",
  "module": "GST India",
  "name": "GST Credential",

--- a/india_compliance/gst_india/doctype/gst_settings/gst_settings.py
+++ b/india_compliance/gst_india/doctype/gst_settings/gst_settings.py
@@ -135,16 +135,22 @@ class GSTSettings(Document):
                 _("Missing Required Field"),
             )
 
-        if (self.enable_e_invoice or self.enable_e_waybill) and all(
-            credential.service != "e-Waybill / e-Invoice"
-            for credential in self.credentials
+        if self.enable_e_invoice and all(
+            credential.service != "e-Invoice" for credential in self.credentials
         ):
             frappe.msgprint(
                 # TODO: Add Link to Documentation.
-                _(
-                    "Please set credentials for e-Waybill / e-Invoice to use API"
-                    " features"
-                ),
+                _("Please set credentials for e-Invoice to use API" " features"),
+                indicator="yellow",
+                alert=True,
+            )
+
+        if self.enable_e_waybill and all(
+            credential.service != "e-Waybill" for credential in self.credentials
+        ):
+            frappe.msgprint(
+                # TODO: Add Link to Documentation.
+                _("Please set credentials for e-Waybill to use API" " features"),
                 indicator="yellow",
                 alert=True,
             )

--- a/india_compliance/patches/post_install/migrate_e_invoice_settings_to_gst_settings.py
+++ b/india_compliance/patches/post_install/migrate_e_invoice_settings_to_gst_settings.py
@@ -62,8 +62,11 @@ def get_credentials_from_e_invoice_user():
         .run(as_dict=True)
     )
 
+    einv_credential = []
+
     for credential in old_credentials:
         credential.password = credential.password and decrypt(credential.password)
-        credential.service = "e-Waybill / e-Invoice"
+        credential.service = "e-Waybill"
+        einv_credential.append(frappe._dict({**credential, "service": "e-Invoice"}))
 
-    return old_credentials
+    return old_credentials + einv_credential


### PR DESCRIPTION
Why? In multi-company scenario where one company requires e-Waybill and another requires both, the current setting will enable both for both companies. Splitting the services solves this issue.

![image](https://user-images.githubusercontent.com/52111700/228268524-eb9dc524-7295-4315-9d0a-4cdb51899db3.png)

ToDo: patch to split current credentials into two