### PR TITLE
refactor: consistent naming for amount keys in `transaction_details`

### DIFF
--- a/india_compliance/gst_india/overrides/test_transaction_data.py
+++ b/india_compliance/gst_india/overrides/test_transaction_data.py
@@ -142,9 +142,10 @@ class TestTransactionData(FrappeTestCase):
             gst_transaction_data.transaction_details,
             {
                 "date": format_date(frappe.utils.today(), "dd/mm/yyyy"),
-                "base_total": 100.0,
+                "total": 100.0,
                 "rounding_adjustment": 0.0,
-                "base_grand_total": 100.0,
+                "grand_total": 100.0,
+                "grand_total_in_foreign_currency": "",
                 "discount_amount": 0,
                 "company_gstin": "24AAQCA8719H1ZC",
                 "name": doc.name,

--- a/india_compliance/gst_india/utils/e_invoice.py
+++ b/india_compliance/gst_india/utils/e_invoice.py
@@ -394,11 +394,6 @@ class EInvoiceData(GSTTransactionData):
                 "credit_days": credit_days,
                 "outstanding_amount": abs(self.rounded(self.doc.outstanding_amount)),
                 "payment_terms": self.sanitize_value(self.doc.payment_terms_template),
-                "grand_total": (
-                    abs(self.rounded(self.doc.grand_total))
-                    if self.doc.currency != "INR"
-                    else ""
-                ),
             }
         )
 
@@ -542,7 +537,7 @@ class EInvoiceData(GSTTransactionData):
             },
             "ItemList": self.item_list,
             "ValDtls": {
-                "AssVal": self.transaction_details.base_total,
+                "AssVal": self.transaction_details.total,
                 "CgstVal": self.transaction_details.total_cgst_amount,
                 "SgstVal": self.transaction_details.total_sgst_amount,
                 "IgstVal": self.transaction_details.total_igst_amount,
@@ -551,8 +546,8 @@ class EInvoiceData(GSTTransactionData):
                 "Discount": self.transaction_details.discount_amount,
                 "RndOffAmt": self.transaction_details.rounding_adjustment,
                 "OthChrg": self.transaction_details.other_charges,
-                "TotInvVal": self.transaction_details.base_grand_total,
-                "TotInvValFc": self.transaction_details.grand_total,
+                "TotInvVal": self.transaction_details.grand_total,
+                "TotInvValFc": self.transaction_details.grand_total_in_foreign_currency,
             },
             "PayDtls": {
                 "Nm": self.transaction_details.payee_name,

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -834,7 +834,7 @@ class EWaybillData(GSTTransactionData):
             "toPincode": self.shipping_address.pincode,
             "toStateCode": self.to_address.state_number,
             "actToStateCode": self.shipping_address.state_number,
-            "totalValue": self.transaction_details.base_total,
+            "totalValue": self.transaction_details.total,
             "cgstValue": self.transaction_details.total_cgst_amount,
             "sgstValue": self.transaction_details.total_sgst_amount,
             "igstValue": self.transaction_details.total_igst_amount,
@@ -842,7 +842,7 @@ class EWaybillData(GSTTransactionData):
             "TotNonAdvolVal": self.transaction_details.total_cess_non_advol_amount,
             "OthValue": self.transaction_details.rounding_adjustment
             + self.transaction_details.other_charges,
-            "totInvValue": self.transaction_details.base_grand_total,
+            "totInvValue": self.transaction_details.grand_total,
             "transMode": self.transaction_details.mode_of_transport,
             "transDistance": self.transaction_details.distance,
             "transporterName": self.transaction_details.transporter_name,


### PR DESCRIPTION
`base_total` => `total`
`base_grand_total` => `grand_total`
`grand_total` => `grand_total_in_foreign_currency`

---

Notes:
- only one amount is required in foreign currency, i.e. `TotInvValFc`
- total before taxes in base currency is calculated using `taxable_value` of items so we don't find reference to `doc.base_total` in `transaction_data.py`