### PR TITLE
fix: fallback to `item_name` if `item_code` is missing in GSTR-1

### DIFF
--- a/india_compliance/gst_india/report/gstr_1/gstr_1.py
+++ b/india_compliance/gst_india/report/gstr_1/gstr_1.py
@@ -368,7 +368,7 @@ class Gstr1Report(object):
 
         items = frappe.db.sql(
             """
-			select item_code, parent, taxable_value, base_net_amount, item_tax_rate, is_nil_exempt,
+			select item_code, item_name, parent, taxable_value, base_net_amount, item_tax_rate, is_nil_exempt,
 			is_non_gst from `tab%s Item`
 			where parent in (%s)
 		"""
@@ -378,6 +378,7 @@ class Gstr1Report(object):
         )
 
         for d in items:
+            d.item_code = d.item_code or d.item_name
             self.invoice_items.setdefault(d.parent, {}).setdefault(d.item_code, 0.0)
             self.invoice_items[d.parent][d.item_code] += d.get(
                 "taxable_value", 0


### PR DESCRIPTION
Reference Support Issue: ISS-23-24-00144