### PR TITLE
fix: send dispatch and shipping address only if different

### DIFF
--- a/india_compliance/gst_india/data/test_e_invoice.json
+++ b/india_compliance/gst_india/data/test_e_invoice.json
@@ -16,13 +16,6 @@
 				"Stcd": "36",
 				"TrdNm": "Test Registered Customer"
 			},
-			"DispDtls": {
-				"Addr1": "Test Address - 1",
-				"Loc": "Test City",
-				"Nm": "Test Indian Registered Company",
-				"Pin": 193501,
-				"Stcd": "01"
-			},
 			"DocDtls": {
 				"Dt": "16/09/2022",
 				"No": "test_invoice_no",
@@ -69,15 +62,6 @@
 				"Pin": 193501,
 				"Stcd": "01",
 				"TrdNm": "Test Indian Registered Company"
-			},
-			"ShipDtls": {
-				"Addr1": "Test Address - 3",
-				"Gstin": "36AMBPG7773M002",
-				"LglNm": "Test Registered Customer",
-				"Loc": "Test City",
-				"Pin": 500055,
-				"Stcd": "36",
-				"TrdNm": "Test Registered Customer"
 			},
 			"TranDtls": {
 				"RegRev": "N",
@@ -138,13 +122,6 @@
 				"Stcd": "36",
 				"TrdNm": "Test Registered Customer"
 			},
-			"DispDtls": {
-				"Addr1": "Test Address - 1",
-				"Loc": "Test City",
-				"Nm": "Test Indian Registered Company",
-				"Pin": 193501,
-				"Stcd": "01"
-			},
 			"DocDtls": {
 				"Dt": "17/09/2022",
 				"No": "test_invoice_no",
@@ -188,15 +165,6 @@
 				"Pin": 193501,
 				"Stcd": "01",
 				"TrdNm": "Test Indian Registered Company"
-			},
-			"ShipDtls": {
-				"Addr1": "Test Address - 3",
-				"Gstin": "36AMBPG7773M002",
-				"LglNm": "Test Registered Customer",
-				"Loc": "Test City",
-				"Pin": 500055,
-				"Stcd": "36",
-				"TrdNm": "Test Registered Customer"
 			},
 			"TranDtls": {
 				"RegRev": "N",
@@ -262,13 +230,6 @@
 				"Stcd": "36",
 				"TrdNm": "Test Registered Customer"
 			},
-			"DispDtls": {
-				"Addr1": "Test Address - 3",
-				"Loc": "Test City",
-				"Nm": "Test Registered Customer",
-				"Pin": 500055,
-				"Stcd": "36"
-			},
 			"DocDtls": {
 				"Dt": "17/09/2022",
 				"No": "test_invoice_no",
@@ -316,15 +277,6 @@
 				"Addr1": "Test Address - 1",
 				"Gstin": "01AMBPG7773M002",
 				"LglNm": "_Test Indian Registered Company",
-				"Loc": "Test City",
-				"Pin": 193501,
-				"Stcd": "01",
-				"TrdNm": "Test Indian Registered Company"
-			},
-			"ShipDtls": {
-				"Addr1": "Test Address - 1",
-				"Gstin": "01AMBPG7773M002",
-				"LglNm": "Test Indian Registered Company",
 				"Loc": "Test City",
 				"Pin": 193501,
 				"Stcd": "01",
@@ -394,13 +346,6 @@
 				"Stcd": "36",
 				"TrdNm": "Test Registered Customer"
 			},
-			"DispDtls": {
-				"Addr1": "Test Address - 1",
-				"Loc": "Test City",
-				"Nm": "Test Indian Registered Company",
-				"Pin": 193501,
-				"Stcd": "01"
-			},
 			"DocDtls": {
 				"Dt": "17/09/2022",
 				"No": "test_invoice_no",
@@ -444,15 +389,6 @@
 				"Pin": 193501,
 				"Stcd": "01",
 				"TrdNm": "Test Indian Registered Company"
-			},
-			"ShipDtls": {
-				"Addr1": "Test Address - 3",
-				"Gstin": "36AMBPG7773M002",
-				"LglNm": "Test Registered Customer",
-				"Loc": "Test City",
-				"Pin": 500055,
-				"Stcd": "36",
-				"TrdNm": "Test Registered Customer"
 			},
 			"TranDtls": {
 				"RegRev": "N",

--- a/india_compliance/gst_india/print_format/e_invoice/e_invoice.html
+++ b/india_compliance/gst_india/print_format/e_invoice/e_invoice.html
@@ -97,13 +97,8 @@
 <h5 class="section-heading">2. Party Details</h5>
 <div class="row section-break info-section">
 	<div class="col-xs-6 column-break">
-		{%- set is_dispatch_address_different = invoice_data.DispDtls and (
-			invoice_data.DispDtls.Addr1 != invoice_data.SellerDtls.Addr1
-			or invoice_data.DispDtls.Pin != invoice_data.SellerDtls.Pin
-		) -%}
-
 		<h6 class="address-heading">
-			{% if is_dispatch_address_different %}
+			{% if invoice_data.DispDtls %}
 				Seller Details
 			{% else %}
 				Seller and Dispatch Details
@@ -111,19 +106,14 @@
 		</h6>
 		{{ get_address_html(invoice_data.SellerDtls) }}
 
-		{%- if is_dispatch_address_different -%}
+		{%- if invoice_data.DispDtls -%}
 		<h6 class="address-heading">Dispatched From</h6>
 			{{ get_address_html(invoice_data.DispDtls) }}
 		{% endif %}
 	</div>
 	<div class="col-xs-6 column-break">
-		{%- set is_shipping_address_different = invoice_data.ShipDtls and (
-			invoice_data.ShipDtls.Addr1 != invoice_data.BuyerDtls.Addr1
-			or invoice_data.ShipDtls.Pin != invoice_data.BuyerDtls.Pin
-		) -%}
-
 		<h6 class="address-heading">
-			{% if is_shipping_address_different %}
+			{% if invoice_data.ShipDtls %}
 				Buyer Details
 			{% else %}
 				Buyer and Shipping Details
@@ -131,7 +121,7 @@
 		</h6>
 		{{ get_address_html(invoice_data.BuyerDtls) }}
 
-		{%- if is_shipping_address_different -%}
+		{%- if invoice_data.ShipDtls -%}
 			<h6 class="address-heading">Shipped To</h6>
 			{{ get_address_html(invoice_data.ShipDtls) }}
 		{% endif %}

--- a/india_compliance/gst_india/utils/e_invoice.py
+++ b/india_compliance/gst_india/utils/e_invoice.py
@@ -449,12 +449,6 @@ class EInvoiceData(GSTTransactionData):
         )
         self.company_address.legal_name = self.sanitize_value(self.doc.company)
 
-        if self.doc.is_return:
-            self.dispatch_address, self.shipping_address = (
-                self.shipping_address,
-                self.dispatch_address,
-            )
-
     def get_invoice_data(self):
         if self.sandbox_mode:
             seller = {
@@ -487,6 +481,12 @@ class EInvoiceData(GSTTransactionData):
                     self.transaction_details.place_of_supply = "36"
                 else:
                     self.transaction_details.place_of_supply = "01"
+
+        if self.doc.is_return:
+            self.dispatch_address, self.shipping_address = (
+                self.shipping_address,
+                self.dispatch_address,
+            )
 
         invoice_data = {
             "Version": "1.1",

--- a/india_compliance/gst_india/utils/e_invoice.py
+++ b/india_compliance/gst_india/utils/e_invoice.py
@@ -449,6 +449,12 @@ class EInvoiceData(GSTTransactionData):
         )
         self.company_address.legal_name = self.sanitize_value(self.doc.company)
 
+        if self.doc.is_return:
+            self.dispatch_address, self.shipping_address = (
+                self.shipping_address,
+                self.dispatch_address,
+            )
+
     def get_invoice_data(self):
         if self.sandbox_mode:
             seller = {
@@ -475,12 +481,6 @@ class EInvoiceData(GSTTransactionData):
                     self.transaction_details.place_of_supply = "36"
                 else:
                     self.transaction_details.place_of_supply = "01"
-
-        if self.doc.is_return:
-            self.dispatch_address, self.shipping_address = (
-                self.shipping_address,
-                self.dispatch_address,
-            )
 
         return {
             "Version": "1.1",

--- a/india_compliance/gst_india/utils/e_invoice.py
+++ b/india_compliance/gst_india/utils/e_invoice.py
@@ -424,8 +424,8 @@ class EInvoiceData(GSTTransactionData):
         )
 
         # Defaults
-        self.shipping_address = frappe._dict()
-        self.dispatch_address = frappe._dict()
+        self.shipping_address = None
+        self.dispatch_address = None
 
         if (
             self.doc.shipping_address_name
@@ -463,10 +463,14 @@ class EInvoiceData(GSTTransactionData):
                 "pincode": 193501,
             }
             self.company_address.update(seller)
-            self.transaction_details.name = random_string(6).lstrip("0")
+            if self.dispatch_address:
+                self.dispatch_address.update(seller)
 
-            if frappe.flags.in_test:
-                self.transaction_details.name = "test_invoice_no"
+            self.transaction_details.name = (
+                random_string(6).lstrip("0")
+                if not frappe.flags.in_test
+                else "test_invoice_no"
+            )
 
             # For overseas transactions, dummy GSTIN is not needed
             if self.doc.gst_category != "Overseas":
@@ -476,13 +480,15 @@ class EInvoiceData(GSTTransactionData):
                     "pincode": 500055,
                 }
                 self.billing_address.update(buyer)
+                if self.shipping_address:
+                    self.shipping_address.update(buyer)
 
                 if self.transaction_details.total_igst_amount > 0:
                     self.transaction_details.place_of_supply = "36"
                 else:
                     self.transaction_details.place_of_supply = "01"
 
-        return {
+        invoice_data = {
             "Version": "1.1",
             "TranDtls": {
                 "TaxSch": self.transaction_details.tax_scheme,
@@ -515,24 +521,6 @@ class EInvoiceData(GSTTransactionData):
                 "Pin": self.billing_address.pincode,
                 "Stcd": self.billing_address.state_number,
                 "Pos": self.transaction_details.place_of_supply,
-            },
-            "DispDtls": {
-                "Nm": self.dispatch_address.address_title,
-                "Addr1": self.dispatch_address.address_line1,
-                "Addr2": self.dispatch_address.address_line2,
-                "Loc": self.dispatch_address.city,
-                "Pin": self.dispatch_address.pincode,
-                "Stcd": self.dispatch_address.state_number,
-            },
-            "ShipDtls": {
-                "Gstin": self.shipping_address.gstin,
-                "LglNm": self.shipping_address.address_title,
-                "TrdNm": self.shipping_address.address_title,
-                "Addr1": self.shipping_address.address_line1,
-                "Addr2": self.shipping_address.address_line2,
-                "Loc": self.shipping_address.city,
-                "Pin": self.shipping_address.pincode,
-                "Stcd": self.shipping_address.state_number,
             },
             "ItemList": self.item_list,
             "ValDtls": {
@@ -577,6 +565,30 @@ class EInvoiceData(GSTTransactionData):
                 "VehType": self.transaction_details.vehicle_type,
             },
         }
+
+        if self.dispatch_address:
+            invoice_data["DispDtls"] = {
+                "Nm": self.dispatch_address.address_title,
+                "Addr1": self.dispatch_address.address_line1,
+                "Addr2": self.dispatch_address.address_line2,
+                "Loc": self.dispatch_address.city,
+                "Pin": self.dispatch_address.pincode,
+                "Stcd": self.dispatch_address.state_number,
+            }
+
+        if self.shipping_address:
+            invoice_data["ShipDtls"] = {
+                "Gstin": self.shipping_address.gstin,
+                "LglNm": self.shipping_address.address_title,
+                "TrdNm": self.shipping_address.address_title,
+                "Addr1": self.shipping_address.address_line1,
+                "Addr2": self.shipping_address.address_line2,
+                "Loc": self.shipping_address.city,
+                "Pin": self.shipping_address.pincode,
+                "Stcd": self.shipping_address.state_number,
+            }
+
+        return invoice_data
 
     def get_item_data(self, item_details):
         return {

--- a/india_compliance/gst_india/utils/e_invoice.py
+++ b/india_compliance/gst_india/utils/e_invoice.py
@@ -424,8 +424,8 @@ class EInvoiceData(GSTTransactionData):
         )
 
         # Defaults
-        self.shipping_address = self.billing_address
-        self.dispatch_address = self.company_address
+        self.shipping_address = frappe._dict()
+        self.dispatch_address = frappe._dict()
 
         if (
             self.doc.shipping_address_name
@@ -457,7 +457,6 @@ class EInvoiceData(GSTTransactionData):
                 "pincode": 193501,
             }
             self.company_address.update(seller)
-            self.dispatch_address.update(seller)
             self.transaction_details.name = random_string(6).lstrip("0")
 
             if frappe.flags.in_test:
@@ -471,7 +470,6 @@ class EInvoiceData(GSTTransactionData):
                     "pincode": 500055,
                 }
                 self.billing_address.update(buyer)
-                self.shipping_address.update(buyer)
 
                 if self.transaction_details.total_igst_amount > 0:
                     self.transaction_details.place_of_supply = "36"


### PR DESCRIPTION
closes: #589 

Issue:
If all addresses are sent, transaction_type is mapped incorrectly with e-Waybill.

Tests:
- e-Invoice gets generated successfully.
- e-Waybill, cannot be tested with a sandbox mode, as e-Waybill data cannot be fetched.

References:
https://einv-apisandbox.nic.in/Mapping_of_ewaybill_schema.html

Fixes:
- only send dispatch and shipping address if they are different
- update print_format as per address details available
- is_return check not needed for sandbox mode as shipping and dispatch address not sent