### PR TITLE
feat: respect e-Waybill threshold in e-Invoice, allow auto generate e-Waybill to be exclusively disabled

### DIFF
--- a/india_compliance/gst_india/client_scripts/e_invoice_actions.js
+++ b/india_compliance/gst_india/client_scripts/e_invoice_actions.js
@@ -45,6 +45,7 @@ frappe.ui.form.on("Sales Invoice", {
             {
                 docname: frm.doc.name,
                 throw: false,
+                submitted_from_ui: true,
             }
         );
     },

--- a/india_compliance/gst_india/client_scripts/e_invoice_actions.js
+++ b/india_compliance/gst_india/client_scripts/e_invoice_actions.js
@@ -45,7 +45,6 @@ frappe.ui.form.on("Sales Invoice", {
             {
                 docname: frm.doc.name,
                 throw: false,
-                submitted_from_ui: true,
             }
         );
     },

--- a/india_compliance/gst_india/data/test_e_invoice.json
+++ b/india_compliance/gst_india/data/test_e_invoice.json
@@ -36,7 +36,7 @@
 			},
 			"ItemList": [
 				{
-					"AssAmt": 100,
+					"AssAmt": 100000,
 					"CesAmt": 0,
 					"CesNonAdvlAmt": 0,
 					"CesRt": 0,
@@ -47,11 +47,11 @@
 					"IgstAmt": 0,
 					"IsServc": "N",
 					"PrdDesc": "Test Trading Goods 1",
-					"Qty": 1,
+					"Qty": 1000,
 					"SgstAmt": 0,
 					"SlNo": "1",
-					"TotAmt": 100,
-					"TotItemVal": 100,
+					"TotAmt": 100000,
+					"TotItemVal": 100000,
 					"Unit": "NOS",
 					"UnitPrice": 100
 				}
@@ -59,7 +59,7 @@
 			"PayDtls": {
 				"CrDay": 0,
 				"PaidAmt": 0,
-				"PaymtDue": 100
+				"PaymtDue": 100000
 			},
 			"SellerDtls": {
 				"Addr1": "Test Address - 1",
@@ -85,7 +85,7 @@
 				"TaxSch": "GST"
 			},
 			"ValDtls": {
-				"AssVal": 100,
+				"AssVal": 100000,
 				"CesVal": 0,
 				"CgstVal": 0,
 				"Discount": 0,
@@ -93,7 +93,7 @@
 				"OthChrg": 0,
 				"RndOffAmt": 0,
 				"SgstVal": 0,
-				"TotInvVal": 100
+				"TotInvVal": 100000
 			},
 			"Version": "1.1"
 		},
@@ -149,9 +149,6 @@
 				"Dt": "17/09/2022",
 				"No": "test_invoice_no",
 				"Typ": "INV"
-			},
-			"EwbDtls": {
-				"Distance": 0
 			},
 			"ItemList": [
 				{
@@ -273,9 +270,6 @@
 				"Dt": "17/09/2022",
 				"No": "test_invoice_no",
 				"Typ": "CRN"
-			},
-			"EwbDtls": {
-				"Distance": 0
 			},
 			"ItemList": [
 				{
@@ -405,9 +399,6 @@
 				"Dt": "17/09/2022",
 				"No": "test_invoice_no",
 				"Typ": "DBN"
-			},
-			"EwbDtls": {
-				"Distance": 0
 			},
 			"ItemList": [
 				{

--- a/india_compliance/gst_india/doctype/gst_settings/gst_settings.json
+++ b/india_compliance/gst_india/doctype/gst_settings/gst_settings.json
@@ -170,8 +170,7 @@
    "description": "e-Waybill will be automatically generated after Sales Invoice submission if the invoice value threshold is met, and data is available and valid",
    "fieldname": "auto_generate_e_waybill",
    "fieldtype": "Check",
-   "label": "Automatically Generate e-Waybill on Invoice Submission",
-   "read_only_depends_on": "eval: india_compliance.is_api_enabled(doc) && doc.enable_e_invoice"
+   "label": "Automatically Generate e-Waybill on Invoice Submission"
   },
   {
    "default": "1",
@@ -250,7 +249,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2023-03-09 04:10:39.690511",
+ "modified": "2023-04-16 21:18:20.822550",
  "modified_by": "Administrator",
  "module": "GST India",
  "name": "GST Settings",

--- a/india_compliance/gst_india/doctype/gst_settings/gst_settings.py
+++ b/india_compliance/gst_india/doctype/gst_settings/gst_settings.py
@@ -43,9 +43,6 @@ class GSTSettings(Document):
         if self.attach_e_waybill_print:
             self.fetch_e_waybill_data = 1
 
-        if self.enable_e_invoice:
-            self.auto_generate_e_waybill = self.auto_generate_e_invoice
-
     def on_update(self):
         self.update_custom_fields()
 

--- a/india_compliance/gst_india/utils/test_e_invoice.py
+++ b/india_compliance/gst_india/utils/test_e_invoice.py
@@ -25,8 +25,7 @@ from india_compliance.gst_india.utils.tests import create_sales_invoice
 class TestEInvoice(FrappeTestCase):
     @classmethod
     def setUpClass(cls):
-        frappe.db.set_value(
-            "GST Settings",
+        frappe.db.set_single_value(
             "GST Settings",
             {
                 "enable_api": 1,
@@ -82,8 +81,7 @@ class TestEInvoice(FrappeTestCase):
         # Mock response for generating irn
         self._mock_e_invoice_response(data=test_data)
 
-        frappe.db.set_value(
-            "GST Settings",
+        frappe.db.set_single_value(
             "GST Settings",
             {
                 "auto_generate_e_waybill": 1,
@@ -93,8 +91,7 @@ class TestEInvoice(FrappeTestCase):
 
         generate_e_invoice(si.name, submitted_from_ui=True)
 
-        frappe.db.set_value(
-            "GST Settings",
+        frappe.db.set_single_value(
             "GST Settings",
             {
                 "auto_generate_e_waybill": 0,
@@ -324,8 +321,7 @@ class TestEInvoice(FrappeTestCase):
             {"AckDt": str(now_datetime())}
         )
 
-        frappe.db.set_value(
-            "GST Settings",
+        frappe.db.set_single_value(
             "GST Settings",
             {
                 "auto_generate_e_waybill": 1,
@@ -342,8 +338,7 @@ class TestEInvoice(FrappeTestCase):
 
         generate_e_invoice(si.name, submitted_from_ui=True)
 
-        frappe.db.set_value(
-            "GST Settings",
+        frappe.db.set_single_value(
             "GST Settings",
             {
                 "auto_generate_e_waybill": 0,

--- a/india_compliance/gst_india/utils/test_e_invoice.py
+++ b/india_compliance/gst_india/utils/test_e_invoice.py
@@ -81,23 +81,11 @@ class TestEInvoice(FrappeTestCase):
         # Mock response for generating irn
         self._mock_e_invoice_response(data=test_data)
 
-        frappe.db.set_single_value(
-            "GST Settings",
-            {
-                "auto_generate_e_waybill": 1,
-                "auto_generate_e_invoice": 1,
-            },
-        )
+        frappe.db.set_single_value("GST Settings", "auto_generate_e_waybill", 1)
 
-        generate_e_invoice(si.name, submitted_from_ui=True)
+        generate_e_invoice(si.name, throw=False)
 
-        frappe.db.set_single_value(
-            "GST Settings",
-            {
-                "auto_generate_e_waybill": 0,
-                "auto_generate_e_invoice": 0,
-            },
-        )
+        frappe.db.set_single_value("GST Settings", "auto_generate_e_waybill", 0)
 
         # Assert if Integration Request Log generated
         self.assertDocumentEqual(
@@ -321,30 +309,17 @@ class TestEInvoice(FrappeTestCase):
             {"AckDt": str(now_datetime())}
         )
 
-        frappe.db.set_single_value(
-            "GST Settings",
-            {
-                "auto_generate_e_waybill": 1,
-                "auto_generate_e_invoice": 1,
-            },
-        )
+        frappe.db.set_single_value("GST Settings", "auto_generate_e_waybill", 1)
 
         # Assert if request data given in Json
-        si._submitted_from_ui = True
         self.assertDictEqual(test_data.get("request_data"), EInvoiceData(si).get_data())
 
         # Mock response for generating irn
         self._mock_e_invoice_response(data=test_data)
 
-        generate_e_invoice(si.name, submitted_from_ui=True)
+        generate_e_invoice(si.name, throw=False)
 
-        frappe.db.set_single_value(
-            "GST Settings",
-            {
-                "auto_generate_e_waybill": 0,
-                "auto_generate_e_invoice": 0,
-            },
-        )
+        frappe.db.set_single_value("GST Settings", "auto_generate_e_waybill", 0)
 
         si_doc = load_doc("Sales Invoice", si.name, "cancel")
         si_doc.get_onload().get("e_invoice_info", {}).update({"acknowledged_on": None})

--- a/india_compliance/gst_india/utils/test_e_invoice.py
+++ b/india_compliance/gst_india/utils/test_e_invoice.py
@@ -30,7 +30,7 @@ class TestEInvoice(FrappeTestCase):
             {
                 "enable_api": 1,
                 "enable_e_invoice": 1,
-                "auto_generate_e_waybill": 1,
+                "auto_generate_e_waybill": 0,
                 "auto_generate_e_invoice": 0,
                 "enable_e_waybill": 1,
                 "fetch_e_waybill_data": 0,
@@ -74,9 +74,7 @@ class TestEInvoice(FrappeTestCase):
         """Generate test e-Invoice for goods item"""
         test_data = self.e_invoice_test_data.get("goods_item_with_ewaybill")
 
-        frappe.db.set_single_value("GST Settings", "auto_generate_e_waybill", 0)
         si = create_sales_invoice(**test_data.get("kwargs"), qty=1000)
-        frappe.db.set_single_value("GST Settings", "auto_generate_e_waybill", 1)
 
         # Assert if request data given in Json
         self.assertDictEqual(test_data.get("request_data"), EInvoiceData(si).get_data())
@@ -84,7 +82,7 @@ class TestEInvoice(FrappeTestCase):
         # Mock response for generating irn
         self._mock_e_invoice_response(data=test_data)
 
-        generate_e_invoice(si.name, throw=False)
+        generate_e_invoice(si.name)
 
         # Assert if Integration Request Log generated
         self.assertDocumentEqual(
@@ -296,9 +294,7 @@ class TestEInvoice(FrappeTestCase):
 
         test_data = self.e_invoice_test_data.get("goods_item_with_ewaybill")
 
-        frappe.db.set_single_value("GST Settings", "auto_generate_e_waybill", 0)
         si = create_sales_invoice(**test_data.get("kwargs"), qty=1000)
-        frappe.db.set_single_value("GST Settings", "auto_generate_e_waybill", 1)
 
         self.assertRaisesRegex(
             frappe.exceptions.ValidationError,
@@ -317,7 +313,7 @@ class TestEInvoice(FrappeTestCase):
         # Mock response for generating irn
         self._mock_e_invoice_response(data=test_data)
 
-        generate_e_invoice(si.name, throw=False)
+        generate_e_invoice(si.name)
 
         si_doc = load_doc("Sales Invoice", si.name, "cancel")
         si_doc.get_onload().get("e_invoice_info", {}).update({"acknowledged_on": None})

--- a/india_compliance/gst_india/utils/test_e_invoice.py
+++ b/india_compliance/gst_india/utils/test_e_invoice.py
@@ -31,6 +31,7 @@ class TestEInvoice(FrappeTestCase):
             {
                 "enable_api": 1,
                 "enable_e_invoice": 1,
+                "auto_generate_e_waybill": 0,
                 "auto_generate_e_invoice": 0,
                 "enable_e_waybill": 1,
                 "fetch_e_waybill_data": 0,
@@ -73,7 +74,7 @@ class TestEInvoice(FrappeTestCase):
     def test_generate_e_invoice_with_goods_item(self):
         """Generate test e-Invoice for goods item"""
         test_data = self.e_invoice_test_data.get("goods_item_with_ewaybill")
-        si = create_sales_invoice(**test_data.get("kwargs"))
+        si = create_sales_invoice(**test_data.get("kwargs"), qty=1000)
 
         # Assert if request data given in Json
         self.assertDictEqual(test_data.get("request_data"), EInvoiceData(si).get_data())
@@ -81,7 +82,25 @@ class TestEInvoice(FrappeTestCase):
         # Mock response for generating irn
         self._mock_e_invoice_response(data=test_data)
 
-        generate_e_invoice(si.name)
+        frappe.db.set_value(
+            "GST Settings",
+            "GST Settings",
+            {
+                "auto_generate_e_waybill": 1,
+                "auto_generate_e_invoice": 1,
+            },
+        )
+
+        generate_e_invoice(si.name, submitted_from_ui=True)
+
+        frappe.db.set_value(
+            "GST Settings",
+            "GST Settings",
+            {
+                "auto_generate_e_waybill": 0,
+                "auto_generate_e_invoice": 0,
+            },
+        )
 
         # Assert if Integration Request Log generated
         self.assertDocumentEqual(
@@ -292,7 +311,7 @@ class TestEInvoice(FrappeTestCase):
         """
 
         test_data = self.e_invoice_test_data.get("goods_item_with_ewaybill")
-        si = create_sales_invoice(**test_data.get("kwargs"))
+        si = create_sales_invoice(**test_data.get("kwargs"), qty=1000)
 
         self.assertRaisesRegex(
             frappe.exceptions.ValidationError,
@@ -305,13 +324,32 @@ class TestEInvoice(FrappeTestCase):
             {"AckDt": str(now_datetime())}
         )
 
+        frappe.db.set_value(
+            "GST Settings",
+            "GST Settings",
+            {
+                "auto_generate_e_waybill": 1,
+                "auto_generate_e_invoice": 1,
+            },
+        )
+
         # Assert if request data given in Json
+        si._submitted_from_ui = True
         self.assertDictEqual(test_data.get("request_data"), EInvoiceData(si).get_data())
 
         # Mock response for generating irn
         self._mock_e_invoice_response(data=test_data)
 
-        generate_e_invoice(si.name)
+        generate_e_invoice(si.name, submitted_from_ui=True)
+
+        frappe.db.set_value(
+            "GST Settings",
+            "GST Settings",
+            {
+                "auto_generate_e_waybill": 0,
+                "auto_generate_e_invoice": 0,
+            },
+        )
 
         si_doc = load_doc("Sales Invoice", si.name, "cancel")
         si_doc.get_onload().get("e_invoice_info", {}).update({"acknowledged_on": None})


### PR DESCRIPTION
closes: #591 

Features:
- When generating an e-Invoice, don't send transporter details if the threshold is not met.
- Also, allow e-Waybill autogeneration to be disabled even though e-Invoice is autogenerated. (Only on-submit from frontend is disabled)

Tests:
- Generated e-Waybill two days after e-Invoice. Works although e-Invoice data is not available.
- Other tests to make sure the feature works.