### PR TITLE
fix: attribute error for "is_cash_or_non_trade_discount" in Delivery Note

### DIFF
--- a/india_compliance/gst_india/utils/transaction_data.py
+++ b/india_compliance/gst_india/utils/transaction_data.py
@@ -60,7 +60,7 @@ class GSTTransactionData:
                 ),
                 "discount_amount": (
                     abs(self.rounded(self.doc.base_discount_amount))
-                    if self.doc.is_cash_or_non_trade_discount
+                    if self.doc.get("is_cash_or_non_trade_discount")
                     else 0
                 ),
                 "company_gstin": self.doc.company_gstin,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/108322669/233647381-0d734f5c-584f-42fc-a711-1d81e4b8e04b.png)



