### PR TITLE
fix: dont rely on field options when validating place of supply

### DIFF
--- a/india_compliance/gst_india/constants/custom_fields.py
+++ b/india_compliance/gst_india/constants/custom_fields.py
@@ -1,22 +1,11 @@
 import frappe
 
 from india_compliance.gst_india.constants import GST_CATEGORIES, STATE_NUMBERS
+from india_compliance.gst_india.utils import get_place_of_supply_options
 
 state_options = "\n" + "\n".join(STATE_NUMBERS)
 gst_category_options = "\n".join(GST_CATEGORIES)
 default_gst_category = "Unregistered"
-
-
-def get_place_of_supply_options(with_other_countries=False):
-    options = []
-
-    for state_name, state_number in STATE_NUMBERS.items():
-        options.append(f"{state_number}-{state_name}")
-
-    if with_other_countries:
-        options.append("96-Other Countries")
-
-    return "\n".join(sorted(options))
 
 
 party_fields = [

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -14,6 +14,7 @@ from india_compliance.gst_india.utils import (
     get_all_gst_accounts,
     get_gst_accounts_by_type,
     get_place_of_supply,
+    get_place_of_supply_options,
     validate_gst_category,
 )
 
@@ -352,7 +353,11 @@ def validate_items(doc):
 
 
 def validate_place_of_supply(doc):
-    valid_options = doc.meta.get_field("place_of_supply").options.split("\n")
+    valid_options = get_place_of_supply_options(
+        as_list=True,
+        with_other_countries=doc.doctype in SALES_DOCTYPES,
+    )
+
     if doc.place_of_supply not in valid_options:
         frappe.throw(
             _(

--- a/india_compliance/gst_india/utils/__init__.py
+++ b/india_compliance/gst_india/utils/__init__.py
@@ -397,3 +397,18 @@ def is_api_enabled(settings=None):
 
 def can_enable_api(settings):
     return settings.api_secret or frappe.conf.ic_api_secret
+
+
+def get_place_of_supply_options(*, as_list=False, with_other_countries=False):
+    options = []
+
+    for state_name, state_number in STATE_NUMBERS.items():
+        options.append(f"{state_number}-{state_name}")
+
+    if with_other_countries:
+        options.append("96-Other Countries")
+
+    if as_list:
+        return options
+
+    return "\n".join(sorted(options))


### PR DESCRIPTION
While this is not exactly a bug, we are just switching to a better approach to avoid such issues.