### PR TITLE
fix: allow same gstin in all transactions with validation

### DIFF
--- a/india_compliance/gst_india/client_scripts/e_invoice_actions.js
+++ b/india_compliance/gst_india/client_scripts/e_invoice_actions.js
@@ -162,6 +162,7 @@ function is_e_invoice_applicable(frm) {
         india_compliance.is_e_invoice_enabled() &&
         frm.doc.docstatus == 1 &&
         frm.doc.company_gstin &&
+        frm.doc.company_gstin != frm.doc.billing_address_gstin &&
         frm.doc.gst_category != "Unregistered" &&
         !frm.doc.items[0].is_non_gst &&
         moment(frm.doc.posting_date).diff(gst_settings.e_invoice_applicable_from) >= 0

--- a/india_compliance/gst_india/client_scripts/e_waybill_actions.js
+++ b/india_compliance/gst_india/client_scripts/e_waybill_actions.js
@@ -29,8 +29,6 @@ function setup_e_waybill_actions(doctype) {
                 frm.doc.docstatus != 1 ||
                 frm.is_dirty() ||
                 !is_e_waybill_applicable(frm) ||
-                (frm.doctype === "Sales Invoice" &&
-                    frm.doc.company_gstin === frm.doc.billing_address_gstin) ||
                 (frm.doctype === "Delivery Note" && !frm.doc.customer_address)
             )
                 return;
@@ -117,7 +115,6 @@ function setup_e_waybill_actions(doctype) {
             if (
                 // threshold is only met for Sales Invoice
                 !has_e_waybill_threshold_met(frm) ||
-                frm.doc.company_gstin === frm.doc.billing_address_gstin ||
                 frm.doc.ewaybill ||
                 frm.doc.is_return ||
                 frm.doc.is_debit_note ||
@@ -621,7 +618,12 @@ function has_e_waybill_threshold_met(frm) {
 
 function is_e_waybill_applicable(frm) {
     // means company is Indian and not Unregistered
-    if (!frm.doc.company_gstin) return;
+    if (
+        !frm.doc.company_gstin ||
+        (frm.doctype === "Sales Invoice" &&
+            frm.doc.company_gstin === frm.doc.billing_address_gstin)
+    )
+        return;
 
     // at least one item is not a service
     for (const item of frm.doc.items) {

--- a/india_compliance/gst_india/client_scripts/e_waybill_actions.js
+++ b/india_compliance/gst_india/client_scripts/e_waybill_actions.js
@@ -29,6 +29,8 @@ function setup_e_waybill_actions(doctype) {
                 frm.doc.docstatus != 1 ||
                 frm.is_dirty() ||
                 !is_e_waybill_applicable(frm) ||
+                (frm.doctype === "Sales Invoice" &&
+                    frm.doc.company_gstin === frm.doc.billing_address_gstin) ||
                 (frm.doctype === "Delivery Note" && !frm.doc.customer_address)
             )
                 return;
@@ -115,6 +117,7 @@ function setup_e_waybill_actions(doctype) {
             if (
                 // threshold is only met for Sales Invoice
                 !has_e_waybill_threshold_met(frm) ||
+                frm.doc.company_gstin === frm.doc.billing_address_gstin ||
                 frm.doc.ewaybill ||
                 frm.doc.is_return ||
                 frm.doc.is_debit_note ||

--- a/india_compliance/gst_india/overrides/purchase_invoice.py
+++ b/india_compliance/gst_india/overrides/purchase_invoice.py
@@ -1,5 +1,4 @@
 import frappe
-from frappe import _
 from frappe.utils import flt
 
 from india_compliance.gst_india.overrides.transaction import validate_transaction
@@ -11,7 +10,6 @@ def validate(doc, method=None):
         return
 
     update_itc_totals(doc)
-    validate_supplier_gstin(doc)
 
 
 def update_itc_totals(doc, method=None):
@@ -35,14 +33,6 @@ def update_itc_totals(doc, method=None):
 
         if tax.account_head == gst_accounts.cess_account:
             doc.itc_cess_amount += flt(tax.base_tax_amount_after_discount_amount)
-
-
-def validate_supplier_gstin(doc):
-    if doc.company_gstin == doc.supplier_gstin:
-        frappe.throw(
-            _("Supplier GSTIN and Company GSTIN cannot be the same"),
-            title=_("Invalid Supplier GSTIN"),
-        )
 
 
 def onload(doc, method):

--- a/india_compliance/gst_india/overrides/sales_invoice.py
+++ b/india_compliance/gst_india/overrides/sales_invoice.py
@@ -53,7 +53,6 @@ def validate(doc, method=None):
 
     validate_invoice_number(doc)
     validate_fields_and_set_status_for_e_invoice(doc)
-    validate_billing_address_gstin(doc)
 
 
 def validate_invoice_number(doc):
@@ -90,14 +89,6 @@ def validate_fields_and_set_status_for_e_invoice(doc):
 
     if doc._action == "submit" and not doc.irn:
         doc.einvoice_status = "Pending"
-
-
-def validate_billing_address_gstin(doc):
-    if doc.company_gstin == doc.billing_address_gstin:
-        frappe.throw(
-            _("Billing Address GSTIN and Company GSTIN cannot be the same"),
-            title=_("Invalid Billing Address GSTIN"),
-        )
 
 
 def on_submit(doc, method=None):

--- a/india_compliance/gst_india/overrides/sales_invoice.py
+++ b/india_compliance/gst_india/overrides/sales_invoice.py
@@ -116,6 +116,7 @@ def on_submit(doc, method=None):
     elif (
         not gst_settings.enable_e_waybill
         or not gst_settings.auto_generate_e_waybill
+        or doc.company_gstin == doc.billing_address_gstin
         or doc.ewaybill
         or doc.is_return
         or doc.is_debit_note

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -142,6 +142,7 @@ def validate_gst_accounts(doc, is_sales_transaction=False):
     """
     Validate GST accounts
     - Only Valid Accounts should be allowed
+    - No GST account should be specified for transactions where Company GSTIN = Party GSTIN
     - If export is made without GST, then no GST account should be specified
     - SEZ / Inter-State supplies should not have CGST or SGST account
     - Intra-State supplies should not have IGST account
@@ -177,6 +178,19 @@ def validate_gst_accounts(doc, is_sales_transaction=False):
     all_valid_accounts, intra_state_accounts, inter_state_accounts = get_valid_accounts(
         doc.company, is_sales_transaction
     )
+
+    # Company GSTIN = Party GSTIN
+    party_gstin = doc.get("billing_address_gstin") or doc.get("supplier_gstin")
+    if (
+        party_gstin
+        and doc.company_gstin == party_gstin
+        and (idx := _get_matched_idx(rows_to_validate, all_valid_accounts))
+    ):
+        _throw(
+            _(
+                "Cannot charge GST in Row #{0} since Company GSTIN and Party GSTIN are same"
+            ).format(idx)
+        )
 
     # Sales / Purchase Validations
 

--- a/india_compliance/gst_india/utils/e_invoice.py
+++ b/india_compliance/gst_india/utils/e_invoice.py
@@ -229,6 +229,13 @@ def validate_e_invoice_applicability(doc, gst_settings=None, throw=True):
         if throw:
             frappe.throw(error)
 
+    if doc.company_gstin == doc.billing_address_gstin:
+        return _throw(
+            _(
+                "e-Invoice is not applicable for invoices with same company and billing GSTIN"
+            )
+        )
+
     if doc.irn:
         return _throw(
             _("e-Invoice has already been generated for Sales Invoice {0}").format(

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -571,6 +571,7 @@ class EWaybillData(GSTTransactionData):
         - Overseas Returns are not allowed
         - Basic transporter details must be present
         - Grand Total Amount must be greater than Criteria
+        - Sales Invoice with same company and billing gstin
         """
 
         for fieldname in ("company_address", "customer_address"):
@@ -607,6 +608,18 @@ class EWaybillData(GSTTransactionData):
             self.validate_mode_of_transport()
 
         self.validate_non_gst_items()
+
+        if (
+            self.doc.doctype == "Sales Invoice"
+            and self.doc.company_gstin == self.doc.billing_address_gstin
+        ):
+            frappe.throw(
+                _(
+                    "e-Waybill cannot be generated because billing GSTIN is same as"
+                    " company GSTIN"
+                ),
+                title=_("Invalid Data"),
+            )
 
     def validate_doctype_for_e_waybill(self):
         if self.doc.doctype not in PERMITTED_DOCTYPES:


### PR DESCRIPTION
This PR allows you to book a Sales Invoice to self.
https://discuss.frappe.io/t/billing-address-gstin-and-company-gstin-cannot-be-the-same/103864

Frappe Issue: ISS-23-24-00346

- Diluted validation to allow the same GSTIN. But cannot charge GST for the same.
- Added validations in e-Waybill for Sales Invoices and e-Invoice to skip such invoices.
- No similar validation is needed in GSTR-1 as it skips invoices without taxes.