### PR TITLE
fix: prefer legal name over address title for buyer and seller details

### DIFF
--- a/india_compliance/gst_india/data/test_e_invoice.json
+++ b/india_compliance/gst_india/data/test_e_invoice.json
@@ -14,7 +14,7 @@
 				"Pin": 500055,
 				"Pos": "01",
 				"Stcd": "36",
-				"TrdNm": "Test Registered Customer"
+				"TrdNm": "_Test Registered Customer"
 			},
 			"DocDtls": {
 				"Dt": "16/09/2022",
@@ -61,7 +61,7 @@
 				"Loc": "Test City",
 				"Pin": 193501,
 				"Stcd": "01",
-				"TrdNm": "Test Indian Registered Company"
+				"TrdNm": "_Test Indian Registered Company"
 			},
 			"TranDtls": {
 				"RegRev": "N",
@@ -120,7 +120,7 @@
 				"Pin": 500055,
 				"Pos": "01",
 				"Stcd": "36",
-				"TrdNm": "Test Registered Customer"
+				"TrdNm": "_Test Registered Customer"
 			},
 			"DocDtls": {
 				"Dt": "17/09/2022",
@@ -161,7 +161,7 @@
 				"Loc": "Test City",
 				"Pin": 193501,
 				"Stcd": "01",
-				"TrdNm": "Test Indian Registered Company"
+				"TrdNm": "_Test Indian Registered Company"
 			},
 			"TranDtls": {
 				"RegRev": "N",
@@ -225,7 +225,7 @@
 				"Pin": 500055,
 				"Pos": "01",
 				"Stcd": "36",
-				"TrdNm": "Test Registered Customer"
+				"TrdNm": "_Test Registered Customer"
 			},
 			"DocDtls": {
 				"Dt": "17/09/2022",
@@ -274,7 +274,7 @@
 				"Loc": "Test City",
 				"Pin": 193501,
 				"Stcd": "01",
-				"TrdNm": "Test Indian Registered Company"
+				"TrdNm": "_Test Indian Registered Company"
 			},
 			"TranDtls": {
 				"RegRev": "N",
@@ -338,7 +338,7 @@
 				"Pin": 500055,
 				"Pos": "01",
 				"Stcd": "36",
-				"TrdNm": "Test Registered Customer"
+				"TrdNm": "_Test Registered Customer"
 			},
 			"DocDtls": {
 				"Dt": "17/09/2022",
@@ -379,7 +379,7 @@
 				"Loc": "Test City",
 				"Pin": 193501,
 				"Stcd": "01",
-				"TrdNm": "Test Indian Registered Company"
+				"TrdNm": "_Test Indian Registered Company"
 			},
 			"TranDtls": {
 				"RegRev": "N",

--- a/india_compliance/gst_india/overrides/test_transaction_data.py
+++ b/india_compliance/gst_india/overrides/test_transaction_data.py
@@ -141,6 +141,8 @@ class TestTransactionData(FrappeTestCase):
         self.assertDictEqual(
             gst_transaction_data.transaction_details,
             {
+                "company_name": "_Test Indian Registered Company",
+                "customer_name": "_Test Registered Customer",
                 "date": format_date(frappe.utils.today(), "dd/mm/yyyy"),
                 "total": 100.0,
                 "rounding_adjustment": 0.0,

--- a/india_compliance/gst_india/utils/e_invoice.py
+++ b/india_compliance/gst_india/utils/e_invoice.py
@@ -459,11 +459,8 @@ class EInvoiceData(GSTTransactionData):
                 self.doc.dispatch_address_name
             )
 
-        self.billing_address.legal_name = self.sanitize_value(
-            self.doc.customer_name
-            or frappe.db.get_value("Customer", self.doc.customer, "customer_name")
-        )
-        self.company_address.legal_name = self.sanitize_value(self.doc.company)
+        self.billing_address.legal_name = self.transaction_details.customer_name
+        self.company_address.legal_name = self.transaction_details.company_name
 
     def get_invoice_data(self):
         if self.sandbox_mode:
@@ -520,7 +517,7 @@ class EInvoiceData(GSTTransactionData):
             "SellerDtls": {
                 "Gstin": self.company_address.gstin,
                 "LglNm": self.company_address.legal_name,
-                "TrdNm": self.company_address.address_title,
+                "TrdNm": self.company_address.legal_name,
                 "Loc": self.company_address.city,
                 "Pin": self.company_address.pincode,
                 "Stcd": self.company_address.state_number,
@@ -530,7 +527,7 @@ class EInvoiceData(GSTTransactionData):
             "BuyerDtls": {
                 "Gstin": self.billing_address.gstin,
                 "LglNm": self.billing_address.legal_name,
-                "TrdNm": self.billing_address.address_title,
+                "TrdNm": self.billing_address.legal_name,
                 "Addr1": self.billing_address.address_line1,
                 "Addr2": self.billing_address.address_line2,
                 "Loc": self.billing_address.city,

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -768,6 +768,9 @@ class EWaybillData(GSTTransactionData):
 
         self.transaction_details.transaction_type = transaction_type
 
+        self.to_address.legal_name = self.transaction_details.customer_name
+        self.from_address.legal_name = self.transaction_details.company_name
+
         if self.doc.gst_category == "SEZ":
             self.to_address.state_number = 96
 
@@ -822,7 +825,7 @@ class EWaybillData(GSTTransactionData):
             "docNo": self.transaction_details.name,
             "docDate": self.transaction_details.date,
             "transactionType": self.transaction_details.transaction_type,
-            "fromTrdName": self.from_address.address_title,
+            "fromTrdName": self.from_address.legal_name,
             "fromGstin": self.from_address.gstin,
             "fromAddr1": self.dispatch_address.address_line1,
             "fromAddr2": self.dispatch_address.address_line2,
@@ -830,7 +833,7 @@ class EWaybillData(GSTTransactionData):
             "fromPincode": self.dispatch_address.pincode,
             "fromStateCode": self.from_address.state_number,
             "actFromStateCode": self.dispatch_address.state_number,
-            "toTrdName": self.to_address.address_title,
+            "toTrdName": self.to_address.legal_name,
             "toGstin": self.to_address.gstin,
             "toAddr1": self.shipping_address.address_line1,
             "toAddr2": self.shipping_address.address_line2,

--- a/india_compliance/gst_india/utils/transaction_data.py
+++ b/india_compliance/gst_india/utils/transaction_data.py
@@ -47,6 +47,13 @@ class GSTTransactionData:
 
         self.transaction_details.update(
             {
+                "company_name": self.sanitize_value(self.doc.company),
+                "customer_name": self.sanitize_value(
+                    self.doc.customer_name
+                    or frappe.db.get_value(
+                        "Customer", self.doc.customer, "customer_name"
+                    )
+                ),
                 "date": format_date(self.doc.posting_date, self.DATE_FORMAT),
                 "total": abs(
                     self.rounded(sum(row.taxable_value for row in self.doc.items))


### PR DESCRIPTION
Effect after this PR:
- Legal Name (Customer Name or Company Name) for Buyer and Seller Address will be used
- Address Title for Dispatch and Shipping Address will be used