### PR TITLE
fix: don't support autofill in sandbox mode

### DIFF
--- a/india_compliance/gst_india/api_classes/public.py
+++ b/india_compliance/gst_india/api_classes/public.py
@@ -1,9 +1,20 @@
+import frappe
+from frappe import _
+
 from india_compliance.gst_india.api_classes.base import BaseAPI
 
 
 class PublicAPI(BaseAPI):
     API_NAME = "GST Public"
     BASE_PATH = "commonapi"
+
+    def setup(self):
+        if self.sandbox_mode:
+            frappe.throw(
+                _(
+                    "Autofill Party Information based on GSTIN is not supported in sandbox mode"
+                )
+            )
 
     def get_gstin_info(self, gstin):
         response = self.get("search", params={"action": "TP", "gstin": gstin})

--- a/india_compliance/gst_india/doctype/gst_settings/gst_settings.py
+++ b/india_compliance/gst_india/doctype/gst_settings/gst_settings.py
@@ -159,6 +159,17 @@ class GSTSettings(Document):
                 )
             )
 
+        if (
+            self.sandbox_mode
+            and self.autofill_party_info
+            and self.has_value_changed("sandbox_mode")
+        ):
+            frappe.msgprint(
+                _(
+                    "Autofill Party Information based on GSTIN is not supported in sandbox mode"
+                ),
+            )
+
 
 @frappe.whitelist()
 def disable_api_promo():

--- a/india_compliance/public/js/quick_entry.js
+++ b/india_compliance/public/js/quick_entry.js
@@ -85,7 +85,7 @@ class GSTQuickEntryForm extends frappe.ui.form.QuickEntryForm {
                 ignore_validation: true,
                 onchange: () => {
                     const d = this.dialog;
-                    if (this.api_enabled) return autofill_fields(d);
+                    if (this.api_enabled && !gst_settings.sandbox_mode) return autofill_fields(d);
 
                     d.set_value(
                         "gst_category",
@@ -280,15 +280,6 @@ async function autofill_fields(dialog) {
         return;
     }
 
-    if (gst_settings.sandbox_mode && gstin !== "33GSPTN9771G3ZP") {
-        frappe.show_alert({
-            message: __("Skipping data retrieval for GSTIN restricted in Sandbox Mode"),
-        });
-
-        gstin_field.set_description("");
-        return;
-    }
-
     const gstin_info = await get_gstin_info(gstin);
     set_gstin_description(gstin_field, gstin_info.status);
     map_gstin_info(dialog.doc, gstin_info);
@@ -385,7 +376,6 @@ function get_gstin_description() {
     }
 
     return __(
-        `To test the feature to autofill party information in Sandbox Mode,
-        use the following GSTIN: <br><strong>33GSPTN9771G3ZP</strong>`
+        `Autofill is not supported in sandbox mode`
     );
 }


### PR DESCRIPTION
closes: #595 

### Purpose
- Autofill can be used for demo in production mode (even for demo)
- Sandbox GSTIN raising error and not supported by Govt.