### PR TITLE
fix: show zero rated items in GSTR-1 b2b and cdnr-reg report

### DIFF
--- a/india_compliance/gst_india/report/gstr_1/gstr_1.py
+++ b/india_compliance/gst_india/report/gstr_1/gstr_1.py
@@ -388,7 +388,7 @@ class Gstr1Report(object):
             )
 
         elif self.filters.get("type_of_business") == "CDNR-REG":
-            conditions += """ AND (is_return = 1 OR is_debit_note = 1) AND IFNULL(gst_category, '') in ('Registered Regular', 'Deemed Export', 'SEZ')"""
+            conditions += """ AND (is_return = 1 OR is_debit_note = 1) AND IFNULL(gst_category, '') not in ('Unregistered', 'Overseas')"""
 
         elif self.filters.get("type_of_business") == "CDNR-UNREG":
             conditions += """ AND ifnull(SUBSTR(place_of_supply, 1, 2),'') != ifnull(SUBSTR(company_gstin, 1, 2),'')
@@ -520,12 +520,21 @@ class Gstr1Report(object):
         # Build itemised tax for export invoices where tax table is blank
         for invoice, items in self.invoice_items.items():
             if (
-                invoice not in self.items_based_on_tax_rate
-                and invoice not in unidentified_gst_accounts_invoice
-                and not self.invoices.get(invoice, {}).get("is_export_with_gst")
+                invoice in self.items_based_on_tax_rate
+                or invoice in unidentified_gst_accounts_invoice
+            ):
+                continue
+
+            if (
+                self.invoices.get(invoice, {}).get("is_export_with_gst")
                 and self.invoices.get(invoice, {}).get("gst_category")
                 in OVERSEAS_GST_CATEGORIES
             ):
+                self.items_based_on_tax_rate.setdefault(invoice, {}).setdefault(
+                    0, []
+                ).extend(items)
+
+            if invoice in self.nil_exempt_non_gst:
                 self.items_based_on_tax_rate.setdefault(invoice, {}).setdefault(
                     0, []
                 ).extend(items)

--- a/india_compliance/gst_india/report/gstr_1/gstr_1.py
+++ b/india_compliance/gst_india/report/gstr_1/gstr_1.py
@@ -491,7 +491,7 @@ class Gstr1Report(object):
                 continue
 
             if (
-                self.invoices.get(invoice, {}).get("is_export_with_gst")
+                not self.invoices.get(invoice, {}).get("is_export_with_gst")
                 and self.invoices.get(invoice, {}).get("gst_category")
                 in OVERSEAS_GST_CATEGORIES
             ):


### PR DESCRIPTION
closes: #648 

- Until now it was only accumulating this value for unregistered sales.
- Additionally, fix the condition for cdnr-reg
- Remove dependency on `item_tax_rate` as its not consistent and causes problems when there is no Item Tax Template