### PR TITLE
fix: segregate `with_irn` dependency, add validation for distance

### DIFF
--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -482,7 +482,7 @@ class EWaybillData(GSTTransactionData):
         self.validate_transaction()
 
         if with_irn:
-            return self.get_data_for_irn()
+            return self.get_data_with_irn()
 
         self.set_transaction_details()
         self.set_item_list()
@@ -492,7 +492,7 @@ class EWaybillData(GSTTransactionData):
 
         return self.get_transaction_data()
 
-    def get_data_for_irn(self):
+    def get_data_with_irn(self):
         self.set_transporter_details()
         self.set_party_address_details()
         self.set_same_pincode_distance()
@@ -761,9 +761,9 @@ class EWaybillData(GSTTransactionData):
         self.from_address = self.get_address_details(self.doc.company_address)
 
         # Defaults
-        # billing state is changed for SEZ, hence copy()
+        # calling copy() since we're mutating from_address and to_address below
         self.shipping_address = self.to_address.copy()
-        self.dispatch_address = self.from_address
+        self.dispatch_address = self.from_address.copy()
 
         if has_different_shipping_address and has_different_dispatch_address:
             transaction_type = 4

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -488,14 +488,14 @@ class EWaybillData(GSTTransactionData):
         self.set_item_list()
         self.set_transporter_details()
         self.set_party_address_details()
-        self.set_same_pincode_distance()
+        self.validate_distance_for_same_pincode()
 
         return self.get_transaction_data()
 
     def get_data_with_irn(self):
         self.set_transporter_details()
         self.set_party_address_details()
-        self.set_same_pincode_distance()
+        self.validate_distance_for_same_pincode()
 
         return self.sanitize_data(
             {
@@ -800,7 +800,7 @@ class EWaybillData(GSTTransactionData):
 
         return address_details
 
-    def set_same_pincode_distance(self):
+    def validate_distance_for_same_pincode(self):
         """
         1. For same pincode, distance should be between 1 and 100 km.
 
@@ -808,11 +808,17 @@ class EWaybillData(GSTTransactionData):
         Hardcode distance to 1 km to simplify and automate this.
         Accuracy of distance is immaterial and used only for e-Waybill validity determination.
         """
+
         if self.dispatch_address.pincode != self.shipping_address.pincode:
             return
 
         if self.transaction_details.distance > 100:
-            self.transaction_details.distance = 100
+            frappe.throw(
+                _(
+                    "Distance should be less than 100km when the Pincode is same for"
+                    " Dispatch and Shipping Address"
+                )
+            )
 
         if self.transaction_details.distance == 0:
             self.transaction_details.distance = 1


### PR DESCRIPTION
- fixes issue from #642 where address details are set before legal_name
- adds validation for same pincode distance (https://github.com/resilient-tech/india-compliance/issues/601)