### PR TITLE
fix(UX): Improve HSN code field

### DIFF
--- a/india_compliance/gst_india/client_scripts/item.js
+++ b/india_compliance/gst_india/client_scripts/item.js
@@ -1,8 +1,20 @@
 frappe.ui.form.on('Item', {
+	onload: function(frm) {
+		if (!gst_settings.validate_hsn_code) return;
+		frm.set_query('gst_hsn_code', function() {
+			const wildcard = '_'.repeat(gst_settings.min_hsn_digits) + '%';
+			return {
+				filters: {
+					'name': ['like', wildcard]
+				}
+			};
+		});
+	},
+
 	gst_hsn_code: function(frm) {
 		if ((!frm.doc.taxes || !frm.doc.taxes.length) && frm.doc.gst_hsn_code) {
 			frappe.db.get_doc("GST HSN Code", frm.doc.gst_hsn_code).then(hsn_doc => {
-				$.each(hsn_doc.taxes || [], function(i, tax) {
+				$.each(hsn_doc.taxes || [], function(_, tax) {
 					let a = frappe.model.add_child(frm.doc, 'Item Tax', 'taxes');
 					a.item_tax_template = tax.item_tax_template;
 					a.tax_category = tax.tax_category;

--- a/india_compliance/gst_india/constants/custom_fields.py
+++ b/india_compliance/gst_india/constants/custom_fields.py
@@ -593,6 +593,7 @@ CUSTOM_FIELDS = {
             "options": "GST HSN Code",
             "insert_after": "item_group",
             "allow_in_quick_entry": 1,
+            "mandatory_depends_on": "eval:gst_settings.validate_hsn_code && doc.is_sales_item",
             "description": "You can search code by the description of the category.",
         },
         {

--- a/india_compliance/gst_india/constants/custom_fields.py
+++ b/india_compliance/gst_india/constants/custom_fields.py
@@ -593,6 +593,7 @@ CUSTOM_FIELDS = {
             "options": "GST HSN Code",
             "insert_after": "item_group",
             "allow_in_quick_entry": 1,
+            "description": "You can search code by the description of the category.",
         },
         {
             "fieldname": "is_nil_exempt",

--- a/india_compliance/gst_india/doctype/gst_settings/gst_settings.py
+++ b/india_compliance/gst_india/doctype/gst_settings/gst_settings.py
@@ -3,9 +3,8 @@
 
 import frappe
 from frappe import _
-from frappe.custom.doctype.property_setter.property_setter import make_property_setter
 from frappe.model.document import Document
-from frappe.utils import cint, getdate
+from frappe.utils import getdate
 
 from india_compliance.gst_india.constants import GST_ACCOUNT_FIELDS
 from india_compliance.gst_india.constants.custom_fields import (
@@ -37,7 +36,6 @@ class GSTSettings(Document):
         self.validate_e_invoice_applicability_date()
         self.validate_credentials()
         self.clear_api_auth_session()
-        self.update_propery_setters()
 
     def clear_api_auth_session(self):
         if self.has_value_changed("api_secret") and self.api_secret:
@@ -100,16 +98,6 @@ class GSTSettings(Document):
             toggle_custom_fields(
                 SALES_REVERSE_CHARGE_FIELDS, self.enable_reverse_charge_in_sales
             )
-
-    def update_propery_setters(self):
-        make_property_setter(
-            "Item",
-            "gst_hsn_code",
-            "reqd",
-            cint(self.validate_hsn_code),
-            property_type="docfield",
-            validate_fields_for_doctype=True,
-        )
 
     def validate_e_invoice_applicability_date(self):
         if not self.enable_api or not self.enable_e_invoice:

--- a/india_compliance/gst_india/doctype/gst_settings/gst_settings.py
+++ b/india_compliance/gst_india/doctype/gst_settings/gst_settings.py
@@ -3,8 +3,9 @@
 
 import frappe
 from frappe import _
+from frappe.custom.doctype.property_setter.property_setter import make_property_setter
 from frappe.model.document import Document
-from frappe.utils import getdate
+from frappe.utils import cint, getdate
 
 from india_compliance.gst_india.constants import GST_ACCOUNT_FIELDS
 from india_compliance.gst_india.constants.custom_fields import (
@@ -36,6 +37,7 @@ class GSTSettings(Document):
         self.validate_e_invoice_applicability_date()
         self.validate_credentials()
         self.clear_api_auth_session()
+        self.update_propery_setters()
 
     def clear_api_auth_session(self):
         if self.has_value_changed("api_secret") and self.api_secret:
@@ -98,6 +100,16 @@ class GSTSettings(Document):
             toggle_custom_fields(
                 SALES_REVERSE_CHARGE_FIELDS, self.enable_reverse_charge_in_sales
             )
+
+    def update_propery_setters(self):
+        make_property_setter(
+            "Item",
+            "gst_hsn_code",
+            "reqd",
+            cint(self.validate_hsn_code),
+            property_type="docfield",
+            validate_fields_for_doctype=True,
+        )
 
     def validate_e_invoice_applicability_date(self):
         if not self.enable_api or not self.enable_e_invoice:

--- a/india_compliance/patches.txt
+++ b/india_compliance/patches.txt
@@ -3,7 +3,7 @@ india_compliance.patches.v15.check_version_compatibility
 
 [post_model_sync]
 india_compliance.patches.v14.set_default_for_overridden_accounts_setting
-execute:from india_compliance.gst_india.setup import create_custom_fields; create_custom_fields() #12
+execute:from india_compliance.gst_india.setup import create_custom_fields; create_custom_fields() #13
 execute:from india_compliance.gst_india.setup import create_property_setters; create_property_setters() #2
 india_compliance.patches.post_install.update_custom_role_for_e_invoice_summary
 india_compliance.patches.v14.remove_ecommerce_gstin_from_purchase_invoice


### PR DESCRIPTION
1. Add description to let user know that HSN code can be filtered by descriptions.
2. Set property setter for `reqd` based on GST settings. This is required so it can be validated client side too.
