### PR TITLE
fix: import of goods for GSTR-3B report from boe

### DIFF
--- a/india_compliance/gst_india/doctype/gstr_3b_report/gstr_3b_report.py
+++ b/india_compliance/gst_india/doctype/gstr_3b_report/gstr_3b_report.py
@@ -176,7 +176,9 @@ class GSTR3BReport(Document):
             )[0][0] or 0
 
         igst, cess = _get_tax_amount("igst_account"), _get_tax_amount("cess_account")
-        itc_details.setdefault("Import Of Goods", {"iamt": igst, "csamt": cess})
+        itc_details.setdefault("Import Of Goods", {"iamt": 0, "csamt": 0})
+        itc_details["Import Of Goods"]["iamt"] += igst
+        itc_details["Import Of Goods"]["csamt"] += cess
 
     def get_inward_nil_exempt(self, state):
         inward_nil_exempt = frappe.db.sql(


### PR DESCRIPTION
ISS-23-24-01083
`set_default` was set earlier with zero amount. hence tax amount was not getting updated.