### PR TITLE
fix: multiple fixes, sql, gstr-1, tax-defaults

### DIFF
--- a/india_compliance/gst_india/data/tax_defaults.json
+++ b/india_compliance/gst_india/data/tax_defaults.json
@@ -76,22 +76,19 @@
                         {
                             "tax_type": {
                                 "account_name": "Input Tax SGST RCM",
-                                "tax_rate": 9.0,
-                                "root_type": "Asset"
+                                "tax_rate": 9.0
                             }
                         },
                         {
                             "tax_type": {
                                 "account_name": "Input Tax CGST RCM",
-                                "tax_rate": 9.0,
-                                "root_type": "Asset"
+                                "tax_rate": 9.0
                             }
                         },
                         {
                             "tax_type": {
                                 "account_name": "Input Tax IGST RCM",
-                                "tax_rate": 18.0,
-                                "root_type": "Asset"
+                                "tax_rate": 18.0
                             }
                         }
                     ]
@@ -141,22 +138,19 @@
                         {
                             "tax_type": {
                                 "account_name": "Input Tax SGST RCM",
-                                "tax_rate": 2.5,
-                                "root_type": "Asset"
+                                "tax_rate": 2.5
                             }
                         },
                         {
                             "tax_type": {
                                 "account_name": "Input Tax CGST RCM",
-                                "tax_rate": 2.5,
-                                "root_type": "Asset"
+                                "tax_rate": 2.5
                             }
                         },
                         {
                             "tax_type": {
                                 "account_name": "Input Tax IGST RCM",
-                                "tax_rate": 5.0,
-                                "root_type": "Asset"
+                                "tax_rate": 5.0
                             }
                         }
                     ]
@@ -206,22 +200,19 @@
                         {
                             "tax_type": {
                                 "account_name": "Input Tax SGST RCM",
-                                "tax_rate": 6.0,
-                                "root_type": "Asset"
+                                "tax_rate": 6.0
                             }
                         },
                         {
                             "tax_type": {
                                 "account_name": "Input Tax CGST RCM",
-                                "tax_rate": 6.0,
-                                "root_type": "Asset"
+                                "tax_rate": 6.0
                             }
                         },
                         {
                             "tax_type": {
                                 "account_name": "Input Tax IGST RCM",
-                                "tax_rate": 12.0,
-                                "root_type": "Asset"
+                                "tax_rate": 12.0
                             }
                         }
                     ]
@@ -271,22 +262,19 @@
                         {
                             "tax_type": {
                                 "account_name": "Input Tax SGST RCM",
-                                "tax_rate": 14.0,
-                                "root_type": "Asset"
+                                "tax_rate": 14.0
                             }
                         },
                         {
                             "tax_type": {
                                 "account_name": "Input Tax CGST RCM",
-                                "tax_rate": 14.0,
-                                "root_type": "Asset"
+                                "tax_rate": 14.0
                             }
                         },
                         {
                             "tax_type": {
                                 "account_name": "Input Tax IGST RCM",
-                                "tax_rate": 28.0,
-                                "root_type": "Asset"
+                                "tax_rate": 28.0
                             }
                         }
                     ]
@@ -387,7 +375,6 @@
                             "account_head": {
                                 "account_name": "Input Tax CGST RCM",
                                 "tax_rate": 9.0,
-                                "root_type": "Asset",
                                 "account_type": "Tax"
                             },
                             "add_deduct_tax": "Deduct"
@@ -396,7 +383,6 @@
                             "account_head": {
                                 "account_name": "Input Tax SGST RCM",
                                 "tax_rate": 9.0,
-                                "root_type": "Asset",
                                 "account_type": "Tax"
                             },
                             "add_deduct_tax": "Deduct"
@@ -419,7 +405,6 @@
                             "account_head": {
                                 "account_name": "Input Tax IGST RCM",
                                 "tax_rate": 18.0,
-                                "root_type": "Asset",
                                 "account_type": "Tax"
                             },
                             "add_deduct_tax": "Deduct"

--- a/india_compliance/gst_india/overrides/purchase_invoice.py
+++ b/india_compliance/gst_india/overrides/purchase_invoice.py
@@ -46,3 +46,18 @@ def onload(doc, method):
             {"purchase_invoice": doc.name, "docstatus": 1},
         ),
     )
+
+
+def get_dashboard_data(data):
+    transactions = data.setdefault("transactions", [])
+    reference_section = next(
+        (row for row in transactions if row.get("label") == "Reference"), None
+    )
+
+    if reference_section is None:
+        reference_section = {"label": "Reference", "items": []}
+        transactions.append(reference_section)
+
+    reference_section["items"].append("Bill of Entry")
+
+    return data

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -728,7 +728,7 @@ def validate_reverse_charge_transaction(doc, method=None):
 
         frappe.throw(msg)
 
-    if doc.eligibility_for_itc == "All Other ITC":
+    if doc.get("eligibility_for_itc") == "All Other ITC":
         doc.eligibility_for_itc = "ITC on Reverse Charge"
 
 

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -728,7 +728,8 @@ def validate_reverse_charge_transaction(doc, method=None):
 
         frappe.throw(msg)
 
-    doc.eligibility_for_itc = "ITC on Reverse Charge"
+    if doc.eligibility_for_itc == "All Other ITC":
+        doc.eligibility_for_itc = "ITC on Reverse Charge"
 
 
 def is_export_without_payment_of_gst(doc):

--- a/india_compliance/gst_india/report/e_invoice_summary/e_invoice_summary.py
+++ b/india_compliance/gst_india/report/e_invoice_summary/e_invoice_summary.py
@@ -84,6 +84,11 @@ def get_data(filters=None):
         query = query.where(sales_invoice.docstatus == 1)
 
     else:
+        # invoice is cancelled but irn is not cancelled
+        query = query.where(sales_invoice.docstatus == 2).where(
+            (sales_invoice.irn != "") | (sales_invoice.irn.notnull())
+        )
+
         valid_irns = frappe.get_all(
             "Sales Invoice",
             pluck="irn",
@@ -96,12 +101,8 @@ def get_data(filters=None):
             },
         )
 
-        # invoice is cancelled but irn is not cancelled
-        query = (
-            query.where(sales_invoice.docstatus == 2)
-            .where((sales_invoice.irn != "") | (sales_invoice.irn.notnull()))
-            .where(sales_invoice.irn.notin(valid_irns))
-        )
+        if valid_irns:
+            query = query.where(sales_invoice.irn.notin(valid_irns))
 
     query = query.orderby(sales_invoice.posting_date)
 

--- a/india_compliance/gst_india/report/gstr_1/gstr_1.py
+++ b/india_compliance/gst_india/report/gstr_1/gstr_1.py
@@ -344,8 +344,7 @@ class Gstr1Report(object):
 
         if self.filters.get("type_of_business") == "B2B":
             conditions += (
-                "AND IFNULL(gst_category, '') in ('Registered Regular', 'Registered"
-                " Composition', 'Deemed Export', 'SEZ') AND is_return != 1 AND"
+                "AND IFNULL(gst_category, '') not in ('Unregistered', 'Overseas') AND is_return != 1 AND"
                 " is_debit_note !=1"
             )
 
@@ -1290,6 +1289,8 @@ def get_invoice_type(row):
             "Deemed Export": "DE",
             "Registered Regular": "R",
             "Registered Composition": "R",
+            "Tax Deductor": "R",
+            "UIN Holders": "R",
             "Unregistered": "B2CL",
         }
     ).get(gst_category)

--- a/india_compliance/hooks.py
+++ b/india_compliance/hooks.py
@@ -184,6 +184,9 @@ override_doctype_dashboards = {
     "Delivery Note": (
         "india_compliance.gst_india.overrides.delivery_note.get_dashboard_data"
     ),
+    "Purchase Invoice": (
+        "india_compliance.gst_india.overrides.purchase_invoice.get_dashboard_data"
+    ),
 }
 
 override_doctype_class = {

--- a/india_compliance/patches.txt
+++ b/india_compliance/patches.txt
@@ -17,3 +17,4 @@ india_compliance.patches.post_install.rename_import_of_capital_goods
 execute:from india_compliance.audit_trail.setup import create_custom_fields, CUSTOM_FIELDS; create_custom_fields(CUSTOM_FIELDS)
 india_compliance.patches.post_install.update_hsn_code
 execute:from india_compliance.gst_india.setup import map_default_uoms; map_default_uoms()
+india_compliance.patches.v14.set_correct_root_account_for_rcm

--- a/india_compliance/patches/v14/set_correct_root_account_for_rcm.py
+++ b/india_compliance/patches/v14/set_correct_root_account_for_rcm.py
@@ -1,12 +1,6 @@
 import frappe
 
-GST_ACCOUNT_FIELDS = [
-    "cgst_account",
-    "sgst_account",
-    "igst_account",
-    "cess_account",
-    "cess_non_advol_account",
-]
+from india_compliance.gst_india.constants import GST_ACCOUNT_FIELDS
 
 
 def execute():

--- a/india_compliance/patches/v14/set_correct_root_account_for_rcm.py
+++ b/india_compliance/patches/v14/set_correct_root_account_for_rcm.py
@@ -1,0 +1,63 @@
+import frappe
+
+GST_ACCOUNT_FIELDS = [
+    "cgst_account",
+    "sgst_account",
+    "igst_account",
+    "cess_account",
+    "cess_non_advol_account",
+]
+
+
+def execute():
+    settings = frappe.get_doc("GST Settings")
+    company_accounts = get_company_accounts(settings)
+
+    for accounts in company_accounts.values():
+        if not accounts.get("Output") or not accounts.get("Reverse Charge"):
+            continue
+
+        rcm_accounts = get_asset_rcm_accounts(accounts)
+        if not rcm_accounts:
+            continue
+
+        output_account = frappe.db.get_value(
+            "Account",
+            accounts["Output"].cgst_account,
+            ["parent_account", "root_type"],
+            as_dict=True,
+        )
+
+        if not output_account:
+            continue
+
+        # update reverse charge accounts
+        frappe.db.set_value(
+            "Account",
+            {"name": ("in", rcm_accounts)},
+            output_account,
+            update_modified=False,
+        )
+
+
+def get_company_accounts(settings):
+    company_accounts = {}
+    for row in settings.gst_accounts:
+        company_accounts.setdefault(row.company, {})
+        company_accounts[row.company][row.account_type] = row
+
+    return company_accounts
+
+
+def get_asset_rcm_accounts(accounts):
+    return frappe.get_all(
+        "Account",
+        filters={
+            "root_type": "Asset",
+            "name": (
+                "in",
+                [accounts["Reverse Charge"].get(field) for field in GST_ACCOUNT_FIELDS],
+            ),
+        },
+        pluck="name",
+    )


### PR DESCRIPTION
- [x] [sql syntax error with empty list of valid_irns](https://github.com/resilient-tech/india-compliance/commit/75e1fd9f1910f27b3dac73f340a39ac43e06a300)
- [x] [better B2B condition to cover all GST categories](https://github.com/resilient-tech/india-compliance/commit/b9ebc616cf98f0b7bf23cb6e3dd80f2dfeca901a)
- [x] [RCM defaults should be liability account instead of asset account](https://github.com/resilient-tech/india-compliance/commit/e0bf4ade796e000ad588d9e098cacfd7f0515f52)
- [x] BOE in Purchase Invoice Dashboard
- [x] Respect User Input for eligibility of ITC during reverse charge
- [x] Patch RCM root to Liability