### PR TITLE
feat: GST Balance Report by company GSTIN

### DIFF
--- a/india_compliance/gst_india/client_scripts/journal_entry.js
+++ b/india_compliance/gst_india/client_scripts/journal_entry.js
@@ -19,7 +19,7 @@ async function toggle_company_gstin(frm) {
 }
 
 async function contains_gst_account(frm) {
-    if (!frm.gst_accounts || frm.company != frm.doc.company) {
+    if (!frm.gst_accounts || frm.company !== frm.doc.company) {
         frm.gst_accounts = await india_compliance.get_account_options(frm.doc.company);
         frm.company = frm.doc.company;
     }

--- a/india_compliance/gst_india/client_scripts/journal_entry.js
+++ b/india_compliance/gst_india/client_scripts/journal_entry.js
@@ -1,17 +1,35 @@
 frappe.ui.form.on("Journal Entry", {
-	refresh: function(frm) {
-		frm.set_query('company_address', function(doc) {
-			if(!doc.company) {
-				frappe.throw(__('Please set Company'));
-			}
-
-			return {
-				query: 'frappe.contacts.doctype.address.address.address_query',
-				filters: {
-					link_doctype: 'Company',
-					link_name: doc.company
-				}
-			};
-		});
-	}
+    company: set_gstin_options,
 });
+
+async function set_gstin_options(frm) {
+    const options = await india_compliance.get_gstin_options(frm.doc.company);
+	frm.get_field("company_gstin").set_data(options);
+
+    frm.set_value("company_gstin", options.length === 1 ? options[0] : "");
+}
+
+frappe.ui.form.on("Journal Entry Account", {
+    account: toggle_company_gstin,
+    accounts_remove: toggle_company_gstin,
+});
+
+async function toggle_company_gstin(frm) {
+    _toggle_company_gstin(frm, await contains_gst_account(frm));
+}
+
+async function contains_gst_account(frm) {
+    if (!frm.gst_accounts || frm.company != frm.doc.company) {
+        frm.gst_accounts = await india_compliance.get_account_options(frm.doc.company);
+        frm.company = frm.doc.company;
+    }
+
+    return frm.doc.accounts.some(row => frm.gst_accounts.includes(row.account));
+}
+
+function _toggle_company_gstin(frm, reqd) {
+    if (frm.get_field("company_gstin").df.reqd !== reqd) {
+        frm.set_df_property("company_gstin", "reqd", reqd);
+        frm.refresh_field("company_gstin");
+    }
+}

--- a/india_compliance/gst_india/constants/custom_fields.py
+++ b/india_compliance/gst_india/constants/custom_fields.py
@@ -235,6 +235,22 @@ CUSTOM_FIELDS = {
             "depends_on": "eval:doc.gst_category == 'Overseas' && doc.place_of_supply == '96-Other Countries'",
         },
     ],
+    ("Journal Entry", "GL Entry"): [
+        {
+            "fieldname": "company_gstin",
+            "label": "Company GSTIN",
+            "fieldtype": "Autocomplete",
+            "insert_after": "company",
+            "hidden": 0,
+            # clear original default values
+            "read_only": 0,
+            "print_hide": 1,
+            "fetch_from": "",
+            "depends_on": "",
+            "mandatory_depends_on": "",
+            "translatable": 0,
+        }
+    ],
     # Transaction Item Fields
     (
         "Material Request Item",
@@ -531,28 +547,6 @@ CUSTOM_FIELDS = {
             "options": "As per rules 42 & 43 of CGST Rules\nOthers",
             "depends_on": "eval:doc.voucher_type == 'Reversal Of ITC'",
             "mandatory_depends_on": "eval:doc.voucher_type == 'Reversal Of ITC'",
-            "translatable": 0,
-        },
-        {
-            "fieldname": "company_address",
-            "label": "Company Address",
-            "fieldtype": "Link",
-            "options": "Address",
-            "insert_after": "reversal_type",
-            "print_hide": 1,
-            "depends_on": "eval:doc.voucher_type == 'Reversal Of ITC'",
-            "mandatory_depends_on": "eval:doc.voucher_type == 'Reversal Of ITC'",
-        },
-        {
-            "fieldname": "company_gstin",
-            "label": "Company GSTIN",
-            "fieldtype": "Data",
-            "read_only": 1,
-            "insert_after": "company_address",
-            "print_hide": 1,
-            "fetch_from": "company_address.gstin",
-            "depends_on": "eval:doc.voucher_type == 'Reversal Of ITC'",
-            "mandatory_depends_on": "eval:doc.voucher_type=='Reversal Of ITC'",
             "translatable": 0,
         },
     ],

--- a/india_compliance/gst_india/constants/custom_fields.py
+++ b/india_compliance/gst_india/constants/custom_fields.py
@@ -244,7 +244,7 @@ CUSTOM_FIELDS = {
             "hidden": 0,
             # clear original default values
             "read_only": 0,
-            "print_hide": 1,
+            "print_hide": 0,
             "fetch_from": "",
             "depends_on": "",
             "mandatory_depends_on": "",

--- a/india_compliance/gst_india/doctype/gst_settings/gst_settings.js
+++ b/india_compliance/gst_india/doctype/gst_settings/gst_settings.js
@@ -129,6 +129,7 @@ function show_update_gstin_button(frm) {
 }
 
 function get_update_gstin_message(voucher_types) {
+    // nosemgrep
     let message = __(
         `
         Company GSTIN is a mandatory field for all transactions.

--- a/india_compliance/gst_india/doctype/gst_settings/gst_settings.js
+++ b/india_compliance/gst_india/doctype/gst_settings/gst_settings.js
@@ -23,10 +23,6 @@ frappe.ui.form.on("GST Settings", {
         });
     },
     onload: show_ic_api_promo,
-    refresh(frm) {
-        if (frm.doc?.__onload?.voucher_types_for_gstin_update)
-            show_update_gstin_button(frm);
-    },
     attach_e_waybill_print(frm) {
         if (!frm.doc.attach_e_waybill_print || frm.doc.fetch_e_waybill_data) return;
         frm.set_value("fetch_e_waybill_data", 1);
@@ -103,60 +99,4 @@ function set_auto_generate_e_waybill(frm) {
         "auto_generate_e_waybill",
         frm.doc.auto_generate_e_invoice && frm.doc.generate_e_waybill_with_e_invoice
     );
-}
-
-// TEMPORARY CODE: trigger patch manually
-function show_update_gstin_button(frm) {
-    const voucher_types = frm.doc.__onload.voucher_types_for_gstin_update;
-
-    frm.add_custom_button(__("Update Company GSTIN"), () => {
-        const message = get_update_gstin_message(voucher_types);
-        frappe.msgprint({
-            title: __("Update Company GSTIN"),
-            message: message,
-            primary_action: {
-                label: __("Execute Patch"),
-                server_action:
-                    "india_compliance.patches.post_install.update_company_gstin.execute",
-                hide_on_success: true,
-            },
-        });
-
-        frappe.msg_dialog.custom_onhide = () => {
-            frm.reload_doc();
-        };
-    });
-}
-
-function get_update_gstin_message(voucher_types) {
-    // nosemgrep
-    let message = __(
-        `
-        Company GSTIN is a mandatory field for all transactions.
-        It could not be set automatically as you have Multi-GSTIN setup.
-        Please update the GSTIN for the following transactions <strong>before</strong>
-        executing the patch:<br>
-        `
-    );
-
-    voucher_types.forEach(voucher_type => {
-        let account_field = "account_head";
-        if (voucher_type === "Journal Entry") account_field = "account";
-
-        let element_text = `<br><a><span class="custom-link" data-fieldtype="Link" data-doctype="${voucher_type}" data-accountfield="${account_field}">${voucher_type}</span></a>`;
-        message += element_text;
-    });
-
-    $(document).on("click", ".custom-link", function () {
-        const doctype = $(this).data("doctype");
-        const account_field = $(this).data("accountfield");
-
-        frappe.set_route("List", doctype, {
-            docstatus: 1,
-            company_gstin: ["is", "not set"],
-            [account_field]: ["like", "%gst%"],
-        });
-    });
-
-    return message;
 }

--- a/india_compliance/gst_india/doctype/gst_settings/gst_settings.py
+++ b/india_compliance/gst_india/doctype/gst_settings/gst_settings.py
@@ -18,16 +18,20 @@ from india_compliance.gst_india.page.india_compliance_account import (
 )
 from india_compliance.gst_india.utils import can_enable_api
 from india_compliance.gst_india.utils.custom_fields import toggle_custom_fields
+from india_compliance.patches.post_install.update_company_gstin import (
+    verify_gstin_update,
+)
 
 E_INVOICE_START_DATE = "2021-01-01"
 
 
 class GSTSettings(Document):
     def onload(self):
-        if can_enable_api(self) or frappe.db.get_global("ic_api_promo_dismissed"):
-            return
+        if not (can_enable_api(self) or frappe.db.get_global("ic_api_promo_dismissed")):
+            self.set_onload("can_show_promo", True)
 
-        self.set_onload("can_show_promo", True)
+        if not frappe.db.get_global("company_gstin_updated"):
+            self.set_onload("voucher_types_for_gstin_update", verify_gstin_update())
 
     def validate(self):
         self.update_dependant_fields()

--- a/india_compliance/gst_india/doctype/gst_settings/gst_settings.py
+++ b/india_compliance/gst_india/doctype/gst_settings/gst_settings.py
@@ -18,20 +18,16 @@ from india_compliance.gst_india.page.india_compliance_account import (
 )
 from india_compliance.gst_india.utils import can_enable_api
 from india_compliance.gst_india.utils.custom_fields import toggle_custom_fields
-from india_compliance.patches.post_install.update_company_gstin import (
-    verify_gstin_update,
-)
 
 E_INVOICE_START_DATE = "2021-01-01"
 
 
 class GSTSettings(Document):
     def onload(self):
-        if not (can_enable_api(self) or frappe.db.get_global("ic_api_promo_dismissed")):
-            self.set_onload("can_show_promo", True)
+        if can_enable_api(self) or frappe.db.get_global("ic_api_promo_dismissed"):
+            return
 
-        if not frappe.db.get_global("company_gstin_updated"):
-            self.set_onload("voucher_types_for_gstin_update", verify_gstin_update())
+        self.set_onload("can_show_promo", True)
 
     def validate(self):
         self.update_dependant_fields()

--- a/india_compliance/gst_india/overrides/gl_entry.py
+++ b/india_compliance/gst_india/overrides/gl_entry.py
@@ -1,0 +1,25 @@
+import frappe
+from frappe import _
+
+from india_compliance.gst_india.overrides.transaction import (
+    is_indian_registered_company,
+)
+from india_compliance.gst_india.utils import get_all_gst_accounts
+
+
+def validate(doc, method=None):
+    if doc.company_gstin or not is_indian_registered_company(doc):
+        return
+
+    gst_accounts = get_all_gst_accounts(doc.company)
+    if doc.account not in gst_accounts:
+        return
+
+    frappe.throw(
+        _("Company GSTIN is a mandatory field for accounting of GST Accounts.")
+    )
+
+
+def update_gl_dict_with_regional_fields(doc, gl_dict):
+    if doc.get("company_gstin"):
+        gl_dict["company_gstin"] = doc.company_gstin

--- a/india_compliance/gst_india/overrides/journal_entry.py
+++ b/india_compliance/gst_india/overrides/journal_entry.py
@@ -1,0 +1,23 @@
+import frappe
+from frappe import _
+
+from india_compliance.gst_india.overrides.transaction import (
+    is_indian_registered_company,
+)
+from india_compliance.gst_india.utils import get_all_gst_accounts
+
+
+def validate(doc, method=None):
+    if doc.company_gstin or not is_indian_registered_company(doc):
+        return
+
+    # validate company_gstin
+    contains_gst_account = False
+    gst_accounts = get_all_gst_accounts(doc.company)
+    for row in doc.accounts:
+        if row.account in gst_accounts:
+            contains_gst_account = True
+            break
+
+    if contains_gst_account:
+        frappe.throw(_("Company GSTIN is mandatory if any GST account is present."))

--- a/india_compliance/gst_india/report/gst_balance/gst_balance.js
+++ b/india_compliance/gst_india/report/gst_balance/gst_balance.js
@@ -1,0 +1,70 @@
+// Copyright (c) 2023, Resilient Tech and contributors
+// For license information, please see license.txt
+/* eslint-disable */
+
+frappe.query_reports["GST Balance"] = {
+    filters: [
+        {
+            fieldname: "company",
+            label: __("Company"),
+            fieldtype: "Link",
+            options: "Company",
+            default: frappe.defaults.get_user_default("Company"),
+            on_change: report => {
+                set_gstin_options(report);
+                report.set_filter_value({
+                    company_gstin: "",
+                });
+            },
+            reqd: 1,
+        },
+        {
+            fieldname: "company_gstin",
+            label: __("Company GSTIN"),
+            fieldtype: "Autocomplete",
+            get_data: () => set_gstin_options(frappe.query_report),
+        },
+        {
+            fieldname: "from_date",
+            label: __("From Date"),
+            fieldtype: "Date",
+            default: frappe.defaults.get_user_default("year_start_date"),
+        },
+        {
+            fieldname: "to_date",
+            label: __("To Date"),
+            fieldtype: "Date",
+            default: frappe.defaults.get_user_default("year_end_date"),
+        },
+        {
+            fieldname: "show_summary",
+            label: __("Show Summary"),
+            fieldtype: "Check",
+            on_change: report => {
+                toggle_filters(report);
+                report.refresh();
+            },
+        },
+    ],
+
+    onload(report) {
+        toggle_filters(report);
+        set_gstin_options(report);
+    },
+};
+
+async function set_gstin_options(report) {
+    const options = await india_compliance.get_gstin_options(
+        report.get_filter_value("company")
+    );
+    const gstin_field = report.get_filter("company_gstin");
+    gstin_field.set_data(options);
+
+    if (options.length == 1) gstin_field.set_value(options[0]);
+}
+
+function toggle_filters(report) {
+    const show_summary = report.get_filter_value("show_summary");
+    report.get_filter("company_gstin").toggle(!show_summary);
+    report.get_filter("from_date").toggle(!show_summary);
+}

--- a/india_compliance/gst_india/report/gst_balance/gst_balance.js
+++ b/india_compliance/gst_india/report/gst_balance/gst_balance.js
@@ -15,6 +15,7 @@ frappe.query_reports["GST Balance"] = {
                 report.set_filter_value({
                     company_gstin: "",
                 });
+                add_custom_button_to_update_gstin(report);
             },
             reqd: 1,
         },
@@ -50,6 +51,7 @@ frappe.query_reports["GST Balance"] = {
     onload(report) {
         toggle_filters(report);
         set_gstin_options(report);
+        add_custom_button_to_update_gstin(report);
     },
 };
 
@@ -67,4 +69,76 @@ function toggle_filters(report) {
     const show_summary = report.get_filter_value("show_summary");
     report.get_filter("company_gstin").toggle(!show_summary);
     report.get_filter("from_date").toggle(!show_summary);
+}
+
+function add_custom_button_to_update_gstin(report) {
+    frappe
+        .call({
+            method: "india_compliance.gst_india.report.gst_balance.gst_balance.get_pending_voucher_types",
+            args: {
+                company: report.get_filter_value("company"),
+            },
+        })
+        .then(r => {
+            if (!r.message) return;
+            const [voucher_types, company_accounts] = r.message;
+            if (!voucher_types.length) return;
+
+            report._gst_accounts = company_accounts;
+            report.page.add_inner_button(
+                __("Update GSTIN"),
+                () => update_gstin_message(report, voucher_types)
+            );
+        });
+}
+
+async function update_gstin_message(report, voucher_types) {
+    const message = get_update_gstin_message(report, voucher_types);
+    frappe.msgprint({
+        title: __("Update Company GSTIN"),
+        message: message,
+        primary_action: {
+            label: __("Execute Patch"),
+            server_action:
+                "india_compliance.gst_india.report.gst_balance.gst_balance.update_company_gstin",
+            hide_on_success: true,
+        },
+    });
+
+    frappe.msg_dialog.custom_onhide = () => {
+        report.refresh();
+    }
+}
+
+function get_update_gstin_message(report, voucher_types) {
+    // nosemgrep
+    let message = __(
+        `
+        Company GSTIN is a mandatory field for all transactions.
+        It could not be set automatically as you have Multi-GSTIN setup.
+        Please update the GSTIN for the following transactions <strong>before</strong>
+        executing the patch:<br>
+        `
+    );
+
+    voucher_types.forEach(voucher_type => {
+        let account_field = "account_head";
+        if (voucher_type === "Journal Entry") account_field = "account";
+
+        let element_text = `<br><a><span class="custom-link" data-fieldtype="Link" data-doctype="${voucher_type}" data-accountfield="${account_field}">${voucher_type}</span></a>`;
+        message += element_text;
+    });
+
+    $(document).on("click", ".custom-link", function () {
+        const doctype = $(this).data("doctype");
+        const account_field = $(this).data("accountfield");
+
+        frappe.set_route("List", doctype, {
+            docstatus: 1,
+            company_gstin: ["is", "not set"],
+            [account_field]: ["in", report._gst_accounts],
+        });
+    });
+
+    return message;
 }

--- a/india_compliance/gst_india/report/gst_balance/gst_balance.json
+++ b/india_compliance/gst_india/report/gst_balance/gst_balance.json
@@ -1,0 +1,31 @@
+{
+ "add_total_row": 1,
+ "columns": [],
+ "creation": "2023-06-05 14:48:26.693826",
+ "disabled": 0,
+ "docstatus": 0,
+ "doctype": "Report",
+ "filters": [],
+ "idx": 0,
+ "is_standard": "Yes",
+ "modified": "2023-06-05 14:48:26.693826",
+ "modified_by": "Administrator",
+ "module": "GST India",
+ "name": "GST Balance",
+ "owner": "Administrator",
+ "prepared_report": 0,
+ "ref_doctype": "GL Entry",
+ "report_name": "GST Balance",
+ "report_type": "Script Report",
+ "roles": [
+  {
+   "role": "Accounts User"
+  },
+  {
+   "role": "Accounts Manager"
+  },
+  {
+   "role": "Auditor"
+  }
+ ]
+}

--- a/india_compliance/gst_india/report/gst_balance/gst_balance.py
+++ b/india_compliance/gst_india/report/gst_balance/gst_balance.py
@@ -1,0 +1,236 @@
+# Copyright (c) 2023, Resilient Tech and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe import _
+from frappe.query_builder.functions import Sum
+from frappe.utils import cstr
+
+from india_compliance.gst_india.utils import get_all_gst_accounts, get_gstin_list
+
+
+def execute(filters=None):
+    report = GSTBalanceReport(filters)
+    columns = report.get_columns()
+
+    if not filters.show_summary:
+        data = report.get_trial_balance_data()
+
+    else:
+        data = report.get_summary_data()
+
+    return columns, data
+
+
+class GSTBalanceReport:
+    def __init__(self, filters=None):
+        self.filters = frappe._dict(filters or {})
+        self.validate_filters()
+        self.gst_accounts = get_all_gst_accounts(filters.company)
+        self.gl_entry = frappe.qb.DocType("GL Entry")
+        self.default_finance_book = frappe.get_cached_value(
+            "Company", self.filters.company, "default_finance_book"
+        )
+
+    def validate_filters(self):
+        if not self.filters.company:
+            frappe.throw(_("Please select a Company"))
+
+        if not self.filters.from_date and not self.filters.show_summary:
+            frappe.throw(_("Please select a From Date"))
+
+        if not self.filters.to_date:
+            frappe.throw(_("Please select a To Date"))
+
+        if self.filters.from_date and self.filters.from_date > self.filters.to_date:
+            frappe.throw(_("From Date cannot be greater than To Date"))
+
+    def get_columns(self):
+        if not self.filters.show_summary:
+            return [
+                {
+                    "fieldname": "account",
+                    "label": _("Account"),
+                    "fieldtype": "Link",
+                    "options": "Account",
+                    "width": 250,
+                },
+                {
+                    "fieldname": "opening_debit",
+                    "label": _("Opening (Dr)"),
+                    "fieldtype": "Currency",
+                    "options": "currency",
+                    "width": 150,
+                },
+                {
+                    "fieldname": "opening_credit",
+                    "label": _("Opening (Cr)"),
+                    "fieldtype": "Currency",
+                    "options": "currency",
+                    "width": 150,
+                },
+                {
+                    "fieldname": "debit",
+                    "label": _("Debit"),
+                    "fieldtype": "Currency",
+                    "options": "currency",
+                    "width": 150,
+                },
+                {
+                    "fieldname": "credit",
+                    "label": _("Credit"),
+                    "fieldtype": "Currency",
+                    "options": "currency",
+                    "width": 150,
+                },
+                {
+                    "fieldname": "closing_debit",
+                    "label": _("Closing (Dr)"),
+                    "fieldtype": "Currency",
+                    "options": "currency",
+                    "width": 150,
+                },
+                {
+                    "fieldname": "closing_credit",
+                    "label": _("Closing (Cr)"),
+                    "fieldtype": "Currency",
+                    "options": "currency",
+                    "width": 150,
+                },
+            ]
+
+        else:
+            columns = [
+                {
+                    "fieldname": "account",
+                    "label": _("Account"),
+                    "fieldtype": "Link",
+                    "options": "Account",
+                    "width": 250,
+                }
+            ]
+
+            self.company_gstins = get_gstin_list(self.filters.company)
+            for gstin in self.company_gstins:
+                columns.append(
+                    {
+                        "fieldname": f"gstin_{gstin}",
+                        "label": gstin,
+                        "fieldtype": "Currency",
+                        "options": "currency",
+                        "width": 150,
+                    }
+                )
+
+            return columns
+
+    def get_trial_balance_data(self):
+        opening_balance = self.get_opening_balance()
+        transactions = self.get_transactions()
+
+        def _process_opening_balance(account, is_debit=True):
+            row = opening_balance.get(account, {})
+            balance = row.get("debit", 0) - row.get("credit", 0)
+
+            if is_debit:
+                return max(balance, 0)
+            else:
+                return max(-balance, 0)
+
+        data = frappe._dict()
+        for account in self.gst_accounts:
+            transaction = transactions.get(account, {})
+            data[account] = frappe._dict(
+                {
+                    "account": account,
+                    "opening_debit": _process_opening_balance(account, is_debit=True),
+                    "opening_credit": _process_opening_balance(account, is_debit=False),
+                    "debit": transaction.get("debit", 0),
+                    "credit": transaction.get("credit", 0),
+                }
+            )
+
+            data[account]["closing_debit"] = (
+                data[account]["opening_debit"] + data[account]["debit"]
+            )
+            data[account]["closing_credit"] = (
+                data[account]["opening_credit"] + data[account]["credit"]
+            )
+
+        return list(data.values())
+
+    def get_summary_data(self):
+        data = frappe._dict()
+        for company_gstin in self.company_gstins:
+            self.filters.company_gstin = company_gstin
+            balance = self.get_closing_balance()
+
+            for account in self.gst_accounts:
+                data.setdefault(account, frappe._dict(account=account))
+                row = balance.get(account, {})
+
+                data[account][f"gstin_{company_gstin}"] = row.get("debit", 0) - row.get(
+                    "credit", 0
+                )
+
+        return list(data.values())
+
+    def get_transactions(self):
+        return self.get_account_wise_dict(
+            self.get_gl_query()
+            .where(
+                (self.gl_entry.posting_date >= self.filters.from_date)
+                & (self.gl_entry.posting_date <= self.filters.to_date)
+                & (self.gl_entry.is_opening == 0)
+            )
+            .run(as_dict=True)
+        )
+
+    def get_opening_balance(self):
+        return self.get_account_wise_dict(
+            self.get_gl_query()
+            .where(
+                (self.gl_entry.posting_date < self.filters.from_date)
+                | (
+                    (self.gl_entry.posting_date >= self.filters.from_date)
+                    & (self.gl_entry.posting_date <= self.filters.to_date)
+                    & (self.gl_entry.is_opening == 1)
+                )
+            )
+            .run(as_dict=True)
+        )
+
+    def get_closing_balance(self):
+        return self.get_account_wise_dict(
+            self.get_gl_query()
+            .where((self.gl_entry.posting_date <= self.filters.to_date))
+            .run(as_dict=True)
+        )
+
+    def get_gl_query(self):
+        query = (
+            frappe.qb.from_(self.gl_entry)
+            .select(
+                self.gl_entry.account,
+                Sum(self.gl_entry.debit).as_("debit"),
+                Sum(self.gl_entry.credit).as_("credit"),
+            )
+            .where(self.gl_entry.is_cancelled == 0)
+            .where(self.gl_entry.company == self.filters.company)
+            .where(self.gl_entry.account.isin(self.gst_accounts))
+            .where(
+                (self.gl_entry.finance_book.isin(["", cstr(self.default_finance_book)]))
+                | (self.gl_entry.finance_book.isnull())
+            )
+            .groupby(self.gl_entry.account)
+        )
+
+        if self.filters.company_gstin:
+            query = query.where(
+                self.gl_entry.company_gstin == self.filters.company_gstin
+            )
+
+        return query
+
+    def get_account_wise_dict(self, data):
+        return {d.account: d for d in data}

--- a/india_compliance/gst_india/report/gst_balance/gst_balance.py
+++ b/india_compliance/gst_india/report/gst_balance/gst_balance.py
@@ -181,7 +181,7 @@ class GSTBalanceReport:
             .where(
                 (self.gl_entry.posting_date >= self.filters.from_date)
                 & (self.gl_entry.posting_date <= self.filters.to_date)
-                & (self.gl_entry.is_opening == 0)
+                & (self.gl_entry.is_opening == "No")
             )
             .run(as_dict=True)
         )
@@ -194,7 +194,7 @@ class GSTBalanceReport:
                 | (
                     (self.gl_entry.posting_date >= self.filters.from_date)
                     & (self.gl_entry.posting_date <= self.filters.to_date)
-                    & (self.gl_entry.is_opening == 1)
+                    & (self.gl_entry.is_opening == "Yes")
                 )
             )
             .run(as_dict=True)

--- a/india_compliance/gst_india/utils/__init__.py
+++ b/india_compliance/gst_india/utils/__init__.py
@@ -330,6 +330,7 @@ def get_gst_accounts_by_type(company, account_type, throw=True):
     )
 
 
+@frappe.whitelist()
 def get_all_gst_accounts(company):
     if not company:
         frappe.throw(_("Please set Company first"))

--- a/india_compliance/hooks.py
+++ b/india_compliance/hooks.py
@@ -78,7 +78,13 @@ doc_events = {
             "india_compliance.gst_india.overrides.transaction.validate_transaction"
         ),
     },
+    "GL Entry": {
+        "validate": "india_compliance.gst_india.overrides.gl_entry.validate",
+    },
     "Item": {"validate": "india_compliance.gst_india.overrides.item.validate"},
+    "Journal Entry": {
+        "validate": "india_compliance.gst_india.overrides.journal_entry.validate",
+    },
     "Payment Entry": {
         "validate": (
             "india_compliance.gst_india.overrides.payment_entry.update_place_of_supply"
@@ -152,6 +158,7 @@ regional_overrides = {
             "india_compliance.gst_india.utils.get_itemised_tax_breakup_data"
         ),
         "erpnext.controllers.taxes_and_totals.get_regional_round_off_accounts": "india_compliance.gst_india.overrides.transaction.get_regional_round_off_accounts",
+        "erpnext.controllers.accounts_controller.update_gl_dict_with_regional_fields": "india_compliance.gst_india.overrides.gl_entry.update_gl_dict_with_regional_fields",
         "erpnext.accounts.party.get_regional_address_details": (
             "india_compliance.gst_india.overrides.transaction.update_party_details"
         ),

--- a/india_compliance/install.py
+++ b/india_compliance/install.py
@@ -34,6 +34,7 @@ POST_INSTALL_PATCHES = (
     "remove_deprecated_docs",
     "remove_old_fields",
     "update_custom_role_for_e_invoice_summary",
+    "update_company_gstin",
 )
 
 

--- a/india_compliance/patches.txt
+++ b/india_compliance/patches.txt
@@ -3,8 +3,9 @@ india_compliance.patches.v15.check_version_compatibility
 
 [post_model_sync]
 india_compliance.patches.v14.set_default_for_overridden_accounts_setting
-execute:from india_compliance.gst_india.setup import create_custom_fields; create_custom_fields() #14
+execute:from india_compliance.gst_india.setup import create_custom_fields; create_custom_fields() #15
 execute:from india_compliance.gst_india.setup import create_property_setters; create_property_setters() #2
+india_compliance.patches.post_install.remove_old_fields
 india_compliance.patches.post_install.update_custom_role_for_e_invoice_summary
 india_compliance.patches.v14.remove_ecommerce_gstin_from_purchase_invoice
 india_compliance.patches.v14.set_sandbox_mode_in_gst_settings

--- a/india_compliance/patches.txt
+++ b/india_compliance/patches.txt
@@ -6,6 +6,7 @@ india_compliance.patches.v14.set_default_for_overridden_accounts_setting
 execute:from india_compliance.gst_india.setup import create_custom_fields; create_custom_fields() #15
 execute:from india_compliance.gst_india.setup import create_property_setters; create_property_setters() #2
 india_compliance.patches.post_install.remove_old_fields
+india_compliance.patches.post_install.update_company_gstin
 india_compliance.patches.post_install.update_custom_role_for_e_invoice_summary
 india_compliance.patches.v14.remove_ecommerce_gstin_from_purchase_invoice
 india_compliance.patches.v14.set_sandbox_mode_in_gst_settings

--- a/india_compliance/patches/post_install/remove_old_fields.py
+++ b/india_compliance/patches/post_install/remove_old_fields.py
@@ -18,3 +18,4 @@ def execute():
     )
     delete_old_fields("pan_details", "Company")
     delete_old_fields("export_type", ("Customer", "Supplier"))
+    delete_old_fields("company_address", "Journal Entry")

--- a/india_compliance/patches/post_install/update_company_gstin.py
+++ b/india_compliance/patches/post_install/update_company_gstin.py
@@ -1,0 +1,183 @@
+import click
+
+import frappe
+
+from india_compliance.gst_india.utils import get_all_gst_accounts, get_gstin_list
+
+##############################################################################################################################
+# Steps to manually migrate:
+##############################################################################################################################
+# Method 1:
+# 1. Update company gstin for Doctypes where its Missing.
+# 2. Execute the patch once again from GST Settings.
+##############################################################################################################################
+# Method 2 (Where Method 1 is not possible):
+# 1. Update same company gstin for all Doctypes where its Missing.
+# 2. Execute the patch once again from GST Settings.
+# 3. Create adjustment Journal Entry to distribute the balance between other company gstins.
+##############################################################################################################################
+
+
+@frappe.whitelist()
+def execute():
+    if not frappe.flags.in_install:
+        frappe.has_permission("GST Settings", ptype="write", throw=True)
+
+    company_list = get_indian_companies()
+    all_gst_accounts = get_gst_accounts(company_list)
+
+    for company in company_list:
+        update_gstin_for_je(company.name, all_gst_accounts)
+
+    update_gl_entries(all_gst_accounts)
+    voucher_types = verify_gstin_update(all_gst_accounts)
+    return voucher_types
+
+
+def get_indian_companies():
+    return frappe.get_all("Company", filters={"country": "India"})
+
+
+def get_gst_accounts(company_list=None):
+    if not company_list:
+        company_list = get_indian_companies()
+
+    all_gst_accounts = []
+    for company in company_list:
+        gst_accounts = get_all_gst_accounts(company.name)
+        all_gst_accounts.extend(gst_accounts)
+
+    return all_gst_accounts
+
+
+def verify_gstin_update(gst_accounts=None):
+    if not gst_accounts:
+        gst_accounts = get_gst_accounts()
+
+    voucher_types = get_pending_voucher_types(gst_accounts)
+
+    if voucher_types:
+        toggle_allow_on_submit(True)
+        return voucher_types
+
+    toggle_allow_on_submit(False)
+    frappe.db.set_global("company_gstin_updated", 1)
+
+
+def update_gstin_for_je(company, gst_accounts):
+    docs_with_gst_account = frappe.get_all(
+        "Journal Entry",
+        filters={
+            "company": company,
+            "docstatus": 1,
+            "account": ("in", gst_accounts),
+            "company_gstin": ("is", "not set"),
+        },
+        pluck="name",
+    )
+
+    if not docs_with_gst_account:
+        return
+
+    company_gstins = get_gstin_list(company)
+    if len(company_gstins) > 1:
+        click.secho(
+            "Multiple GSTINs found for company {0}. Please update Company GSTIN in Journal Entry manually to use GST Balance Report.",
+            fg="yellow",
+        )
+
+    journal_entries = [docname for docname in docs_with_gst_account]
+    return _update_gstins_for_je(journal_entries, company_gstins[0])
+
+
+def _update_gstins_for_je(je_list, gstin):
+    doc = frappe.qb.DocType("Journal Entry")
+    frappe.qb.update(doc).set(doc.company_gstin, gstin).where(
+        doc.name.isin(je_list)
+    ).run()
+
+
+def update_gl_entries(gst_accounts):
+    voucher_types = get_pending_voucher_types(gst_accounts)
+
+    if not voucher_types:
+        return
+
+    error_voucher_types = set()
+    for voucher_type in voucher_types:
+        while True:
+            entries = fetch_gl_entries(gst_accounts, voucher_type, error_voucher_types)
+            if not entries:
+                break
+
+            gstin_voucher_map = get_gstin_wise_vouchers(entries)
+            _update_gl_entries(gstin_voucher_map)
+
+            # nosemgrep
+            frappe.db.commit()  # commit after every 50000 entries
+
+    if error_voucher_types:
+        click.secho(
+            "Company GSTIN is now a required field in GL Entry with GST Account. Seems it is missing in your custom doctypes: {0}".format(
+                ", ".join(error_voucher_types)
+            ),
+            fg="red",
+        )
+
+
+def fetch_gl_entries(gst_accounts, voucher_type, error_voucher_types):
+    doc = frappe.qb.DocType(voucher_type)
+    gl_doc = frappe.qb.DocType("GL Entry")
+
+    try:
+        return (
+            frappe.qb.from_(gl_doc)
+            .join(doc)
+            .on((gl_doc.voucher_no == doc.name) & (gl_doc.voucher_type == voucher_type))
+            .where(gl_doc.account.isin(gst_accounts))
+            .where(gl_doc.company_gstin.isnull() | (gl_doc.company_gstin == ""))
+            .where(doc.company_gstin.notnull() & (doc.company_gstin != ""))
+            .select(gl_doc.name, doc.company_gstin)
+            .limit(50000)
+            .run(as_dict=True)
+        )
+    except Exception:
+        error_voucher_types.add(voucher_type)
+
+
+def get_gstin_wise_vouchers(entries):
+    gstin_voucher_map = frappe._dict()
+    for entry in entries:
+        gstin_voucher_map.setdefault(entry.company_gstin, []).append(entry.name)
+
+    return gstin_voucher_map
+
+
+def _update_gl_entries(gstin_voucher_map):
+    doc = frappe.qb.DocType("GL Entry")
+    for gstin, gl_entries in gstin_voucher_map.items():
+        frappe.qb.update(doc).set(doc.company_gstin, gstin).where(
+            doc.name.isin(gl_entries)
+        ).run()
+
+
+def get_pending_voucher_types(gst_accounts):
+    return frappe.get_all(
+        "GL Entry",
+        filters={
+            "account": ["in", gst_accounts],
+            "company_gstin": ("is", "not set"),
+            "is_cancelled": 0,
+        },
+        pluck="voucher_type",
+        distinct=True,
+    )
+
+
+def toggle_allow_on_submit(allow=True):
+    frappe.set_value(
+        "Custom Field",
+        {"fieldname": "company_gstin"},
+        "allow_on_submit",
+        allow,
+    )

--- a/india_compliance/public/js/utils.js
+++ b/india_compliance/public/js/utils.js
@@ -35,6 +35,18 @@ Object.assign(india_compliance, {
         return message;
     },
 
+    async get_account_options(company) {
+        if (!company) return;
+        const { message } = await frappe.call({
+            method: "india_compliance.gst_india.utils.get_all_gst_accounts",
+            args: {
+                company,
+            },
+        });
+
+        return message || [];
+    },
+
     get_party_type(doctype) {
         return in_list(frappe.boot.sales_doctypes, doctype) ? "Customer" : "Supplier";
     },


### PR DESCRIPTION
depends on: https://github.com/frappe/erpnext/pull/35550
closes: #255 

## GST Balance Summary
![image](https://github.com/resilient-tech/india-compliance/assets/10496564/4f7b53b4-b8ea-49e3-ad18-a4ec729dd0af)

## GST Balance Details
![image](https://github.com/resilient-tech/india-compliance/assets/10496564/009d8a34-dc7c-48b6-9da2-9e43552958df)

## Patch Highlights

### Objective
- Set GSTIN in Journal Entry where GST Account is used
- Set GSTIN in GL Entry
- Verify GSTIN Update and mark patch as complete

### Update Journal Entry
- Identify Docs with GST Account.
- Get all company GSTINs
- Update GSTIN if there is only one company GSTIN

### Update GL Entry
- From Parent Doc, get GSTIN and update GL Entry
- Update is done in batches.
- Update of all historical records is needed to get the correct opening balance

### What if there is more than one company GSTIN (for Journal Entry)?
- If it's missing, manually update GSTIN for each Journal Entry.
- Execute the patch from GST Settings.
