### PR TITLE
fix(patch): hardcode `root_type` for RCM to avoid duplicate error

### DIFF
--- a/india_compliance/install.py
+++ b/india_compliance/install.py
@@ -23,7 +23,7 @@ POST_INSTALL_PATCHES = (
     "update_state_name_to_puducherry",
     "rename_import_of_capital_goods",
     "update_hsn_code",
-    "create_company_fixtures",
+    "update_company_fixtures",
     "merge_utgst_account_into_sgst_account",
     "remove_consumer_gst_category",
     "migrate_e_invoice_settings_to_gst_settings",

--- a/india_compliance/patches/post_install/create_company_fixtures.py
+++ b/india_compliance/patches/post_install/create_company_fixtures.py
@@ -23,4 +23,46 @@ def execute():
 
         # GST fixtures
         if not frappe.db.exists("GST Account", {"company": company}):
+            update_root_for_rcm(company)
             create_gst_fixtures(company)
+
+
+def update_root_for_rcm(company):
+    # Root type for RCM had been updated to "Liability".
+    # This will ensure DuplicateEntryError is not raised for RCM accounts.
+
+    # Hardcoded for exact account names only
+    rcm_accounts = frappe.get_all(
+        "Account",
+        filters={
+            "root_type": "Asset",
+            "name": ("like", "Input Tax %GST RCM%"),
+            "company": company,
+        },
+        pluck="name",
+    )
+
+    if not rcm_accounts:
+        return
+
+    output_account = frappe.db.get_value(
+        "Account",
+        {"name": ("like", "Output Tax %GST%"), "company": company},
+        ["parent_account", "root_type"],
+        as_dict=True,
+    )
+
+    if not output_account:
+        abbr = frappe.db.get_value("Company", company, "abbr")
+        output_account = {
+            "parent_account": f"Duties and Taxes - {abbr}",
+            "root_type": "Liability",
+        }
+
+    # update reverse charge accounts
+    frappe.db.set_value(
+        "Account",
+        {"name": ("in", rcm_accounts)},
+        output_account,
+        update_modified=False,
+    )


### PR DESCRIPTION
```
An error occurred while installing india_compliance: ('Account', 'Input Tax SGST RCM - SGFT', IntegrityError(1062, "Duplicate entry 'Input Tax SGST RCM - SGFT' for key 'PRIMARY'"))
Traceback (most recent call last):
  File "apps/frappe/frappe/model/base_document.py", line 502, in db_insert
    frappe.db.sql(
  File "apps/frappe/frappe/database/database.py", line 219, in sql
    self._cursor.execute(query, values)
  File "env/lib/python3.10/site-packages/pymysql/cursors.py", line 158, in execute
    result = self._query(query)
  File "env/lib/python3.10/site-packages/pymysql/cursors.py", line 325, in _query
    conn.query(q)
  File "env/lib/python3.10/site-packages/pymysql/connections.py", line 549, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "env/lib/python3.10/site-packages/pymysql/connections.py", line 779, in _read_query_result
    result.read()
  File "env/lib/python3.10/site-packages/pymysql/connections.py", line 1157, in read
    first_packet = self.connection._read_packet()
  File "env/lib/python3.10/site-packages/pymysql/connections.py", line 729, in _read_packet
    packet.raise_for_error()
  File "env/lib/python3.10/site-packages/pymysql/protocol.py", line 221, in raise_for_error
    err.raise_mysql_exception(self._data)
  File "env/lib/python3.10/site-packages/pymysql/err.py", line 143, in raise_mysql_exception
    raise errorclass(errno, errval)
pymysql.err.IntegrityError: (1062, "Duplicate entry 'Input Tax SGST RCM - SGFT' for key 'PRIMARY'")

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "apps/frappe/frappe/commands/site.py", line 416, in install_app
    _install_app(app, verbose=context.verbose, force=force)
  File "apps/frappe/frappe/installer.py", line 304, in install_app
    frappe.get_attr(after_install)()
  File "apps/india_compliance/india_compliance/install.py", line 63, in after_install
    raise e
  File "apps/india_compliance/india_compliance/install.py", line 52, in after_install
    run_post_install_patches()
  File "apps/india_compliance/india_compliance/install.py", line 76, in run_post_install_patches
    frappe.get_attr(f"india_compliance.patches.post_install.{patch}.execute")()
  File "apps/india_compliance/india_compliance/patches/post_install/create_company_fixtures.py", line 26, in execute
    create_gst_fixtures(company)
  File "apps/india_compliance/india_compliance/gst_india/overrides/company.py", line 30, in create_company_fixtures
    make_default_tax_templates(company)
  File "apps/india_compliance/india_compliance/gst_india/overrides/company.py", line 60, in make_default_tax_templates
    from_detailed_data(company, default_taxes)
  File "apps/erpnext/erpnext/setup/setup_wizard/operations/taxes_setup.py", line 106, in from_detailed_data
    make_item_tax_template(company_name, template)
  File "apps/erpnext/erpnext/setup/setup_wizard/operations/taxes_setup.py", line 184, in make_item_tax_template
    account = get_or_create_account(company_name, account_data)
  File "apps/erpnext/erpnext/setup/setup_wizard/operations/taxes_setup.py", line 232, in get_or_create_account
    doc.insert(ignore_permissions=True, ignore_mandatory=True)
  File "apps/frappe/frappe/model/document.py", line 270, in insert
    self.db_insert(ignore_if_duplicate=ignore_if_duplicate)
  File "apps/frappe/frappe/model/base_document.py", line 529, in db_insert
    raise frappe.DuplicateEntryError(self.doctype, self.name, e)
frappe.exceptions.DuplicateEntryError: ('Account', 'Input Tax SGST RCM - SGFT', IntegrityError(1062, "Duplicate entry 'Input Tax SGST RCM - SGFT' for key 'PRIMARY'"))
```