### PR TITLE
fix: Improved query for "Invoice Cancelled but not e-Invoice"

### DIFF
--- a/india_compliance/gst_india/report/e_invoice_summary/e_invoice_summary.py
+++ b/india_compliance/gst_india/report/e_invoice_summary/e_invoice_summary.py
@@ -86,7 +86,7 @@ def get_data(filters=None):
     else:
         # invoice is cancelled but irn is not cancelled
         query = query.where(sales_invoice.docstatus == 2).where(
-            (sales_invoice.irn != "") | (sales_invoice.irn.notnull())
+            (sales_invoice.irn != "") & (sales_invoice.irn.notnull())
         )
 
         valid_irns = frappe.get_all(


### PR DESCRIPTION
- Previous report included empty IRN (" ") sales invoice for "Invoice Cancelled but not e-Invoice".
- Replaced the logical OR operator (|) with the logical AND operator (&) in the IRN filtering condition to ensure both conditions are met for non-empty and not null values.