### PR TITLE
refactor: use of `set_single_value` for single doctypes

### DIFF
--- a/india_compliance/gst_india/overrides/test_transaction.py
+++ b/india_compliance/gst_india/overrides/test_transaction.py
@@ -377,7 +377,7 @@ class TestTransaction(FrappeTestCase):
         if not self.is_sales_doctype:
             return
 
-        frappe.db.set_value("GST Settings", None, "enable_overseas_transactions", 1)
+        frappe.db.set_single_value("GST Settings", "enable_overseas_transactions", 1)
         # default is_export_with_gst is 0
         doc = create_transaction(
             **self.transaction_details,
@@ -391,13 +391,13 @@ class TestTransaction(FrappeTestCase):
             re.compile(r"^(.*since export is without.*)$"),
             doc.insert,
         )
-        frappe.db.set_value("GST Settings", None, "enable_overseas_transactions", 0)
+        frappe.db.set_single_value("GST Settings", "enable_overseas_transactions", 0)
 
     def test_reverse_charge_for_sales_transaction(self):
         if not self.is_sales_doctype:
             return
 
-        frappe.db.set_value("GST Settings", None, "enable_reverse_charge_in_sales", 1)
+        frappe.db.set_single_value("GST Settings", "enable_reverse_charge_in_sales", 1)
         doc = create_transaction(
             **self.transaction_details,
             is_reverse_charge=1,
@@ -410,7 +410,7 @@ class TestTransaction(FrappeTestCase):
             re.compile(r"^(.*since supply is under reverse charge.*)$"),
             doc.insert,
         )
-        frappe.db.set_value("GST Settings", None, "enable_reverse_charge_in_sales", 0)
+        frappe.db.set_single_value("GST Settings", "enable_reverse_charge_in_sales", 0)
 
     def test_purchase_from_composition_dealer(self):
         if self.is_sales_doctype:

--- a/india_compliance/gst_india/page/india_compliance_account/__init__.py
+++ b/india_compliance/gst_india/page/india_compliance_account/__init__.py
@@ -31,7 +31,9 @@ def set_api_secret(api_secret: str):
     set_encrypted_password(
         "GST Settings", "GST Settings", api_secret, fieldname="api_secret"
     )
-    frappe.db.set_value("GST Settings", None, "api_secret", "*" * random.randint(8, 16))
+    frappe.db.set_single_value(
+        "GST Settings", "api_secret", "*" * random.randint(8, 16)
+    )
     post_login()
 
 
@@ -42,7 +44,7 @@ def post_login():
 
 def logout():
     remove_encrypted_password("GST Settings", "GST Settings", fieldname="api_secret")
-    frappe.db.set_value("GST Settings", None, "api_secret", None)
+    frappe.db.set_single_value("GST Settings", "api_secret", None)
 
 
 @frappe.whitelist()

--- a/india_compliance/gst_india/setup/__init__.py
+++ b/india_compliance/gst_india/setup/__init__.py
@@ -181,9 +181,8 @@ def set_default_accounts_settings():
 
     show_accounts_settings_override_warning()
 
-    frappe.db.set_value(
+    frappe.db.set_single_value(
         "Accounts Settings",
-        None,
         {
             "determine_address_tax_category_from": "Billing Address",
             "add_taxes_from_item_tax_template": 0,

--- a/india_compliance/patches/post_install/set_default_gst_settings.py
+++ b/india_compliance/patches/post_install/set_default_gst_settings.py
@@ -18,7 +18,7 @@ def execute():
     enable_e_waybill_from_dn(new_settings)
 
     if new_settings:
-        frappe.db.set_value("GST Settings", None, new_settings)
+        frappe.db.set_single_value("GST Settings", new_settings)
 
 
 def enable_e_waybill_from_dn(settings):


### PR DESCRIPTION
`set_value` for single doctypes is deprecated.
Ref: https://github.com/frappe/frappe/pull/21316