### PR TITLE
fix: missing attribute `_action`

### DIFF
--- a/india_compliance/gst_india/overrides/sales_invoice.py
+++ b/india_compliance/gst_india/overrides/sales_invoice.py
@@ -99,7 +99,7 @@ def validate_fields_and_set_status_for_e_invoice(doc):
         _("{0} is a mandatory field for generating e-Invoices"),
     )
 
-    if doc._action == "submit" and not doc.irn:
+    if doc.docstatus == 1 and not doc.irn:
         doc.einvoice_status = "Pending"
 
 

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -458,7 +458,7 @@ def validate_hsn_codes(doc, method=None):
         elif len(hsn_code) < min_hsn_digits:
             rows_with_invalid_hsn.append(str(item.idx))
 
-    if doc._action == "submit":
+    if not doc.get("_action") or doc._action == "submit":
         # Same error for erroneous rows on submit
         rows_with_invalid_hsn += rows_with_missing_hsn
 

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -458,7 +458,7 @@ def validate_hsn_codes(doc, method=None):
         elif len(hsn_code) < min_hsn_digits:
             rows_with_invalid_hsn.append(str(item.idx))
 
-    if not doc.get("_action") or doc._action == "submit":
+    if doc.docstatus == 1:
         # Same error for erroneous rows on submit
         rows_with_invalid_hsn += rows_with_missing_hsn
 


### PR DESCRIPTION
Documents created via APIs won't have `_action` attribute.

```
Traceback (most recent call last):
  File "apps/xyz/xyz/api/v1/distributor.py", line 160, in sales_order
    sales_order.run_method("validate")
  File "apps/frappe/frappe/model/document.py", line 914, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1264, in composer
    return composed(self, method, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1248, in runner
    add_to_return_value(self, f(self, method, *args, **kwargs))
  File "apps/india_compliance/india_compliance/gst_india/overrides/transaction.py", line 788, in validate_transaction
    validate_hsn_codes(doc)
  File "apps/india_compliance/india_compliance/gst_india/overrides/transaction.py", line 462, in validate_hsn_codes
    if doc._action == "submit":
AttributeError: 'SalesOrder' object has no attribute '_action'
```