### PR TITLE
fix: for unlimited account show used credits on Accounts page

### DIFF
--- a/india_compliance/public/js/india_compliance_account/pages/AccountPage.vue
+++ b/india_compliance/public/js/india_compliance_account/pages/AccountPage.vue
@@ -13,7 +13,7 @@
           <p class="last-updated-text">Last Updated On {{ last_synced_on }}</p>
           <div class="subscription-details-item">
             <p class="label">{{ is_unlimited_account ? 'Used Credits' : 'Available Credits' }}</p>
-            <p class="value">{{ is_unlimited_account ? getReadableNumber(used_credits, 0) : getReadableNumber(balance_credits, 0) }}</p>
+            <p class="value">{{ getReadableNumber(is_unlimited_account ? used_credits : balance_credits, 0)}}</p>
           </div>
           <div class="subscription-details-item">
             <p class="label">{{ is_unlimited_account ? 'Next Billing Date' : 'Valid Upto' }}</p>

--- a/india_compliance/public/js/india_compliance_account/pages/AccountPage.vue
+++ b/india_compliance/public/js/india_compliance_account/pages/AccountPage.vue
@@ -13,7 +13,7 @@
           <p class="last-updated-text">Last Updated On {{ last_synced_on }}</p>
           <div v-if="is_unlimited_account" class="subscription-details-item">
             <p class="label">Used Credits</p>
-            <p class="value">{{ getReadableNumber(balance_credits, 0) }}</p>
+            <p class="value">{{ getReadableNumber(used_credits, 0) }}</p>
           </div>
           <div v-else class="subscription-details-item">
             <p class="label">Available Credits</p>
@@ -23,7 +23,7 @@
             <p class="label">Valid Upto</p>
             <p class="value">{{ valid_upto }}</p>
           </div>
-          <router-link
+          <router-link v-if="!is_unlimited_account"
             class="btn btn-primary btn-sm btn-block"
             to="/purchase-credits"
           >
@@ -99,8 +99,12 @@ export default {
     },
 
     is_unlimited_account() {
-      if (this.subscriptionDetails.balance_credits < 0) return true
+      if (this.subscriptionDetails.total_credits == -1) return true
       return false
+    },
+
+    used_credits() {
+      return this.subscriptionDetails.used_credits;
     },
 
     balance_credits() {

--- a/india_compliance/public/js/india_compliance_account/pages/AccountPage.vue
+++ b/india_compliance/public/js/india_compliance_account/pages/AccountPage.vue
@@ -20,7 +20,8 @@
             <p class="value">{{ getReadableNumber(balance_credits, 0) }}</p>
           </div>
           <div class="subscription-details-item">
-            <p class="label">Valid Upto</p>
+            <p v-if="is_unlimited_account" class="label">Next Billing Date</p>
+            <p v-else class="label">Valid Upto</p>
             <p class="value">{{ valid_upto }}</p>
           </div>
           <router-link v-if="!is_unlimited_account"

--- a/india_compliance/public/js/india_compliance_account/pages/AccountPage.vue
+++ b/india_compliance/public/js/india_compliance_account/pages/AccountPage.vue
@@ -11,17 +11,12 @@
       <div class="main-content">
         <div class="card subscription-info">
           <p class="last-updated-text">Last Updated On {{ last_synced_on }}</p>
-          <div v-if="is_unlimited_account" class="subscription-details-item">
-            <p class="label">Used Credits</p>
-            <p class="value">{{ getReadableNumber(used_credits, 0) }}</p>
-          </div>
-          <div v-else class="subscription-details-item">
-            <p class="label">Available Credits</p>
-            <p class="value">{{ getReadableNumber(balance_credits, 0) }}</p>
+          <div class="subscription-details-item">
+            <p class="label">{{ is_unlimited_account ? 'Used Credits' : 'Available Credits' }}</p>
+            <p class="value">{{ is_unlimited_account ? getReadableNumber(used_credits, 0) : getReadableNumber(balance_credits, 0) }}</p>
           </div>
           <div class="subscription-details-item">
-            <p v-if="is_unlimited_account" class="label">Next Billing Date</p>
-            <p v-else class="label">Valid Upto</p>
+            <p class="label">{{ is_unlimited_account ? 'Next Billing Date' : 'Valid Upto' }}</p>
             <p class="value">{{ valid_upto }}</p>
           </div>
           <router-link v-if="!is_unlimited_account"
@@ -100,8 +95,7 @@ export default {
     },
 
     is_unlimited_account() {
-      if (this.subscriptionDetails.total_credits == -1) return true
-      return false
+      return this.subscriptionDetails.total_credits === -1;
     },
 
     used_credits() {
@@ -109,9 +103,6 @@ export default {
     },
 
     balance_credits() {
-      if(this.subscriptionDetails.balance_credits < 0) {
-        return -1 * (this.subscriptionDetails.balance_credits + 1);
-      }
       return this.subscriptionDetails.balance_credits;
     },
 

--- a/india_compliance/public/js/india_compliance_account/pages/AccountPage.vue
+++ b/india_compliance/public/js/india_compliance_account/pages/AccountPage.vue
@@ -11,7 +11,11 @@
       <div class="main-content">
         <div class="card subscription-info">
           <p class="last-updated-text">Last Updated On {{ last_synced_on }}</p>
-          <div class="subscription-details-item">
+          <div v-if="is_unlimited_account" class="subscription-details-item">
+            <p class="label">Used Credits</p>
+            <p class="value">{{ getReadableNumber(balance_credits, 0) }}</p>
+          </div>
+          <div v-else class="subscription-details-item">
             <p class="label">Available Credits</p>
             <p class="value">{{ getReadableNumber(balance_credits, 0) }}</p>
           </div>
@@ -94,7 +98,15 @@ export default {
       return this.$store.state.account.subscriptionDetails || {};
     },
 
+    is_unlimited_account() {
+      if (this.subscriptionDetails.balance_credits < 0) return true
+      return false
+    },
+
     balance_credits() {
+      if(this.subscriptionDetails.balance_credits < 0) {
+        return -1 * (this.subscriptionDetails.balance_credits + 1);
+      }
       return this.subscriptionDetails.balance_credits;
     },
 


### PR DESCRIPTION
Page: Account Page
Changes: For Unlimited user i.e. Total Credits = -1
1) Show Used Credits instead of Available Credits
2) Hide the Purchase Credits button
3) Show Next Billing date instead of Valid Upto date