### PR TITLE
fix: removed unused dependency "rapidfuzz"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ dynamic = ["version"]
 dependencies = [
     "python-barcode~=0.13.1",
     "titlecase~=2.3",
-    "rapidfuzz~=2.1.4",
 
     # Not used directly - required by PyQRCode for PNG generation
     "pypng~=0.20220715.0",


### PR DESCRIPTION
closes: #806 