### PR TITLE
refactor: separating lending doctypes from audit_trail_doctypes

### DIFF
--- a/india_compliance/audit_trail/utils.py
+++ b/india_compliance/audit_trail/utils.py
@@ -7,7 +7,15 @@ def is_audit_trail_enabled():
 
 
 def get_audit_trail_doctypes():
-    return set(frappe.get_hooks("audit_trail_doctypes"))
+    audit_trail_doctypes = []
+
+    audit_trail_doctypes += frappe.get_hooks("erpnext_audit_trail_doctypes")
+    audit_trail_doctypes += frappe.get_hooks("india_compliance_audit_trail_doctypes")
+
+    if "lending" in frappe.get_installed_apps():
+        audit_trail_doctypes += frappe.get_hooks("lending_audit_trail_doctypes")
+
+    return set(audit_trail_doctypes)
 
 
 def enqueue_disable_audit_trail_notification():

--- a/india_compliance/hooks.py
+++ b/india_compliance/hooks.py
@@ -205,7 +205,7 @@ ignore_links_on_delete = ["e-Waybill Log", "e-Invoice Log"]
 accounting_dimension_doctypes = ["Bill of Entry", "Bill of Entry Item"]
 
 # DocTypes for which Audit Trail must be maintained
-audit_trail_doctypes = [
+erpnext_audit_trail_doctypes = [
     # To track the "Enable Audit Trail" setting
     "Accounts Settings",
     # ERPNext DocTypes that make GL Entries
@@ -220,12 +220,6 @@ audit_trail_doctypes = [
     "Asset",
     "Asset Capitalization",
     "Asset Repair",
-    "Loan Balance Adjustment",
-    "Loan Disbursement",
-    "Loan Interest Accrual",
-    "Loan Refund",
-    "Loan Repayment",
-    "Loan Write Off",
     "Delivery Note",
     "Landed Cost Voucher",
     "Purchase Receipt",
@@ -234,10 +228,22 @@ audit_trail_doctypes = [
     "Subcontracting Receipt",
     # Additional ERPNext DocTypes that constitute "Books of Account"
     "POS Invoice",
+]
+
+india_compliance_audit_trail_doctypes = [
     # India Compliance DocTypes that make GL Entries
     "Bill of Entry",
 ]
 
+lending_audit_trail_doctypes = [
+    # Lending DocTypes that make GL Entries
+    "Loan Balance Adjustment",
+    "Loan Disbursement",
+    "Loan Interest Accrual",
+    "Loan Refund",
+    "Loan Repayment",
+    "Loan Write Off",
+]
 
 # Includes in <head>
 # ------------------


### PR DESCRIPTION
Loan management module is not a part of ERPNext anymore and has been separated into the new lending app. Hence separating the lending doctypes from audit_trail_doctypes, and only using them if the lending app is installed.

More: https://github.com/frappe/erpnext/pull/35522.