### PR TITLE
fix: create gstin field in expense claim doctype hrms

### DIFF
--- a/india_compliance/gst_india/client_scripts/expense_claim.js
+++ b/india_compliance/gst_india/client_scripts/expense_claim.js
@@ -1,0 +1,12 @@
+frappe.ui.form.on("Expense Claim", {
+    company: set_gstin_options,
+});
+
+frappe.ui.form.on("Expense Taxes and Charges", {
+    account_head: toggle_gstin_for_expense_claim,
+    accounts_head_remove: toggle_gstin_for_expense_claim,
+});
+
+function toggle_gstin_for_expense_claim(frm) {
+	toggle_company_gstin(frm, taxes_table="taxes", account_field="account_head");
+}

--- a/india_compliance/gst_india/client_scripts/journal_entry.js
+++ b/india_compliance/gst_india/client_scripts/journal_entry.js
@@ -10,21 +10,25 @@ async function set_gstin_options(frm) {
 }
 
 frappe.ui.form.on("Journal Entry Account", {
-    account: toggle_company_gstin,
-    accounts_remove: toggle_company_gstin,
+    account: toggle_gstin_for_journal_entry,
+    accounts_remove: toggle_gstin_for_journal_entry,
 });
 
-async function toggle_company_gstin(frm) {
-    _toggle_company_gstin(frm, await contains_gst_account(frm));
+function toggle_gstin_for_journal_entry(frm) {
+    toggle_company_gstin(frm, taxes_table="accounts", account_head="account");
 }
 
-async function contains_gst_account(frm) {
+async function toggle_company_gstin(frm, taxes_table, account_head) {
+    _toggle_company_gstin(frm, await contains_gst_account(frm, taxes_table, account_head));
+}
+
+async function contains_gst_account(frm, taxes_table, account_field) {
     if (!frm.gst_accounts || frm.company !== frm.doc.company) {
         frm.gst_accounts = await india_compliance.get_account_options(frm.doc.company);
         frm.company = frm.doc.company;
     }
 
-    return frm.doc.accounts.some(row => frm.gst_accounts.includes(row.account));
+    return frm.doc[taxes_table].some(row => frm.gst_accounts.includes(row[account_field]));
 }
 
 function _toggle_company_gstin(frm, reqd) {

--- a/india_compliance/gst_india/constants/custom_fields.py
+++ b/india_compliance/gst_india/constants/custom_fields.py
@@ -623,6 +623,18 @@ CUSTOM_FIELDS = {
     ],
 }
 
+HRMS_CUSTOM_FIELDS = {
+    "Expense Claim": [
+        {
+            "fieldname": "company_gstin",
+            "label": "Company GSTIN",
+            "fieldtype": "Autocomplete",
+            "insert_after": "company",
+            "translatable": 0,
+        }
+    ],
+}
+
 reverse_charge_field = frappe._dict(
     fieldname="is_reverse_charge",
     label="Is Reverse Charge",

--- a/india_compliance/gst_india/setup/__init__.py
+++ b/india_compliance/gst_india/setup/__init__.py
@@ -14,6 +14,7 @@ from india_compliance.gst_india.constants.custom_fields import (
     CUSTOM_FIELDS,
     E_INVOICE_FIELDS,
     E_WAYBILL_FIELDS,
+    HRMS_CUSTOM_FIELDS,
     SALES_REVERSE_CHARGE_FIELDS,
 )
 from india_compliance.gst_india.setup.property_setters import get_property_setters
@@ -39,6 +40,12 @@ def create_custom_fields():
     # Will not fail if a core field with same name already exists (!)
     # Will update a custom field if it already exists
     _create_custom_fields(get_all_custom_fields(), ignore_validate=True)
+    if "hrms" in frappe.get_installed_apps():
+        create_hrms_custom_fields()
+
+
+def create_hrms_custom_fields():
+    _create_custom_fields(HRMS_CUSTOM_FIELDS, ignore_validate=True)
 
 
 def create_accounting_dimension_fields():

--- a/india_compliance/gst_india/uninstall.py
+++ b/india_compliance/gst_india/uninstall.py
@@ -1,6 +1,7 @@
 import frappe
 
 from india_compliance.gst_india.setup import (
+    HRMS_CUSTOM_FIELDS,
     ITEM_VARIANT_FIELDNAMES,
     get_all_custom_fields,
     get_property_setters,
@@ -13,6 +14,10 @@ def before_uninstall():
     delete_property_setters()
     delete_accounting_dimension_fields()
     remove_fields_from_item_variant_settings()
+
+
+def delete_hrms_custom_fields():
+    delete_custom_fields(HRMS_CUSTOM_FIELDS)
 
 
 def delete_property_setters():

--- a/india_compliance/gst_india/uninstall.py
+++ b/india_compliance/gst_india/uninstall.py
@@ -11,6 +11,7 @@ from india_compliance.gst_india.utils.custom_fields import delete_custom_fields
 
 def before_uninstall():
     delete_custom_fields(get_all_custom_fields())
+    delete_hrms_custom_fields()
     delete_property_setters()
     delete_accounting_dimension_fields()
     remove_fields_from_item_variant_settings()

--- a/india_compliance/hooks.py
+++ b/india_compliance/hooks.py
@@ -12,11 +12,13 @@ required_apps = ["frappe/erpnext"]
 
 before_install = "india_compliance.patches.check_version_compatibility.execute"
 after_install = "india_compliance.install.after_install"
+after_app_install = "india_compliance.install.after_app_install"
 before_migrate = "india_compliance.patches.check_version_compatibility.execute"
 after_migrate = "india_compliance.audit_trail.setup.after_migrate"
 before_tests = "india_compliance.tests.before_tests"
 boot_session = "india_compliance.boot.set_bootinfo"
 before_uninstall = "india_compliance.uninstall.before_uninstall"
+before_app_uninstall = "india_compliance.uninstall.before_app_uninstall"
 
 setup_wizard_requires = "assets/india_compliance/js/setup_wizard.js"
 setup_wizard_complete = "india_compliance.gst_india.setup.setup_wizard_complete"

--- a/india_compliance/hooks.py
+++ b/india_compliance/hooks.py
@@ -35,6 +35,10 @@ doctype_js = {
         "gst_india/client_scripts/delivery_note.js",
     ],
     "Item": "gst_india/client_scripts/item.js",
+    "Expense Claim": [
+        "gst_india/client_scripts/journal_entry.js",
+        "gst_india/client_scripts/expense_claim.js",
+    ],
     "Journal Entry": "gst_india/client_scripts/journal_entry.js",
     "Payment Entry": "gst_india/client_scripts/payment_entry.js",
     "Purchase Invoice": "gst_india/client_scripts/purchase_invoice.js",

--- a/india_compliance/install.py
+++ b/india_compliance/install.py
@@ -5,6 +5,7 @@ import frappe
 from india_compliance.audit_trail.setup import setup_fixtures as setup_audit_trail
 from india_compliance.gst_india.constants import BUG_REPORT_URL
 from india_compliance.gst_india.setup import after_install as setup_gst
+from india_compliance.gst_india.setup import create_hrms_custom_fields
 from india_compliance.income_tax_india.setup import after_install as setup_income_tax
 
 # list of filenames (without extension) in sequence of execution
@@ -91,3 +92,8 @@ def disable_ic_account_page():
         return
 
     frappe.get_doc(doctype="Custom Role", page="india-compliance-account").insert()
+
+
+def after_app_install(app_name):
+    if app_name == "hrms":
+        create_hrms_custom_fields()

--- a/india_compliance/patches.txt
+++ b/india_compliance/patches.txt
@@ -3,7 +3,7 @@ execute:import frappe; frappe.delete_doc_if_exists("DocType", "GSTIN")
 
 [post_model_sync]
 india_compliance.patches.v14.set_default_for_overridden_accounts_setting
-execute:from india_compliance.gst_india.setup import create_custom_fields; create_custom_fields() #19
+execute:from india_compliance.gst_india.setup import create_custom_fields; create_custom_fields() #20
 execute:from india_compliance.gst_india.setup import create_property_setters; create_property_setters() #2
 india_compliance.patches.post_install.remove_old_fields
 india_compliance.patches.post_install.update_company_gstin

--- a/india_compliance/patches/check_version_compatibility.py
+++ b/india_compliance/patches/check_version_compatibility.py
@@ -11,6 +11,7 @@ VERSION_COMPATIBILITY = {
     "15.0.0-dev": {"frappe": "15.0.0-dev", "erpnext": "15.0.0-dev"},
     # Stable Versions
     "15.0.0": {"frappe": "15.0.0", "erpnext": "15.0.0"},
+    "14.14.0": {"frappe": "14.42.0", "erpnext": "14.32.0"},
     "14.10.4": {"frappe": "14.0.0", "erpnext": "14.29.0"},
     "14.0.0": {"frappe": "14.0.0", "erpnext": "14.0.0"},
 }

--- a/india_compliance/uninstall.py
+++ b/india_compliance/uninstall.py
@@ -2,6 +2,7 @@ import click
 
 from india_compliance.gst_india.constants import BUG_REPORT_URL
 from india_compliance.gst_india.uninstall import before_uninstall as remove_gst
+from india_compliance.gst_india.uninstall import delete_hrms_custom_fields
 from india_compliance.income_tax_india.uninstall import (
     before_uninstall as remove_income_tax,
 )
@@ -25,3 +26,8 @@ def before_uninstall():
             fg="bright_red",
         )
         raise e
+
+
+def before_app_uninstall(app_name):
+    if app_name == "hrms":
+        delete_hrms_custom_fields()


### PR DESCRIPTION
depends on: https://github.com/frappe/frappe/pull/21784

- Its possible to book taxes from Expense claim in HRMS app.
- In such cases company GSTIN is a required field for GL Entry.

- [x] update compatible apps