### PR TITLE
fix: show message if gst applicable but not applied in sales invoice

### DIFF
--- a/india_compliance/gst_india/client_scripts/sales_invoice.js
+++ b/india_compliance/gst_india/client_scripts/sales_invoice.js
@@ -35,10 +35,10 @@ frappe.ui.form.on(DOCTYPE, {
 
 async function gst_invoice_warning(frm) {
     if (is_gst_invoice(frm) && !(await contains_gst_account(frm))) {
-        frm.layout.show_message();
         frm.dashboard.add_comment(
             __(
-                "GST is applicable for this invoice but no tax accounts specified in GST Settings is charged."
+                `GST is applicable for this invoice but no tax accounts specified in <a href="/app/gst-settings">
+                GST Settings</a> are charged.`
             ),
             "red",
             true
@@ -52,8 +52,8 @@ function is_gst_invoice(frm) {
         frm.doc.is_opening != "Yes" &&
         frm.doc.company_gstin &&
         frm.doc.company_gstin != frm.doc.billing_address_gstin &&
-        !frm.doc.items.some(row => row.is_non_gst) &&
-        !frm.doc.items.every(row => row.is_nil_exempt);
+        !frm.doc.items.some(item => item.is_non_gst) &&
+        !frm.doc.items.every(item => item.is_nil_exempt);
 
     if (frm.doc.place_of_supply === "96-Other Countries") {
         return gst_invoice_conditions && frm.doc.is_export_with_gst;
@@ -66,7 +66,7 @@ async function contains_gst_account(frm) {
     const gst_accounts = await _get_account_options(frm.doc.company);
     const accounts = frm.doc.taxes.map(taxes => taxes.account_head);
 
-    return accounts.some(row => gst_accounts.includes(row));
+    return accounts.some(account => gst_accounts.includes(account));
 }
 
 async function _get_account_options(company) {

--- a/india_compliance/gst_india/client_scripts/sales_invoice.js
+++ b/india_compliance/gst_india/client_scripts/sales_invoice.js
@@ -26,5 +26,41 @@ frappe.ui.form.on(DOCTYPE, {
 
     before_submit(frm) {
         frm.doc._submitted_from_ui = 1;
-    }
+    },
+
+    refresh(frm) {
+        gst_invoice_warning(frm);
+    },
 });
+
+async function gst_invoice_warning(frm) {
+    if (is_gst_invoice(frm) && !(await contains_gst_account(frm))) {
+        frm.layout.show_message();
+        frm.dashboard.add_comment(
+            __(
+                "GST is applicable for this invoice but no account from GST Settings is charged."
+            ),
+            "red",
+            true
+        );
+    }
+}
+
+function is_gst_invoice(frm) {
+    return (
+        (frm.doc.docstatus == 1 &&
+            frm.doc.is_opening != "Yes" &&
+            frm.doc.company_gstin &&
+            frm.doc.company_gstin != frm.doc.billing_address_gstin &&
+            !frm.doc.items.some(row => row.is_non_gst) &&
+            !frm.doc.items.every(row => row.is_nil_exempt)) ||
+        frm.doc.is_export_with_gst
+    );
+}
+
+async function contains_gst_account(frm) {
+    frm.gst_accounts = await india_compliance.get_account_options(frm.doc.company);
+    frm.accounts = frm.doc.taxes.map(taxes => taxes.account_head);
+
+    return frm.accounts.some(row => frm.gst_accounts.includes(row));
+}


### PR DESCRIPTION
Whenever gst is applicable in sales invoices, and no accounts from gst settings are used in taxes and charges table then message will be shown.

![image](https://github.com/resilient-tech/india-compliance/assets/108322669/9a852838-44a9-49c2-843d-0145ab32a3e4)
