### PR TITLE
test: generate e-waybill for Delivery Note and Purchase Invoice

### DIFF
--- a/india_compliance/gst_india/data/test_e_waybill.json
+++ b/india_compliance/gst_india/data/test_e_waybill.json
@@ -355,7 +355,9 @@
     },
     "is_return_dn_with_same_gstin": {
         "kwargs": {
-            "qty": 1000
+            "qty": 1000,
+            "customer_address": "_Test Registered Customer-Billing",
+            "company_address": "_Test Registered Customer-Billing"
         },
         "values": {
             "distance": 100,
@@ -399,7 +401,7 @@
             "sgstValue": 0,
             "subSupplyType": 12,
             "supplyType": "I",
-            "toAddr1": "Test Address - 1",
+            "toAddr1": "Test Address - 3",
             "toGstin": "05AAACG2115R1ZN",
             "toPincode": 380015,
             "toPlace": "Test City",
@@ -592,7 +594,7 @@
             "docDate": "07/08/2023",
             "docNo": "test_invoice_no",
             "docType": "CHL",
-            "fromAddr1": "Test Address - 1",
+            "fromAddr1": "Test Address - 3",
             "fromGstin": "05AAACG2115R1ZN",
             "fromPincode": 380015,
             "fromPlace": "Test City",
@@ -619,7 +621,7 @@
             "subSupplyType": 5,
             "supplyType": "O",
             "toAddr1": "Test Address - 3",
-            "toGstin": "05AAACG2140A1ZL",
+            "toGstin": "05AAACG2115R1ZN",
             "toPincode": 380015,
             "toPlace": "Test City",
             "toStateCode": 24,

--- a/india_compliance/gst_india/data/test_e_waybill.json
+++ b/india_compliance/gst_india/data/test_e_waybill.json
@@ -647,5 +647,219 @@
             },
             "success": true
         }
+    },
+    "pi_data_for_unregistered_supplier": {
+        "kwargs": {
+            "supplier": "_Test Unregistered Supplier",
+            "qty": 1000,
+            "distance": 10,
+            "mode_of_transport": "Road",
+            "vehicle_no": "GJ05DL9009"
+        },
+        "request_data": {
+            "OthValue": 0.0,
+            "TotNonAdvolVal": 0,
+            "actFromStateCode": 24,
+            "actToStateCode": 24,
+            "cessValue": 0,
+            "cgstValue": 0,
+            "docDate": "08/08/2023",
+            "docNo": "test_invoice_no",
+            "docType": "INV",
+            "fromAddr1": "Test Address - 10",
+            "fromGstin": "05AAACG2140A1ZL",
+            "fromPincode": 380015,
+            "fromPlace": "Test City",
+            "fromStateCode": 24,
+            "fromTrdName": "_Test Unregistered Supplier",
+            "igstValue": 0,
+            "itemList": [
+                {
+                    "cessNonAdvol": 0,
+                    "cessRate": 0,
+                    "cgstRate": 0,
+                    "hsnCode": "61149090",
+                    "igstRate": 0,
+                    "itemNo": 1,
+                    "productDesc": "Test Trading Goods 1",
+                    "qtyUnit": "NOS",
+                    "quantity": 1000.0,
+                    "sgstRate": 0,
+                    "taxableAmount": 100000.0
+                }
+            ],
+            "mainHsnCode": "61149090",
+            "sgstValue": 0,
+            "subSupplyType": 1,
+            "supplyType": "I",
+            "toAddr1": "Test Address - 1",
+            "toGstin": "05AAACG2115R1ZN",
+            "toPincode": 380015,
+            "toPlace": "Test City",
+            "toStateCode": 24,
+            "toTrdName": "_Test Indian Registered Company",
+            "totInvValue": 100000.0,
+            "totalValue": 100000.0,
+            "transDistance": 10,
+            "transMode": 1,
+            "transactionType": 1,
+            "userGstin": "05AAACG2115R1ZN",
+            "vehicleNo": "GJ05DL9009",
+            "vehicleType": "R"
+        },
+        "params": "action=GENEWAYBILL",
+        "response_data": {
+            "message": "E-Way Bill is generated successfully",
+            "result": {
+                "alert": "",
+                "ewayBillDate": "08/08/2023 03:28:00 PM",
+                "ewayBillNo": 371003383264,
+                "validUpto": "09/08/2023 11:59:00 PM"
+            },
+            "success": true
+        }
+    },
+    "pi_data_for_registered_supplier": {
+        "kwargs": {
+            "supplier": "_Test Registered Supplier",
+            "qty": 1000,
+            "distance": 10,
+            "mode_of_transport": "Road",
+            "vehicle_no": "GJ05DL9009"
+        },
+        "request_data": {
+            "OthValue": 0.0,
+            "TotNonAdvolVal": 0,
+            "actFromStateCode": 24,
+            "actToStateCode": 24,
+            "cessValue": 0,
+            "cgstValue": 0,
+            "docDate": "08/08/2023",
+            "docNo": "test_invoice_no",
+            "docType": "INV",
+            "fromAddr1": "Test Address - 7",
+            "fromGstin": "05AAACG2140A1ZL",
+            "fromPincode": 380015,
+            "fromPlace": "Test City",
+            "fromStateCode": 24,
+            "fromTrdName": "_Test Registered Supplier",
+            "igstValue": 0,
+            "itemList": [
+                {
+                    "cessNonAdvol": 0,
+                    "cessRate": 0,
+                    "cgstRate": 0,
+                    "hsnCode": "61149090",
+                    "igstRate": 0,
+                    "itemNo": 1,
+                    "productDesc": "Test Trading Goods 1",
+                    "qtyUnit": "NOS",
+                    "quantity": 1000.0,
+                    "sgstRate": 0,
+                    "taxableAmount": 100000.0
+                }
+            ],
+            "mainHsnCode": "61149090",
+            "sgstValue": 0,
+            "subSupplyType": 1,
+            "supplyType": "I",
+            "toAddr1": "Test Address - 1",
+            "toGstin": "05AAACG2115R1ZN",
+            "toPincode": 380015,
+            "toPlace": "Test City",
+            "toStateCode": 24,
+            "toTrdName": "_Test Indian Registered Company",
+            "totInvValue": 100000.0,
+            "totalValue": 100000.0,
+            "transDistance": 10,
+            "transMode": 1,
+            "transactionType": 1,
+            "userGstin": "05AAACG2115R1ZN",
+            "vehicleNo": "GJ05DL9009",
+            "vehicleType": "R"
+        },
+        "params": "action=GENEWAYBILL",
+        "response_data": {
+            "message": "E-Way Bill is generated successfully",
+            "result": {
+                "alert": "",
+                "ewayBillDate": "08/08/2023 12:18:00 PM",
+                "ewayBillNo": 301003383151,
+                "validUpto": "09/08/2023 11:59:00 PM"
+            },
+            "success": true
+        }
+    },
+    "purchase_return_for_registered_supplier": {
+        "kwargs": {
+            "supplier": "_Test Registered Supplier",
+            "qty": 1000,
+            "distance": 10,
+            "mode_of_transport": "Road",
+            "vehicle_no": "GJ05DL9009"
+        },
+        "request_data": {
+            "OthValue": 0.0,
+            "TotNonAdvolVal": 0,
+            "actFromStateCode": 24,
+            "actToStateCode": 24,
+            "cessValue": 0,
+            "cgstValue": 0,
+            "docDate": "08/08/2023",
+            "docNo": "test_invoice_no",
+            "docType": "OTH",
+            "fromAddr1": "Test Address - 1",
+            "fromGstin": "05AAACG2115R1ZN",
+            "fromPincode": 380015,
+            "fromPlace": "Test City",
+            "fromStateCode": 24,
+            "fromTrdName": "_Test Indian Registered Company",
+            "igstValue": 0,
+            "itemList": [
+                {
+                    "cessNonAdvol": 0,
+                    "cessRate": 0,
+                    "cgstRate": 0,
+                    "hsnCode": "61149090",
+                    "igstRate": 0,
+                    "itemNo": 1,
+                    "productDesc": "Test Trading Goods 1",
+                    "qtyUnit": "NOS",
+                    "quantity": 1000.0,
+                    "sgstRate": 0,
+                    "taxableAmount": 100000.0
+                }
+            ],
+            "mainHsnCode": "61149090",
+            "sgstValue": 0,
+            "subSupplyDesc": "Purchase Return",
+            "subSupplyType": 8,
+            "supplyType": "O",
+            "toAddr1": "Test Address - 7",
+            "toGstin": "05AAACG2140A1ZL",
+            "toPincode": 380015,
+            "toPlace": "Test City",
+            "toStateCode": 24,
+            "toTrdName": "_Test Registered Supplier",
+            "totInvValue": 100000.0,
+            "totalValue": 100000.0,
+            "transDistance": 10,
+            "transMode": 1,
+            "transactionType": 1,
+            "userGstin": "05AAACG2115R1ZN",
+            "vehicleNo": "GJ05DL9009",
+            "vehicleType": "R"
+        },
+        "params": "action=GENEWAYBILL",
+        "response_data": {
+            "message": "E-Way Bill is generated successfully",
+            "result": {
+                "alert": "",
+                "ewayBillDate": "08/08/2023 03:30:00 PM",
+                "ewayBillNo": 341003383265,
+                "validUpto": "09/08/2023 11:59:00 PM"
+            },
+            "success": true
+        }
     }
 }

--- a/india_compliance/gst_india/data/test_e_waybill.json
+++ b/india_compliance/gst_india/data/test_e_waybill.json
@@ -352,5 +352,297 @@
             },
             "success": true
         }
+    },
+    "is_return_dn_with_same_gstin": {
+        "kwargs": {
+            "qty": 1000
+        },
+        "values": {
+            "distance": 100,
+            "mode_of_transport": "Road",
+            "vehicle_no": "GJ07DL9009",
+            "sub_supply_type": "Exhibition or Fairs"
+        },
+        "request_data": {
+            "OthValue": 0.0,
+            "TotNonAdvolVal": 0,
+            "actFromStateCode": 24,
+            "actToStateCode": 24,
+            "cessValue": 0,
+            "cgstValue": 0,
+            "docDate": "07/08/2023",
+            "docNo": "test_invoice_no",
+            "docType": "CHL",
+            "fromAddr1": "Test Address - 3",
+            "fromGstin": "05AAACG2115R1ZN",
+            "fromPincode": 380015,
+            "fromPlace": "Test City",
+            "fromStateCode": 24,
+            "fromTrdName": "_Test Registered Customer",
+            "igstValue": 0,
+            "itemList": [
+                {
+                    "cessNonAdvol": 0,
+                    "cessRate": 0,
+                    "cgstRate": 0,
+                    "hsnCode": "61149090",
+                    "igstRate": 0,
+                    "itemNo": 1,
+                    "productDesc": "Test Trading Goods 1",
+                    "qtyUnit": "NOS",
+                    "quantity": 1000.0,
+                    "sgstRate": 0,
+                    "taxableAmount": 100000.0
+                }
+            ],
+            "mainHsnCode": "61149090",
+            "sgstValue": 0,
+            "subSupplyType": 12,
+            "supplyType": "I",
+            "toAddr1": "Test Address - 1",
+            "toGstin": "05AAACG2115R1ZN",
+            "toPincode": 380015,
+            "toPlace": "Test City",
+            "toStateCode": 24,
+            "toTrdName": "_Test Indian Registered Company",
+            "totInvValue": 100000.0,
+            "totalValue": 100000.0,
+            "transDistance": 100,
+            "transMode": 1,
+            "transactionType": 1,
+            "userGstin": "05AAACG2115R1ZN",
+            "vehicleNo": "GJ07DL9009",
+            "vehicleType": "R"
+        },
+        "params": "action=GENEWAYBILL",
+        "response_data": {
+            "message": "E-Way Bill is generated successfully",
+            "result": {
+                "alert": "",
+                "ewayBillDate": "07/08/2023 12:34:00 PM",
+                "ewayBillNo": 321003382521,
+                "validUpto": "08/08/2023 11:59:00 PM"
+            },
+            "success": true
+        }
+    },
+    "is_return_dn_with_different_gstin": {
+        "kwargs": {
+            "qty": 1000
+        },
+        "values": {
+            "distance": 100,
+            "mode_of_transport": "Road",
+            "vehicle_no": "GJ07DL9009",
+            "sub_supply_type": "Job Work Returns"
+        },
+        "request_data": {
+            "OthValue": 0.0,
+            "TotNonAdvolVal": 0,
+            "actFromStateCode": 24,
+            "actToStateCode": 24,
+            "cessValue": 0,
+            "cgstValue": 0,
+            "docDate": "07/08/2023",
+            "docNo": "test_invoice_no",
+            "docType": "CHL",
+            "fromAddr1": "Test Address - 3",
+            "fromGstin": "05AAACG2140A1ZL",
+            "fromPincode": 380015,
+            "fromPlace": "Test City",
+            "fromStateCode": 24,
+            "fromTrdName": "_Test Registered Customer",
+            "igstValue": 0,
+            "itemList": [
+                {
+                    "cessNonAdvol": 0,
+                    "cessRate": 0,
+                    "cgstRate": 0,
+                    "hsnCode": "61149090",
+                    "igstRate": 0,
+                    "itemNo": 1,
+                    "productDesc": "Test Trading Goods 1",
+                    "qtyUnit": "NOS",
+                    "quantity": 1000.0,
+                    "sgstRate": 0,
+                    "taxableAmount": 100000.0
+                }
+            ],
+            "mainHsnCode": "61149090",
+            "sgstValue": 0,
+            "subSupplyType": 6,
+            "supplyType": "I",
+            "toAddr1": "Test Address - 1",
+            "toGstin": "05AAACG2115R1ZN",
+            "toPincode": 380015,
+            "toPlace": "Test City",
+            "toStateCode": 24,
+            "toTrdName": "_Test Indian Registered Company",
+            "totInvValue": 100000.0,
+            "totalValue": 100000.0,
+            "transDistance": 100,
+            "transMode": 1,
+            "transactionType": 1,
+            "userGstin": "05AAACG2115R1ZN",
+            "vehicleNo": "GJ07DL9009",
+            "vehicleType": "R"
+        },
+        "params": "action=GENEWAYBILL",
+        "response_data": {
+            "message": "E-Way Bill is generated successfully",
+            "result": {
+                "alert": "",
+                "ewayBillDate": "07/08/2023 12:18:00 PM",
+                "ewayBillNo": 361003382507,
+                "validUpto": "08/08/2023 11:59:00 PM"
+            },
+            "success": true
+        }
+    },
+    "dn_with_different_gstin": {
+        "kwargs": {
+            "qty": 1000
+        },
+        "values": {
+            "distance": 100,
+            "mode_of_transport": "Road",
+            "vehicle_no": "GJ07DL9009",
+            "sub_supply_type": "Job Work"
+        },
+        "request_data": {
+            "OthValue": 0.0,
+            "TotNonAdvolVal": 0,
+            "actFromStateCode": 24,
+            "actToStateCode": 24,
+            "cessValue": 0,
+            "cgstValue": 0,
+            "docDate": "07/08/2023",
+            "docNo": "test_invoice_no",
+            "docType": "CHL",
+            "fromAddr1": "Test Address - 1",
+            "fromGstin": "05AAACG2115R1ZN",
+            "fromPincode": 380015,
+            "fromPlace": "Test City",
+            "fromStateCode": 24,
+            "fromTrdName": "_Test Indian Registered Company",
+            "igstValue": 0,
+            "itemList": [
+                {
+                    "cessNonAdvol": 0,
+                    "cessRate": 0,
+                    "cgstRate": 0,
+                    "hsnCode": "61149090",
+                    "igstRate": 0,
+                    "itemNo": 1,
+                    "productDesc": "Test Trading Goods 1",
+                    "qtyUnit": "NOS",
+                    "quantity": 1000.0,
+                    "sgstRate": 0,
+                    "taxableAmount": 100000.0
+                }
+            ],
+            "mainHsnCode": "61149090",
+            "sgstValue": 0,
+            "subSupplyType": 4,
+            "supplyType": "O",
+            "toAddr1": "Test Address - 3",
+            "toGstin": "05AAACG2140A1ZL",
+            "toPincode": 380015,
+            "toPlace": "Test City",
+            "toStateCode": 24,
+            "toTrdName": "_Test Registered Customer",
+            "totInvValue": 100000.0,
+            "totalValue": 100000.0,
+            "transDistance": 100,
+            "transMode": 1,
+            "transactionType": 1,
+            "userGstin": "05AAACG2115R1ZN",
+            "vehicleNo": "GJ07DL9009",
+            "vehicleType": "R"
+        },
+        "params": "action=GENEWAYBILL",
+        "response_data": {
+            "message": "E-Way Bill is generated successfully",
+            "result": {
+                "alert": "",
+                "ewayBillDate": "07/08/2023 11:58:00 AM",
+                "ewayBillNo": 371003382498,
+                "validUpto": "08/08/2023 11:59:00 PM"
+            },
+            "success": true
+        }
+    },
+    "dn_with_same_gstin": {
+        "kwargs": {
+            "qty": 1000
+        },
+        "values": {
+            "distance": 100,
+            "mode_of_transport": "Road",
+            "vehicle_no": "GJ07DL9009",
+            "sub_supply_type": "For Own Use"
+        },
+        "request_data": {
+            "OthValue": 0.0,
+            "TotNonAdvolVal": 0,
+            "actFromStateCode": 24,
+            "actToStateCode": 24,
+            "cessValue": 0,
+            "cgstValue": 0,
+            "docDate": "07/08/2023",
+            "docNo": "test_invoice_no",
+            "docType": "CHL",
+            "fromAddr1": "Test Address - 1",
+            "fromGstin": "05AAACG2115R1ZN",
+            "fromPincode": 380015,
+            "fromPlace": "Test City",
+            "fromStateCode": 24,
+            "fromTrdName": "_Test Indian Registered Company",
+            "igstValue": 0,
+            "itemList": [
+                {
+                    "cessNonAdvol": 0,
+                    "cessRate": 0,
+                    "cgstRate": 0,
+                    "hsnCode": "61149090",
+                    "igstRate": 0,
+                    "itemNo": 1,
+                    "productDesc": "Test Trading Goods 1",
+                    "qtyUnit": "NOS",
+                    "quantity": 1000.0,
+                    "sgstRate": 0,
+                    "taxableAmount": 100000.0
+                }
+            ],
+            "mainHsnCode": "61149090",
+            "sgstValue": 0,
+            "subSupplyType": 5,
+            "supplyType": "O",
+            "toAddr1": "Test Address - 3",
+            "toGstin": "05AAACG2115R1ZN",
+            "toPincode": 380015,
+            "toPlace": "Test City",
+            "toStateCode": 24,
+            "toTrdName": "_Test Registered Customer",
+            "totInvValue": 100000.0,
+            "totalValue": 100000.0,
+            "transDistance": 100,
+            "transMode": 1,
+            "transactionType": 1,
+            "userGstin": "05AAACG2115R1ZN",
+            "vehicleNo": "GJ07DL9009",
+            "vehicleType": "R"
+        },
+        "params": "action=GENEWAYBILL",
+        "response_data": {
+            "message": "E-Way Bill is generated successfully",
+            "result": {
+                "alert": "",
+                "ewayBillDate": "07/08/2023 12:24:00 PM",
+                "ewayBillNo": 301003382512,
+                "validUpto": "08/08/2023 11:59:00 PM"
+            },
+            "success": true
+        }
     }
 }

--- a/india_compliance/gst_india/data/test_e_waybill.json
+++ b/india_compliance/gst_india/data/test_e_waybill.json
@@ -667,7 +667,7 @@
             "docNo": "test_invoice_no",
             "docType": "INV",
             "fromAddr1": "Test Address - 10",
-            "fromGstin": "05AAACG2140A1ZL",
+            "fromGstin": "URP",
             "fromPincode": 380015,
             "fromPlace": "Test City",
             "fromStateCode": 24,

--- a/india_compliance/gst_india/data/test_e_waybill.json
+++ b/india_compliance/gst_india/data/test_e_waybill.json
@@ -619,7 +619,7 @@
             "subSupplyType": 5,
             "supplyType": "O",
             "toAddr1": "Test Address - 3",
-            "toGstin": "05AAACG2115R1ZN",
+            "toGstin": "05AAACG2140A1ZL",
             "toPincode": 380015,
             "toPlace": "Test City",
             "toStateCode": 24,

--- a/india_compliance/gst_india/data/test_e_waybill.json
+++ b/india_compliance/gst_india/data/test_e_waybill.json
@@ -576,7 +576,8 @@
     },
     "dn_with_same_gstin": {
         "kwargs": {
-            "qty": 1000
+            "qty": 1000,
+            "company_address": "_Test Registered Customer-Billing"
         },
         "values": {
             "distance": 100,

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -1175,8 +1175,8 @@ class EWaybillData(GSTTransactionData):
                 )
 
             def _get_sandbox_gstin(address, key):
-                if address.gst_category == "Unregistered":
-                    return "URP"
+                if address.gstin == "URP":
+                    return address.gstin
 
                 return sandbox_gstin.get((self.doc.doctype, self.doc.is_return))[key]
 

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -1166,6 +1166,14 @@ class EWaybillData(GSTTransactionData):
                 ("Delivery Note", 1): (OTHER_GSTIN, REGISTERED_GSTIN),
             }
 
+            if frappe.flags.in_test and self.bill_from.gstin == self.bill_to.gstin:
+                sandbox_gstin.update(
+                    {
+                        ("Delivery Note", 0): (REGISTERED_GSTIN, REGISTERED_GSTIN),
+                        ("Delivery Note", 1): (REGISTERED_GSTIN, REGISTERED_GSTIN),
+                    }
+                )
+
             def _get_sandbox_gstin(address, key):
                 if address.gst_category == "Unregistered":
                     return "URP"

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -1166,7 +1166,7 @@ class EWaybillData(GSTTransactionData):
                 ("Delivery Note", 1): (OTHER_GSTIN, REGISTERED_GSTIN),
             }
 
-            if frappe.flags.in_test and self.bill_from.gstin == self.bill_to.gstin:
+            if self.bill_from.gstin == self.bill_to.gstin:
                 sandbox_gstin.update(
                     {
                         ("Delivery Note", 0): (REGISTERED_GSTIN, REGISTERED_GSTIN),

--- a/india_compliance/gst_india/utils/test_e_waybill.py
+++ b/india_compliance/gst_india/utils/test_e_waybill.py
@@ -28,6 +28,7 @@ from india_compliance.gst_india.utils.tests import (
     append_item,
     create_purchase_invoice,
     create_sales_invoice,
+    create_transaction,
 )
 
 DATETIME_FORMAT = "%d/%m/%Y %I:%M:%S %p"
@@ -648,19 +649,109 @@ class TestEWaybill(FrappeTestCase):
             "You have already generated e-Waybill/e-Invoice for this document. This could result in mismatch of item details in e-Waybill/e-Invoice with print format.",
         )
 
+    @change_settings("GST Settings", {"enable_e_waybill_from_dn": 1})
+    @responses.activate
+    def test_e_waybill_for_dn_with_different_gstin(self):
+        """Test to generate e-waybill for Delivery Note with different GSTIN"""
+        dn_with_different_gstin_data = self.e_waybill_test_data.get(
+            "dn_with_different_gstin"
+        )
+        different_gstin_dn = _create_delivery_note(dn_with_different_gstin_data)
+
+        self._generate_e_waybill(
+            "Delivery Note", different_gstin_dn.name, dn_with_different_gstin_data
+        )
+
+        self.assertDocumentEqual(
+            {
+                "name": dn_with_different_gstin_data.get("response_data")
+                .get("result")
+                .get("ewayBillNo")
+            },
+            frappe.get_doc(
+                "e-Waybill Log", {"reference_name": different_gstin_dn.name}
+            ),
+        )
+
+        #  Return Note
+        is_return_dn_with_different_gstin_data = self.e_waybill_test_data.get(
+            "is_return_dn_with_different_gstin"
+        )
+
+        return_note = make_return_doc("Delivery Note", different_gstin_dn.name).submit()
+
+        self._generate_e_waybill(
+            "Delivery Note", return_note.name, is_return_dn_with_different_gstin_data
+        )
+
+        self.assertDocumentEqual(
+            {
+                "name": is_return_dn_with_different_gstin_data.get("response_data")
+                .get("result")
+                .get("ewayBillNo")
+            },
+            frappe.get_doc("e-Waybill Log", {"reference_name": return_note.name}),
+        )
+
+    @change_settings("GST Settings", {"enable_e_waybill_from_dn": 1})
+    @responses.activate
+    def test_e_waybill_for_dn_with_same_gstin(self):
+        """Test to generate e-waybill for Delivery Note with Same GSTIN"""
+        dn_with_same_gstin_data = self.e_waybill_test_data.get("dn_with_same_gstin")
+        same_gstin_dn = _create_delivery_note(dn_with_same_gstin_data)
+
+        self._generate_e_waybill(
+            "Delivery Note", same_gstin_dn.name, dn_with_same_gstin_data
+        )
+
+        self.assertDocumentEqual(
+            {
+                "name": dn_with_same_gstin_data.get("response_data")
+                .get("result")
+                .get("ewayBillNo")
+            },
+            frappe.get_doc("e-Waybill Log", {"reference_name": same_gstin_dn.name}),
+        )
+
+        # Return Note
+        return_note = make_return_doc("Delivery Note", same_gstin_dn.name)
+        return_note.submit()
+
+        is_return_dn_with_same_gstin_data = self.e_waybill_test_data.get(
+            "is_return_dn_with_same_gstin"
+        )
+
+        self._generate_e_waybill(
+            "Delivery Note", return_note.name, is_return_dn_with_same_gstin_data
+        )
+
+        self.assertDocumentEqual(
+            {
+                "name": is_return_dn_with_same_gstin_data.get("response_data")
+                .get("result")
+                .get("ewayBillNo")
+            },
+            frappe.get_doc("e-Waybill Log", {"reference_name": return_note.name}),
+        )
+
     # helper functions
-    def _generate_e_waybill(self):
+    def _generate_e_waybill(
+        self, doctype="Sales Invoice", docname=None, test_data=None
+    ):
         """Generate e-waybill"""
 
+        if not test_data:
+            test_data = self.e_waybill_test_data.goods_item_with_ewaybill
+
+        if not docname and doctype == "Sales Invoice":
+            docname = self.sales_invoice.name
+
         # Mock POST response for generate_e_waybill
-        e_waybill_with_goods_item = self.e_waybill_test_data.goods_item_with_ewaybill
         self._mock_e_waybill_response(
-            data=e_waybill_with_goods_item.get("response_data"),
+            data=test_data.get("response_data"),
             match_list=[
-                matchers.query_string_matcher(e_waybill_with_goods_item.get("params")),
-                matchers.json_params_matcher(
-                    e_waybill_with_goods_item.get("request_data")
-                ),
+                matchers.query_string_matcher(test_data.get("params")),
+                matchers.json_params_matcher(test_data.get("request_data")),
             ],
         )
 
@@ -678,10 +769,11 @@ class TestEWaybill(FrappeTestCase):
             api="getewaybill",
         )
 
-        generate_e_waybill(
-            doctype="Sales Invoice",
-            docname=self.sales_invoice.name,
+        values = (
+            frappe._dict(test_data.get("values")) if test_data.get("values") else None
         )
+
+        generate_e_waybill(doctype=doctype, docname=docname, values=values)
 
     def _mock_e_waybill_response(self, data, match_list, method="POST", api=None):
         """Mock e-waybill response for given data and match_list"""
@@ -758,6 +850,12 @@ def _create_sales_invoice(test_data):
     si.gst_transporter_id = ""
     si.submit()
     return si
+
+
+def _create_delivery_note(test_data):
+    test_data.get("kwargs").update({"doctype": "Delivery Note"})
+    delivery_note = create_transaction(**test_data.get("kwargs"))
+    return delivery_note
 
 
 def _bulk_insert_hsn_wise_items(hsn_codes):

--- a/india_compliance/tests/test_records.json
+++ b/india_compliance/tests/test_records.json
@@ -370,6 +370,25 @@
             ]
         },
         {
+            "name": "_Test Unregistered Supplier-Billing",
+            "address_type": "Billing",
+            "address_line1": "Test Address - 10",
+            "city": "Test City",
+            "state": "Gujarat",
+            "pincode": "380015",
+            "country": "India",
+            "gstin": "",
+            "gst_category": "Unregistered",
+            "is_primary_address": 1,
+            "is_shipping_address": 1,
+            "links": [
+                {
+                    "link_doctype": "Supplier",
+                    "link_name": "_Test Unregistered Supplier"
+                }
+            ]
+        },
+        {
             "name": "_Test Indian Registered Company-Shipping",
             "address_type": "Shipping",
             "address_line1": "Test Address - 5",


### PR DESCRIPTION
Covered cases for:
1. Delivery Note
    a. DN with Same GSTIN
    b. DN with different GSTIN
    c. Return DN with same GSTIN
    d. Return DN with different GSTIN
2. Purchase Invoice
    a. Validate Bill No for Registered Supplier
    b. e-waybill for Purchase Invoice
    c. e-waybill for Purchase Return
