### PR TITLE
feat: validate supplier invoice no for purchase invoice

### DIFF
--- a/india_compliance/gst_india/doctype/gst_settings/gst_settings.json
+++ b/india_compliance/gst_india/doctype/gst_settings/gst_settings.json
@@ -10,6 +10,7 @@
   "enable_reverse_charge_in_sales",
   "enable_overseas_transactions",
   "round_off_gst_values",
+  "require_supplier_invoice_no",
   "column_break_4",
   "validate_hsn_code",
   "min_hsn_digits",
@@ -322,12 +323,19 @@
    "fieldname": "enable_rcm_for_unregistered_supplier",
    "fieldtype": "Check",
    "label": "Enable Reverse Charge for Purchase from Unregistered Supplier"
+  },
+  {
+   "default": "1",
+   "description": "If checked, Supplier Invoice Number will be mandatory for all purchases (except from unregistered suppliers). This will help ensure smooth purchase reconciliation.",
+   "fieldname": "require_supplier_invoice_no",
+   "fieldtype": "Check",
+   "label": "Require Supplier Invoice Number for GST Purchases"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2023-07-12 16:32:45.185690",
+ "modified": "2023-08-08 12:52:48.713020",
  "modified_by": "Administrator",
  "module": "GST India",
  "name": "GST Settings",

--- a/india_compliance/gst_india/setup/__init__.py
+++ b/india_compliance/gst_india/setup/__init__.py
@@ -145,6 +145,7 @@ def set_default_gst_settings():
     default_settings = {
         "hsn_wise_tax_breakup": 1,
         "enable_reverse_charge_in_sales": 0,
+        "require_supplier_invoice_no": 1,
         "validate_hsn_code": 1,
         "min_hsn_digits": 6,
         "enable_e_waybill": 1,

--- a/india_compliance/gst_india/setup/property_setters.py
+++ b/india_compliance/gst_india/setup/property_setters.py
@@ -34,7 +34,7 @@ def get_property_setters():
             "doctype": "Purchase Invoice",
             "fieldname": "bill_no",
             "property": "mandatory_depends_on",
-            "value": "eval: doc.gst_category !== 'Unregistered' & gst_settings.require_supplier_invoice_no === 1",
+            "value": "eval: doc.gst_category !== 'Unregistered' && gst_settings.require_supplier_invoice_no === 1 && doc.company_gstin",
         },
         {
             "doctype": "Address",

--- a/india_compliance/gst_india/setup/property_setters.py
+++ b/india_compliance/gst_india/setup/property_setters.py
@@ -31,6 +31,12 @@ def get_property_setters():
             prepend=False,
         ),
         {
+            "doctype": "Purchase Invoice",
+            "fieldname": "bill_no",
+            "property": "mandatory_depends_on",
+            "value": "eval: doc.gst_category !== 'Unregistered' & gst_settings.require_supplier_invoice_no === 1",
+        },
+        {
             "doctype": "Address",
             "fieldname": "state",
             "property": "fieldtype",

--- a/india_compliance/gst_india/utils/test_e_waybill.py
+++ b/india_compliance/gst_india/utils/test_e_waybill.py
@@ -770,6 +770,8 @@ class TestEWaybill(FrappeTestCase):
             **purchase_invoice_data.get("kwargs"), do_not_submit=True
         )
 
+        purchase_invoice.bill_no = ""
+
         # Bill No Validation
         self.assertRaisesRegex(
             frappe.exceptions.ValidationError,

--- a/india_compliance/gst_india/utils/tests.py
+++ b/india_compliance/gst_india/utils/tests.py
@@ -11,6 +11,10 @@ def create_sales_invoice(**data):
 
 def create_purchase_invoice(**data):
     data["doctype"] = "Purchase Invoice"
+
+    if "bill_no" not in data:
+        data["bill_no"] = frappe.generate_hash(length=5)
+
     return create_transaction(**data)
 
 
@@ -48,9 +52,6 @@ def create_transaction(**data):
             and not transaction.eligibility_for_itc
         ):
             transaction.eligibility_for_itc = "All Other ITC"
-
-        if "bill_no" not in data:
-            transaction.bill_no = frappe.generate_hash(length=5)
 
     if transaction.doctype == "POS Invoice":
         transaction.append(

--- a/india_compliance/gst_india/utils/tests.py
+++ b/india_compliance/gst_india/utils/tests.py
@@ -49,6 +49,9 @@ def create_transaction(**data):
         ):
             transaction.eligibility_for_itc = "All Other ITC"
 
+        if "bill_no" not in data:
+            transaction.bill_no = frappe.generate_hash(length=5)
+
     if transaction.doctype == "POS Invoice":
         transaction.append(
             "payments",

--- a/india_compliance/patches.txt
+++ b/india_compliance/patches.txt
@@ -4,7 +4,7 @@ execute:import frappe; frappe.delete_doc_if_exists("DocType", "GSTIN")
 [post_model_sync]
 india_compliance.patches.v14.set_default_for_overridden_accounts_setting
 execute:from india_compliance.gst_india.setup import create_custom_fields; create_custom_fields() #22
-execute:from india_compliance.gst_india.setup import create_property_setters; create_property_setters() #2
+execute:from india_compliance.gst_india.setup import create_property_setters; create_property_setters() #3
 india_compliance.patches.post_install.remove_old_fields
 india_compliance.patches.post_install.update_company_gstin
 india_compliance.patches.post_install.update_custom_role_for_e_invoice_summary


### PR DESCRIPTION
- Bill number should be part of purchase invoice where user want to claim credit for the invoice. 
- Its encouraged to maintain the same as it would be help distinguish invoices and would simplify the reconciliation with 2A/2B.
- Added settings to make bill no mandatory for purchase invoice.

![image](https://github.com/resilient-tech/india-compliance/assets/108322669/49add3ed-6539-4dc0-8353-04800b64564d)


Closes: #157 