### PR TITLE
fix: move updated taxes in item to long queue

### DIFF
--- a/india_compliance/gst_india/doctype/bill_of_entry/bill_of_entry.py
+++ b/india_compliance/gst_india/doctype/bill_of_entry/bill_of_entry.py
@@ -18,7 +18,9 @@ from india_compliance.gst_india.utils import get_gst_accounts_by_type
 
 class BillofEntry(Document):
     get_gl_dict = AccountsController.get_gl_dict
-    get_value_in_transaction_currency = AccountsController.get_value_in_transaction_currency
+    get_value_in_transaction_currency = (
+        AccountsController.get_value_in_transaction_currency
+    )
 
     def onload(self):
         if self.docstatus != 1:

--- a/india_compliance/gst_india/doctype/gst_hsn_code/gst_hsn_code.py
+++ b/india_compliance/gst_india/doctype/gst_hsn_code/gst_hsn_code.py
@@ -18,7 +18,7 @@ class GSTHSNCode(Document):
 
 @frappe.whitelist()
 def update_taxes_in_item_master(taxes, hsn_code):
-    frappe.enqueue(update_item_document, taxes=taxes, hsn_code=hsn_code)
+    frappe.enqueue(update_item_document, taxes=taxes, hsn_code=hsn_code, queue="long")
     return 1
 
 


### PR DESCRIPTION
- There could be many items that need an update.
- This will increase the timeout and move it to a long queue.
- Fixes support issue https://support.frappe.io/app/hd-ticket/468
