### PR TITLE
fix(ux): don't copy transporter fields in Deliver Note and Sales Invoice

### DIFF
--- a/india_compliance/gst_india/constants/custom_fields.py
+++ b/india_compliance/gst_india/constants/custom_fields.py
@@ -701,6 +701,7 @@ E_WAYBILL_DN_FIELDS = [
         "fieldtype": "Int",
         "insert_after": "vehicle_no",
         "print_hide": 1,
+        "no_copy": 1,
         "description": (
             "Set as zero to update distance as per the e-Waybill portal (if available)"
         ),
@@ -712,6 +713,7 @@ E_WAYBILL_DN_FIELDS = [
         "insert_after": "transporter",
         "fetch_from": "transporter.gst_transporter_id",
         "print_hide": 1,
+        "no_copy": 1,
         "translatable": 0,
     },
     {
@@ -722,6 +724,7 @@ E_WAYBILL_DN_FIELDS = [
         "default": "Road",
         "insert_after": "transporter_name",
         "print_hide": 1,
+        "no_copy": 1,
         "translatable": 0,
     },
     {
@@ -734,6 +737,7 @@ E_WAYBILL_DN_FIELDS = [
         "default": "Regular",
         "insert_after": "lr_date",
         "print_hide": 1,
+        "no_copy": 1,
         "translatable": 0,
     },
 ]
@@ -755,6 +759,7 @@ E_WAYBILL_INV_FIELDS = [
         "insert_after": "transporter_info",
         "options": "Supplier",
         "print_hide": 1,
+        "no_copy": 1,
     },
     {
         "fieldname": "driver",
@@ -763,6 +768,7 @@ E_WAYBILL_INV_FIELDS = [
         "insert_after": "gst_transporter_id",
         "options": "Driver",
         "print_hide": 1,
+        "no_copy": 1,
     },
     {
         "fieldname": "lr_no",
@@ -770,6 +776,7 @@ E_WAYBILL_INV_FIELDS = [
         "fieldtype": "Data",
         "insert_after": "driver",
         "print_hide": 1,
+        "no_copy": 1,
         "translatable": 0,
         "length": 30,
     },
@@ -779,6 +786,7 @@ E_WAYBILL_INV_FIELDS = [
         "fieldtype": "Data",
         "insert_after": "lr_no",
         "print_hide": 1,
+        "no_copy": 1,
         "translatable": 0,
         "length": 15,
     },
@@ -795,6 +803,7 @@ E_WAYBILL_INV_FIELDS = [
         "fetch_from": "transporter.supplier_name",
         "read_only": 1,
         "print_hide": 1,
+        "no_copy": 1,
         "translatable": 0,
     },
     {
@@ -804,6 +813,7 @@ E_WAYBILL_INV_FIELDS = [
         "insert_after": "mode_of_transport",
         "fetch_from": "driver.full_name",
         "print_hide": 1,
+        "no_copy": 1,
         "translatable": 0,
     },
     {
@@ -813,6 +823,7 @@ E_WAYBILL_INV_FIELDS = [
         "insert_after": "driver_name",
         "default": "Today",
         "print_hide": 1,
+        "no_copy": 1,
     },
     *E_WAYBILL_DN_FIELDS,
 ]

--- a/india_compliance/patches.txt
+++ b/india_compliance/patches.txt
@@ -3,7 +3,7 @@ execute:import frappe; frappe.delete_doc_if_exists("DocType", "GSTIN")
 
 [post_model_sync]
 india_compliance.patches.v14.set_default_for_overridden_accounts_setting
-execute:from india_compliance.gst_india.setup import create_custom_fields; create_custom_fields() #28
+execute:from india_compliance.gst_india.setup import create_custom_fields; create_custom_fields() #29
 execute:from india_compliance.gst_india.setup import create_property_setters; create_property_setters() #3
 india_compliance.patches.post_install.remove_old_fields
 india_compliance.patches.post_install.update_company_gstin


### PR DESCRIPTION
closes: #1062 

Usually Sales Invoice is hardly copied in usual scenarios:

### Copy use cases
- Dev UX
- Same Customer and Same Item and no Sales Order or Delivery Note flow.

In other cases copy doesn't make sense.

### Issue Fixed
Transporter fields are copied to Sales Invoice if Credit Note is created from the same