### PR TITLE
fix: set default eligibility for ITC  in Purchase Invoice

### DIFF
--- a/india_compliance/gst_india/overrides/purchase_invoice.py
+++ b/india_compliance/gst_india/overrides/purchase_invoice.py
@@ -69,6 +69,10 @@ def is_b2b_invoice(doc):
 
 
 def update_itc_totals(doc, method=None):
+    # Set default value
+    if not doc.eligibility_for_itc:
+        doc.eligibility_for_itc = "All Other ITC"
+
     # Initialize values
     doc.itc_integrated_tax = 0
     doc.itc_state_tax = 0

--- a/india_compliance/gst_india/report/gstr_3b_details/gstr_3b_details.py
+++ b/india_compliance/gst_india/report/gstr_3b_details/gstr_3b_details.py
@@ -5,7 +5,7 @@ import frappe
 from frappe import _
 from frappe.query_builder import Case
 from frappe.query_builder.custom import ConstantColumn
-from frappe.query_builder.functions import LiteralValue, Sum
+from frappe.query_builder.functions import Ifnull, LiteralValue, Sum
 from frappe.utils import cint, get_first_day, get_last_day
 
 from india_compliance.gst_india.utils import get_gst_accounts_by_type
@@ -142,6 +142,7 @@ class GSTR3B_ITC_Details(BaseGSTR3BDetails):
                 & (purchase_invoice.posting_date[self.from_date : self.to_date])
                 & (purchase_invoice.company == self.company)
                 & (purchase_invoice.company_gstin == self.company_gstin)
+                & (Ifnull(purchase_invoice.eligibility_for_itc, "") != "")
             )
             .groupby(purchase_invoice.name)
         )


### PR DESCRIPTION
- Set default Eligibility for ITC if not set.
- In GSTR-3B include only invoices where eligibility for ITC is set.