### PR TITLE
fix: `get_taxes_summary` return empty dict if no ref

### DIFF
--- a/india_compliance/gst_india/overrides/payment_entry.py
+++ b/india_compliance/gst_india/overrides/payment_entry.py
@@ -291,6 +291,9 @@ def get_taxes_summary(company, payment_entries):
         if advance.reference_type == "Payment Entry"
     ]
 
+    if not references:
+        return {}
+
     gl_entry = frappe.qb.DocType("GL Entry")
     pe = frappe.qb.DocType("Payment Entry")
     taxes = (


### PR DESCRIPTION
Payment Reconciliation of a JV and Invoice throws SQL error due to empty `references`.