### PR TITLE
fix(ux): copy e-waybill fields from DN to SI

### DIFF
--- a/india_compliance/gst_india/overrides/test_transaction.py
+++ b/india_compliance/gst_india/overrides/test_transaction.py
@@ -4,6 +4,8 @@ from parameterized import parameterized_class
 
 import frappe
 from frappe.tests.utils import FrappeTestCase
+from erpnext.accounts.doctype.sales_invoice.sales_invoice import make_sales_return
+from erpnext.stock.doctype.delivery_note.delivery_note import make_sales_invoice
 
 from india_compliance.gst_india.constants import SALES_DOCTYPES
 from india_compliance.gst_india.overrides.transaction import DOCTYPES_WITH_TAXABLE_VALUE
@@ -631,3 +633,19 @@ def get_lead(first_name):
     lead.insert(ignore_permissions=True)
 
     return lead.name
+
+
+class TestSpecificTransactions(FrappeTestCase):
+    def test_copy_e_waybill_fields_from_dn_to_si(self):
+        "Make sure e-Waybill fields are copied from Delivery Note to Sales Invoice"
+        dn = create_transaction(doctype="Delivery Note", vehicle_no="GJ01AA1111")
+        si = make_sales_invoice(dn.name)
+
+        self.assertEqual(si.vehicle_no, dn.vehicle_no)
+
+    def test_copy_e_waybill_fields_from_si_to_return(self):
+        "Make sure e-Waybill fields are not copied from Sales Invoice to Sales Returns"
+        si = create_transaction(doctype="Sales Invoice", vehicle_no="GJ01AA1111")
+        si_return = make_sales_return(si.name)
+
+        self.assertEqual(si_return.vehicle_no, None)

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -10,6 +10,7 @@ from erpnext.controllers.taxes_and_totals import (
 )
 
 from india_compliance.gst_india.constants import SALES_DOCTYPES, STATE_NUMBERS
+from india_compliance.gst_india.constants.custom_fields import E_WAYBILL_INV_FIELDS
 from india_compliance.gst_india.doctype.gstin.gstin import (
     _validate_gstin_info,
     get_gstin_status,
@@ -979,6 +980,19 @@ def validate_transaction(doc, method=None):
 
 def before_validate(doc, method=None):
     set_reverse_charge_as_per_gst_settings(doc)
+
+
+def after_mapping(target_doc, method=None, source_doc=None):
+    # Copy e-Waybill fields only from DN to SI
+    if not source_doc or source_doc.doctype not in (
+        "Delivery Note",
+        "Purchase Receipt",
+    ):
+        return
+
+    for field in E_WAYBILL_INV_FIELDS:
+        fieldname = field.get("fieldname")
+        target_doc.set(fieldname, source_doc.get(fieldname))
 
 
 def ignore_gst_validations(doc):

--- a/india_compliance/hooks.py
+++ b/india_compliance/hooks.py
@@ -120,6 +120,7 @@ doc_events = {
         "before_submit": "india_compliance.gst_india.overrides.ineligible_itc.update_valuation_rate",
         "before_gl_preview": "india_compliance.gst_india.overrides.ineligible_itc.update_valuation_rate",
         "before_sl_preview": "india_compliance.gst_india.overrides.ineligible_itc.update_valuation_rate",
+        "after_mapping": "india_compliance.gst_india.overrides.transaction.after_mapping",
     },
     "Purchase Order": {
         "validate": (
@@ -148,6 +149,7 @@ doc_events = {
             "india_compliance.gst_india.overrides.sales_invoice.on_update_after_submit"
         ),
         "before_cancel": "india_compliance.gst_india.overrides.sales_invoice.before_cancel",
+        "after_mapping": "india_compliance.gst_india.overrides.transaction.after_mapping",
     },
     "Sales Order": {
         "validate": (

--- a/india_compliance/patches/check_version_compatibility.py
+++ b/india_compliance/patches/check_version_compatibility.py
@@ -13,7 +13,7 @@ VERSIONS_TO_COMPARE = [
     {
         "app_name": "Frappe",
         "current_version": version.parse(frappe.__version__),
-        "required_versions": {"version-14": "14.55.2", "version-15": "15.2.0"},
+        "required_versions": {"version-14": "14.57.0", "version-15": "15.3.0"},
     },
     {
         "app_name": "ERPNext",


### PR DESCRIPTION
## Issue

- Use `no_copy` for e-Waybill fields to ensure they don't copy on duplicate or create credit notes from sales invoices.
- However, because of this, fields were not being copied from Delivery Note to Sales Invoice.

closes: #1271

- [x] Update Dependency of frappe after release
