### PR TITLE
perf: always call `parse_json`

### DIFF
--- a/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.py
+++ b/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.py
@@ -30,6 +30,13 @@ from india_compliance.gst_india.utils.gstr import (
     save_gstr_2b,
 )
 
+STATUS_MAP = {
+    "Accept My Values": "Reconciled",
+    "Accept Supplier Values": "Reconciled",
+    "Pending": "Unreconciled",
+    "Ignore": "Ignored",
+}
+
 
 class PurchaseReconciliationTool(Document):
     def __init__(self, *args, **kwargs):
@@ -263,9 +270,7 @@ class PurchaseReconciliationTool(Document):
     def unlink_documents(self, data):
         frappe.has_permission("Purchase Reconciliation Tool", "write", throw=True)
 
-        if isinstance(data, str):
-            data = frappe.parse_json(data)
-
+        data = frappe.parse_json(data)
         inward_supplies = set()
         purchases = set()
         boe = set()
@@ -323,16 +328,7 @@ class PurchaseReconciliationTool(Document):
     def apply_action(self, data, action):
         frappe.has_permission("Purchase Reconciliation Tool", "write", throw=True)
 
-        if isinstance(data, str):
-            data = frappe.parse_json(data)
-
-        STATUS_MAP = {
-            "Accept My Values": "Reconciled",
-            "Accept Supplier Values": "Reconciled",
-            "Pending": "Unreconciled",
-            "Ignore": "Ignored",
-        }
-
+        data = frappe.parse_json(data)
         status = STATUS_MAP.get(action)
 
         inward_supplies = []
@@ -507,7 +503,7 @@ def download_excel_report(data, doc, is_supplier_specific=False):
 
 def parse_params(fun):
     def wrapper(*args, **kwargs):
-        args = [frappe.parse_json(arg) for arg in args]
+        args = (frappe.parse_json(arg) for arg in args)
         kwargs = {k: frappe.parse_json(v) for k, v in kwargs.items()}
         return fun(*args, **kwargs)
 

--- a/india_compliance/gst_india/overrides/payment_entry.py
+++ b/india_compliance/gst_india/overrides/payment_entry.py
@@ -95,8 +95,7 @@ def on_update_after_submit(doc, method=None):
 
 @frappe.whitelist()
 def update_party_details(party_details, doctype, company):
-    if isinstance(party_details, str):
-        party_details = frappe.parse_json(party_details)
+    party_details = frappe.parse_json(party_details)
 
     address = get_default_address("Customer", party_details.get("customer"))
     party_details.update(customer_address=address)

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -659,10 +659,7 @@ def get_gst_details(party_details, doctype, company, *, update_place_of_supply=F
     """
 
     is_sales_transaction = doctype in SALES_DOCTYPES or doctype == "Payment Entry"
-
-    if isinstance(party_details, str):
-        party_details = frappe.parse_json(party_details)
-
+    party_details = frappe.parse_json(party_details)
     gst_details = frappe._dict()
 
     party_address_field = (


### PR DESCRIPTION
- no need for `isinstance`, `parse_json` already does it
- move constant to global namespace
- avoid creating list just for unpacking, use generator expression instead