### PR TITLE
fix: asset WDV depreciation calc according to IT act [dev]

### DIFF
--- a/india_compliance/hooks.py
+++ b/india_compliance/hooks.py
@@ -232,8 +232,11 @@ regional_overrides = {
         "erpnext.accounts.party.get_regional_address_details": (
             "india_compliance.gst_india.overrides.transaction.update_party_details"
         ),
-        "erpnext.assets.doctype.asset_depreciation_schedule.asset_depreciation_schedule.get_updated_rate_of_depreciation_for_wdv_and_dd": (
-            "india_compliance.income_tax_india.overrides.asset_depreciation_schedule.get_updated_rate_of_depreciation_for_wdv_and_dd"
+        "erpnext.assets.doctype.asset_depreciation_schedule.asset_depreciation_schedule.get_wdv_or_dd_depr_amount": (
+            "india_compliance.income_tax_india.overrides.asset_depreciation_schedule.get_wdv_or_dd_depr_amount"
+        ),
+        "erpnext.assets.doctype.asset.depreciation.cancel_depreciation_entries": (
+            "india_compliance.income_tax_india.overrides.asset_depreciation_schedule.cancel_depreciation_entries"
         ),
     }
 }

--- a/india_compliance/income_tax_india/constants/custom_fields.py
+++ b/india_compliance/income_tax_india/constants/custom_fields.py
@@ -20,7 +20,7 @@ CUSTOM_FIELDS = {
             "fieldtype": "Check",
             "insert_after": "finance_book_name",
             "description": (
-                "If the asset is put to use for less than 180 days, the first"
+                "If the asset is put to use for less than 180 days in the first year, the first year's"
                 " Depreciation Rate will be reduced by 50%."
             ),
         }

--- a/india_compliance/income_tax_india/overrides/asset_depreciation_schedule.py
+++ b/india_compliance/income_tax_india/overrides/asset_depreciation_schedule.py
@@ -1,29 +1,132 @@
 import frappe
 from frappe import _
-from frappe.utils import date_diff
+from frappe.utils import (
+    add_days,
+    add_months,
+    cint,
+    date_diff,
+    flt,
+    get_last_day,
+    getdate,
+    is_last_day_of_the_month,
+)
+from erpnext.accounts.utils import get_fiscal_year
+from erpnext.assets.doctype.asset_depreciation_schedule.asset_depreciation_schedule import (
+    get_asset_depr_schedule_doc,
+    get_default_wdv_or_dd_depr_amount,
+)
 
 
-def get_updated_rate_of_depreciation_for_wdv_and_dd(
-    asset, depreciable_value, fb_row, show_msg=True
+def get_wdv_or_dd_depr_amount(
+    asset,
+    fb_row,
+    depreciable_value,
+    schedule_idx,
+    prev_depreciation_amount,
+    has_wdv_or_dd_non_yearly_pro_rata,
+    asset_depr_schedule,
 ):
-    rate_of_depreciation = fb_row.rate_of_depreciation
-    # if its the first depreciation
-    if depreciable_value == asset.gross_purchase_amount:
-        if fb_row.finance_book and frappe.db.get_value(
-            "Finance Book", fb_row.finance_book, "for_income_tax"
-        ):
-            # as per IT act, if the asset is purchased in the 2nd half of fiscal year, then rate is divided by 2
-            diff = date_diff(
-                fb_row.depreciation_start_date, asset.available_for_use_date
-            )
-            if diff <= 180:
-                rate_of_depreciation = rate_of_depreciation / 2
-                if show_msg:
-                    frappe.msgprint(
-                        _(
-                            "As per IT Act, the rate of depreciation for the first"
-                            " depreciation entry is reduced by 50%."
-                        )
-                    )
+    # As per IT act, if the asset is purchased in the 2nd half of fiscal year, then rate is divided by 2 for the first year
 
-    return rate_of_depreciation
+    if not fb_row.finance_book or not frappe.db.get_value(
+        "Finance Book", fb_row.finance_book, "for_income_tax"
+    ):
+        return get_default_wdv_or_dd_depr_amount(
+            asset,
+            fb_row,
+            depreciable_value,
+            schedule_idx,
+            prev_depreciation_amount,
+            has_wdv_or_dd_non_yearly_pro_rata,
+        )
+
+    if not fb_row.daily_prorata_based:
+        frappe.throw(
+            _(
+                "Please tick the 'Depreciate based on daily pro-rata' checkbox in the finance book row"
+            )
+        )
+
+    asset_depr_schedule.flags.wdv_it_act_applied = True
+
+    rate_of_depreciation = fb_row.rate_of_depreciation
+
+    start_date_of_next_fiscal_year = add_days(
+        get_fiscal_year(asset.available_for_use_date)[2], 1
+    )
+
+    num_days_asset_used_in_fiscal_year = date_diff(
+        start_date_of_next_fiscal_year, asset.available_for_use_date
+    )
+    if num_days_asset_used_in_fiscal_year <= 180:
+        rate_of_depreciation = rate_of_depreciation / 2
+
+    is_last_day = is_last_day_of_the_month(fb_row.depreciation_start_date)
+
+    schedule_date = add_months(
+        fb_row.depreciation_start_date,
+        schedule_idx * cint(fb_row.frequency_of_depreciation),
+    )
+    if is_last_day:
+        schedule_date = get_last_day(schedule_date)
+
+    previous_schedule_date = add_months(
+        schedule_date, -1 * cint(fb_row.frequency_of_depreciation)
+    )
+    if is_last_day:
+        previous_schedule_date = get_last_day(previous_schedule_date)
+
+    if fb_row.frequency_of_depreciation == 12:
+        if schedule_date < start_date_of_next_fiscal_year:
+            return flt(asset.gross_purchase_amount) * (flt(rate_of_depreciation) / 100)
+        else:
+            return (
+                flt(depreciable_value)
+                * (flt(fb_row.rate_of_depreciation) / 100)
+                * (date_diff(schedule_date, previous_schedule_date) / 365)
+            )
+    elif fb_row.frequency_of_depreciation == 1:
+        if schedule_date < start_date_of_next_fiscal_year:
+            return (
+                flt(asset.gross_purchase_amount)
+                * (flt(rate_of_depreciation) / 100)
+                * (
+                    date_diff(schedule_date, previous_schedule_date)
+                    / num_days_asset_used_in_fiscal_year
+                )
+            )
+        else:
+            return (
+                flt(depreciable_value)
+                * (flt(fb_row.rate_of_depreciation) / 100)
+                * (date_diff(schedule_date, previous_schedule_date) / 365)
+            )
+    else:
+        frappe.throw(_("Only monthly and yearly depreciations allowed yet."))
+
+
+def cancel_depreciation_entries(asset_doc, date):
+    # Once the asset is sold during the current year, depreciation booked during the year of sale has to be cancelled as per Income Tax Act
+
+    start_date_of_fiscal_year = get_fiscal_year(date)[1]
+
+    fb_for_income_tax_map = dict(
+        frappe.db.get_all("Finance Book", ["name", "for_income_tax"], as_list=True)
+    )
+
+    for row in asset_doc.get("finance_books"):
+        if not row.finance_book:
+            return
+
+        if not fb_for_income_tax_map[row.finance_book]:
+            continue
+
+        asset_depr_schedule_doc = get_asset_depr_schedule_doc(
+            asset_doc.name, "Active", row.finance_book
+        )
+
+        for d in asset_depr_schedule_doc.get("depreciation_schedule"):
+            if getdate(d.schedule_date) < getdate(start_date_of_fiscal_year):
+                continue
+
+            frappe.get_doc("Journal Entry", d.journal_entry).cancel()


### PR DESCRIPTION
First year depreciation for WDV method as per Income Tax act wasn't being calculated properly. Now the depreciation calculations in ERPNext match these [calculations](https://docs.google.com/spreadsheets/d/1zD33bA5kyNmrajNpMxVmMao5eio0a09B/edit?usp=sharing&ouid=105035438770380117661&rtpof=true&sd=true) provided by a customer.

Needs to be merged with: https://github.com/frappe/erpnext/pull/39052.