### PR TITLE
fix: simplify residual match for more inclusive matches

### DIFF
--- a/india_compliance/gst_india/doctype/purchase_reconciliation_tool/__init__.py
+++ b/india_compliance/gst_india/doctype/purchase_reconciliation_tool/__init__.py
@@ -757,9 +757,9 @@ class Reconciler(BaseReconciliation):
         # PAN Level matching
         purchases = self.get_pan_level_data(purchases)
         inward_supplies = self.get_pan_level_data(inward_supplies)
-        self.reconcile_for_rules(PAN_RULES, purchases, inward_supplies, category)
+        self.reconcile_for_rules(PAN_RULES, purchases, inward_supplies)
 
-    def reconcile_for_rules(self, rules, purchases, inward_supplies, category):
+    def reconcile_for_rules(self, rules, purchases, inward_supplies):
         if not (purchases and inward_supplies):
             return
 
@@ -769,12 +769,9 @@ class Reconciler(BaseReconciliation):
                 inward_supplies,
                 rule.get("match_status").value,
                 rule.get("rule"),
-                category,
             )
 
-    def reconcile_for_rule(
-        self, purchases, inward_supplies, match_status, rules, category
-    ):
+    def reconcile_for_rule(self, purchases, inward_supplies, match_status, rules):
         """
         Sequentially reconcile invoices as per rules list.
         - Reconciliation only done between invoices of same GSTIN.
@@ -785,28 +782,18 @@ class Reconciler(BaseReconciliation):
             if not inward_supplies.get(supplier_gstin):
                 continue
 
-            summary_diff = {}
-            if match_status == "Residual Match" and category != "CDNR":
-                summary_diff = self.get_summary_difference(
-                    purchases[supplier_gstin], inward_supplies[supplier_gstin]
-                )
-
             for purchase_invoice_name, purchase in (
                 purchases[supplier_gstin].copy().items()
             ):
-                if summary_diff and not (
-                    abs(summary_diff[purchase.bill_date.month]) < 2
-                ):
-                    continue
-
                 for inward_supply_name, inward_supply in (
                     inward_supplies[supplier_gstin].copy().items()
                 ):
-                    if (
-                        summary_diff
-                        and purchase.bill_date.month != inward_supply.bill_date.month
-                    ):
-                        continue
+                    if match_status == "Residual Match":
+                        if (
+                            abs((purchase.bill_date - inward_supply.bill_date).days)
+                            > 10
+                        ):
+                            continue
 
                     if not self.is_doc_matching(purchase, inward_supply, rules):
                         continue
@@ -822,26 +809,6 @@ class Reconciler(BaseReconciliation):
                     purchases[supplier_gstin].pop(purchase_invoice_name)
                     inward_supplies[supplier_gstin].pop(inward_supply_name)
                     break
-
-    def get_summary_difference(self, data1, data2):
-        """
-        Returns dict with difference of monthly purchase for given supplier data.
-        Calculated only for Residual Match.
-
-        Objective: Residual match is to match Invoices where bill no is completely different.
-                    It should be matched for invoices of a given month only if difference in total invoice
-                    value is negligible for purchase and inward supply.
-        """
-        summary = {}
-        for doc in data1.values():
-            summary.setdefault(doc.bill_date.month, 0)
-            summary[doc.bill_date.month] += BaseUtil.get_total_tax(doc)
-
-        for doc in data2.values():
-            summary.setdefault(doc.bill_date.month, 0)
-            summary[doc.bill_date.month] -= BaseUtil.get_total_tax(doc)
-
-        return summary
 
     def is_doc_matching(self, purchase, inward_supply, rules):
         """


### PR DESCRIPTION
- Simplify Residual Match. Matching only based on invoice values should be enough within a range of days.
- For PAN Matching CGST/IGST Values may never match, because of Inter vs Intra State. Match Total GST Values Instead.
- Better algo to update cess for purchases.

![image](https://github.com/resilient-tech/india-compliance/assets/10496564/85ded33e-a609-4366-b68b-0eda0a0c22cf)
