### PR TITLE
fix: handle missing item_wise_tax_detail in charge type validation

### DIFF
--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -312,7 +312,7 @@ def validate_gst_accounts(doc, is_sales_transaction=False):
         account_head = row.account_head
 
         if row.charge_type == "Actual":
-            item_tax_detail = frappe.parse_json(row.item_wise_tax_detail)
+            item_tax_detail = frappe.parse_json(row.get("item_wise_tax_detail") or {})
             for tax_rate, tax_amount in item_tax_detail.values():
                 if tax_amount and not tax_rate:
                     _throw(


### PR DESCRIPTION
Payment entry doctype doesn't have `item_wise_tax_details`