### PR TITLE
fix: avoid setting invalid place of supply

### DIFF
--- a/india_compliance/gst_india/utils/__init__.py
+++ b/india_compliance/gst_india/utils/__init__.py
@@ -405,7 +405,8 @@ def get_place_of_supply(party_details, doctype):
                 party_details.customer_address,
                 ("gst_state_number", "gst_state"),
             )
-            return f"{gst_state_number}-{gst_state}"
+            if gst_state_number and gst_state:
+                return f"{gst_state_number}-{gst_state}"
 
         party_gstin = party_details.billing_address_gstin or party_details.company_gstin
     else:


### PR DESCRIPTION
If gst-state_number and gst_state isn't set in address then place of supply is set to invalid value "None-".

Use case: Integrations, refer https://support.frappe.io/helpdesk/tickets/9048
