### PR TITLE
fix : Preferred Address checkbox added in quick entry of Customer and Address DocType

### DIFF
--- a/india_compliance/gst_india/overrides/party.py
+++ b/india_compliance/gst_india/overrides/party.py
@@ -132,7 +132,6 @@ def create_primary_address(doc, method=None):
 
     ERPNext uses `address_line1` so we use `_address_line1` to avoid conflict.
     """
-
     if not doc.get("_address_line1"):
         return
 
@@ -157,5 +156,7 @@ def make_address(doc):
             "gstin": doc.gstin,
             "gst_category": doc.gst_category,
             "links": [{"link_doctype": doc.doctype, "link_name": doc.name}],
+            "is_primary_address": doc.get("is_primary_address"),
+            "is_shipping_address": doc.get("is_shipping_address"),
         }
     ).insert()

--- a/india_compliance/public/js/quick_entry.js
+++ b/india_compliance/public/js/quick_entry.js
@@ -24,13 +24,22 @@ class GSTQuickEntryForm extends frappe.ui.form.QuickEntryForm {
                 fieldtype: "Section Break",
                 description: this.api_enabled
                     ? __(
-                          `When you enter a GSTIN, the permanent address linked to it is
+                        `When you enter a GSTIN, the permanent address linked to it is
                         autofilled.<br>
                         Change the {0} to autofill other addresses.`,
-                          [frappe.meta.get_label("Address", "pincode")]
-                      )
+                        [frappe.meta.get_label("Address", "pincode")]
+                    )
                     : "",
                 collapsible: 0,
+            },
+
+            // check boxes for Preferred Address
+
+            {
+                fieldname: "is_primary_address",
+                label: "Preferred Billing Address",
+                fieldtype: "Check",
+                default: 0,
             },
             {
                 // set as _pincode so that frappe.ui.form.Layout doesn't override it
@@ -50,6 +59,12 @@ class GSTQuickEntryForm extends frappe.ui.form.QuickEntryForm {
                 fieldtype: "Column Break",
             },
             {
+                fieldname: "is_shipping_address",
+                label: "Preferred Shipping Address",
+                fieldtype: "Check",
+                default: 0,
+            },
+            {
                 fieldname: "city",
                 fieldtype: "Data",
             },
@@ -67,6 +82,7 @@ class GSTQuickEntryForm extends frappe.ui.form.QuickEntryForm {
                     india_compliance.set_state_options(this.dialog);
                 },
             },
+
         ];
     }
 
@@ -163,6 +179,7 @@ class PartyQuickEntryForm extends GSTQuickEntryForm {
 
     update_doc() {
         const doc = super.update_doc();
+
         // to prevent clash with ERPNext
         doc._address_line1 = doc.address_line1;
         delete doc.address_line1;
@@ -268,6 +285,7 @@ class AddressQuickEntryForm extends GSTQuickEntryForm {
 
     update_doc() {
         const doc = super.update_doc();
+
         if (doc.link_doctype && doc.link_name) {
             const link = frappe.model.add_child(doc, "Dynamic Link", "links");
             link.link_doctype = doc.link_doctype;

--- a/india_compliance/public/js/quick_entry.js
+++ b/india_compliance/public/js/quick_entry.js
@@ -32,9 +32,6 @@ class GSTQuickEntryForm extends frappe.ui.form.QuickEntryForm {
                     : "",
                 collapsible: 0,
             },
-
-            // check boxes for Preferred Address
-
             {
                 fieldname: "is_primary_address",
                 label: "Preferred Billing Address",
@@ -82,7 +79,6 @@ class GSTQuickEntryForm extends frappe.ui.form.QuickEntryForm {
                     india_compliance.set_state_options(this.dialog);
                 },
             },
-
         ];
     }
 


### PR DESCRIPTION
## WORK 

Added **Preferred address** checkbox in quick entry form of `Customer` and `Address` DocType.


## RESULT 

```diff
- BEFORE
```

![before](https://github.com/resilient-tech/india-compliance/assets/99460106/1ba1f35f-a5bf-4326-b896-a019daa56ea6)



```diff
+ AFTER
```

![after](https://github.com/resilient-tech/india-compliance/assets/99460106/8cfe542d-8501-41c6-8d96-fd3ce1fbd69c)
