### PR TITLE
fix: remove gstin fields for non-indian countries in setup wizard

### DIFF
--- a/india_compliance/public/js/setup_wizard.js
+++ b/india_compliance/public/js/setup_wizard.js
@@ -10,9 +10,7 @@ frappe.setup.on("before_load", function () {
     first_slide.onload = function (slide) {
         _onload.call(this, slide);
 
-        const country_input = frappe.wizard
-            ? frappe.wizard.slide_dict[0].get_input("country")
-            : null;
+        const country_input = frappe.wizard?.slide_dict[0].get_input("country");
         if (country_input) {
             country_input.on("change", event => {
                 toggle_india_specific_fields(event.target.value);
@@ -22,7 +20,6 @@ frappe.setup.on("before_load", function () {
 });
 
 function toggle_india_specific_fields(country) {
-    console.log(country);
     if (!country) return;
 
     const india_specific_fields = [
@@ -30,14 +27,16 @@ function toggle_india_specific_fields(country) {
         "default_gst_rate",
         "enable_audit_trail",
     ];
-    const value = country && country.toLowerCase() !== "india" ? 1 : 0;
-    const slide = frappe.wizard.slide_dict[2];
 
-    slide?.form?.fields_list?.map(fieldobj => {
-        if (india_specific_fields.includes(fieldobj.df.fieldname)) {
-            fieldobj.df.hidden = value;
-            fieldobj.refresh();
-        }
+    const hide_field = country && country.toLowerCase() !== "india" ? 1 : 0;
+
+    Object.values(frappe.wizard.slide_dict || {}).forEach(slide => {
+        slide.form?.fields_list?.forEach(fieldobj => {
+            if (india_specific_fields.includes(fieldobj.df.fieldname)) {
+                fieldobj.df.hidden = hide_field;
+                fieldobj.refresh();
+            }
+        });
     });
 }
 
@@ -96,7 +95,7 @@ function update_erpnext_slides_settings() {
 
         toggle_india_specific_fields(frappe.wizard.values.country);
 
-        slide.get_input("company_gstin")?.on?.("change", async function () {
+        slide.get_input("company_gstin")?.on("change", async function () {
             autofill_company_info(slide);
         });
     };

--- a/india_compliance/public/js/setup_wizard.js
+++ b/india_compliance/public/js/setup_wizard.js
@@ -22,6 +22,7 @@ frappe.setup.on("before_load", function () {
 });
 
 function toggle_india_specific_fields(country) {
+    console.log(country);
     if (!country) return;
 
     const india_specific_fields = [
@@ -105,10 +106,11 @@ async function autofill_company_info(slide) {
     const gstin = slide.get_input("company_gstin").val();
     const gstin_field = slide.get_field("company_gstin");
 
-    set_gstin_description(gstin_field);
+    gstin_field.$input.css("border", "none");
 
     if (!india_compliance.validate_gstin(gstin)) {
-        set_gstin_description(gstin_field, "Invalid GSTIN");
+        gstin_field.$input.css("border", "1px solid red");
+        return;
     }
 
     if (!can_fetch_gstin_info()) return;
@@ -119,8 +121,6 @@ async function autofill_company_info(slide) {
         await slide.get_field("company_name").set_value(gstin_info.business_name);
         slide.get_input("company_name").trigger("input");
     }
-
-    set_gstin_description(gstin_field, gstin_info.status);
 }
 
 function can_fetch_gstin_info() {

--- a/india_compliance/setup_wizard.py
+++ b/india_compliance/setup_wizard.py
@@ -4,7 +4,11 @@ from frappe import _
 from india_compliance.audit_trail.utils import enable_audit_trail
 from india_compliance.gst_india.overrides.company import make_default_tax_templates
 from india_compliance.gst_india.overrides.party import validate_pan
-from india_compliance.gst_india.utils import guess_gst_category, is_api_enabled
+from india_compliance.gst_india.utils import (
+    guess_gst_category,
+    is_api_enabled,
+    validate_gstin,
+)
 from india_compliance.gst_india.utils.gstin_info import get_gstin_info
 
 # Setup Wizard
@@ -54,6 +58,11 @@ def setup_company_taxes(params):
 
     if not (params.company_name and frappe.db.exists("Company", params.company_name)):
         return
+
+    try:
+        validate_gstin(params.company_gstin)
+    except Exception:
+        params.company_gstin = ""
 
     gstin_info = frappe._dict()
     if can_fetch_gstin_info():

--- a/india_compliance/setup_wizard.py
+++ b/india_compliance/setup_wizard.py
@@ -61,7 +61,7 @@ def setup_company_taxes(params):
 
     try:
         validate_gstin(params.company_gstin)
-    except Exception:
+    except frappe.ValidationError:
         params.company_gstin = ""
 
     gstin_info = frappe._dict()


### PR DESCRIPTION
- India specific fields

**For non-Indian countries:**

![image](https://github.com/resilient-tech/india-compliance/assets/73271406/48074b0d-4548-42eb-af1f-8ac965000636)

**For India:**

![image](https://github.com/resilient-tech/india-compliance/assets/73271406/dcdf700f-9743-4a68-a67e-9dbc0921a9d1)

- Validate GSTIN

**Invalid GSTIN**

![image](https://github.com/resilient-tech/india-compliance/assets/73271406/3c7c7286-5818-4a35-b46f-c2edf8ae533a)

