### PR TITLE
Asset depreciation for leap year

### DIFF
--- a/india_compliance/income_tax_india/overrides/asset.py
+++ b/india_compliance/income_tax_india/overrides/asset.py
@@ -87,9 +87,6 @@ def get_wdv_or_dd_depr_amount(
     elif fb_row.frequency_of_depreciation == 1:
         if fb_row.daily_prorata_based:
             if schedule_date >= start_date_of_next_fiscal_year:
-                num_days_asset_used_in_fiscal_year = date_diff(
-                    start_date_of_next_fiscal_year, asset.available_for_use_date
-                )
                 num_days_asset_used_in_fiscal_year = 365
             fraction = (
                 date_diff(schedule_date, previous_schedule_date)

--- a/india_compliance/income_tax_india/overrides/asset.py
+++ b/india_compliance/income_tax_india/overrides/asset.py
@@ -61,6 +61,8 @@ def get_wdv_or_dd_depr_amount(
     if is_last_day:
         schedule_date = get_last_day(schedule_date)
 
+    schedule_date = getdate(schedule_date)
+
     if schedule_idx == 0:
         previous_schedule_date = add_days(asset.available_for_use_date, -1)
     else:
@@ -79,9 +81,15 @@ def get_wdv_or_dd_depr_amount(
             depreciation_amount = flt(yearly_opening_wdv) * (
                 flt(fb_row.rate_of_depreciation) / 100
             )
+            # if leap year, then consider 366 days
+            if cint(schedule_date.year) % 4 == 0:
+                depreciation_amount = depreciation_amount * 366 / 365
     elif fb_row.frequency_of_depreciation == 1:
         if fb_row.daily_prorata_based:
             if schedule_date >= start_date_of_next_fiscal_year:
+                num_days_asset_used_in_fiscal_year = date_diff(
+                    start_date_of_next_fiscal_year, asset.available_for_use_date
+                )
                 num_days_asset_used_in_fiscal_year = 365
             fraction = (
                 date_diff(schedule_date, previous_schedule_date)

--- a/india_compliance/income_tax_india/overrides/asset.py
+++ b/india_compliance/income_tax_india/overrides/asset.py
@@ -142,4 +142,5 @@ def cancel_depreciation_entries(asset, date):
         if getdate(d.schedule_date) < getdate(start_date_of_fiscal_year):
             continue
 
-        frappe.get_doc("Journal Entry", d.journal_entry).cancel()
+        if d.journal_entry:
+            frappe.get_doc("Journal Entry", d.journal_entry).cancel()


### PR DESCRIPTION
If depreciation is booked annually using WDV, calculate the depreciation amount considering 366 days for the leap year