### PR TITLE
fix(minor): Show a message if removing invalid GSTIN

### DIFF
--- a/india_compliance/gst_india/overrides/test_transaction.py
+++ b/india_compliance/gst_india/overrides/test_transaction.py
@@ -133,7 +133,7 @@ class TestTransaction(FrappeTestCase):
 
         self.assertTrue(doc.place_of_supply)
 
-    def test_validate_mandatory_company_gstin(self):
+    def test_validate_mandatory_company_address(self):
         def unset_company_gstin():
             doc.set(
                 "company_address" if self.is_sales_doctype else "billing_address", ""
@@ -145,7 +145,9 @@ class TestTransaction(FrappeTestCase):
 
         self.assertRaisesRegex(
             frappe.exceptions.ValidationError,
-            re.compile(r"^(.*is a mandatory field for GST Transactions.*)$"),
+            re.compile(
+                r"^(.*to ensure Company GSTIN is fetched in the transaction.*)$"
+            ),
             doc.save,
         )
 

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -1173,7 +1173,7 @@ def validate_transaction(doc, method=None):
     else:
         doc.place_of_supply = get_place_of_supply(doc, doc.doctype)
 
-    if validate_mandatory_fields(doc, ("company_gstin", "place_of_supply")) is False:
+    if validate_mandatory_fields(doc, ("company_address", "company_gstin", "place_of_supply")) is False:
         return False
 
     # Ignore validation for Quotation not to Customer

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -1175,7 +1175,7 @@ def validate_company_address_field(doc):
             doc,
             company_address_field,
             _(
-                "Please set {0} set to ensure Company GSTIN is fetched in the transaction."
+                "Please set {0} to ensure Company GSTIN is fetched in the transaction."
             ).format(bold(doc.meta.get_label(company_address_field))),
         )
         is False

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -1162,6 +1162,27 @@ def validate_gstin_status(gstin, transaction_date):
     _validate_gstin_info(gstin_doc, transaction_date, throw=True)
 
 
+def validate_company_address_field(doc):
+    if doc.doctype not in DOCTYPES_WITH_GST_DETAIL:
+        return
+
+    company_address_field = "company_address"
+    if doc.doctype not in SALES_DOCTYPES:
+        company_address_field = "billing_address"
+
+    if (
+        validate_mandatory_fields(
+            doc,
+            company_address_field,
+            _(
+                "Please set {0} set to ensure Company GSTIN is fetched in the transaction."
+            ).format(bold(doc.meta.get_label(company_address_field))),
+        )
+        is False
+    ):
+        return False
+
+
 def validate_transaction(doc, method=None):
     if ignore_gst_validations(doc):
         return False
@@ -1173,7 +1194,10 @@ def validate_transaction(doc, method=None):
     else:
         doc.place_of_supply = get_place_of_supply(doc, doc.doctype)
 
-    if validate_mandatory_fields(doc, ("company_address", "company_gstin", "place_of_supply")) is False:
+    if validate_company_address_field(doc) is False:
+        return False
+
+    if validate_mandatory_fields(doc, ("company_gstin", "place_of_supply")) is False:
         return False
 
     # Ignore validation for Quotation not to Customer

--- a/india_compliance/public/js/utils.js
+++ b/india_compliance/public/js/utils.js
@@ -147,7 +147,7 @@ Object.assign(india_compliance, {
 
     validate_gstin(gstin) {
         if (!gstin || gstin.length !== 15) {
-            frappe.msgprint("GSTIN must be 15 characters long")
+            frappe.msgprint(__("GSTIN must be 15 characters long"))
             return;
         }
 
@@ -156,7 +156,7 @@ Object.assign(india_compliance, {
         if (GSTIN_REGEX.test(gstin) && is_gstin_check_digit_valid(gstin)) {
             return gstin;
         } else {
-            frappe.msgprint("Invalid GSTIN");
+            frappe.msgprint(__("Invalid GSTIN"));
         }
     },
 

--- a/india_compliance/public/js/utils.js
+++ b/india_compliance/public/js/utils.js
@@ -146,12 +146,17 @@ Object.assign(india_compliance, {
     },
 
     validate_gstin(gstin) {
-        if (!gstin || gstin.length !== 15) return;
+        if (!gstin || gstin.length !== 15) {
+            frappe.msgprint("GSTIN must be 15 characters long")
+            return;
+        }
 
         gstin = gstin.trim().toUpperCase();
 
         if (GSTIN_REGEX.test(gstin) && is_gstin_check_digit_valid(gstin)) {
             return gstin;
+        } else {
+            frappe.msgprint("Invalid GSTIN");
         }
     },
 


### PR DESCRIPTION
Was testing some thing with a sandbox GSTIN - got very annoyed that it kept deleting it without any message.
This will at least let the user know their GSTIN is invalid.