### PR TITLE
fix: use text editor for gst breakup table instead of long text

### DIFF
--- a/india_compliance/gst_india/constants/custom_fields.py
+++ b/india_compliance/gst_india/constants/custom_fields.py
@@ -153,7 +153,7 @@ CUSTOM_FIELDS = {
         {
             "fieldname": "gst_breakup_table",
             "label": "GST Breakup Table",
-            "fieldtype": "Long Text",
+            "fieldtype": "Text Editor",
             "insert_after": "section_gst_breakup",
             "is_virtual": 1,
             "read_only": 1,
@@ -258,7 +258,7 @@ CUSTOM_FIELDS = {
         {
             "fieldname": "gst_breakup_table",
             "label": "GST Breakup Table",
-            "fieldtype": "Long Text",
+            "fieldtype": "Text Editor",
             "insert_after": "section_gst_breakup",
             "is_virtual": 1,
             "read_only": 1,

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -50,9 +50,13 @@ def set_gst_breakup(doc, method=None, print_settings=None):
     if ignore_gst_validations(doc) or not doc.place_of_supply or not doc.company_gstin:
         return
 
-    doc.gst_breakup_table = frappe.render_template(
+    gst_breakup_html = frappe.render_template(
         "templates/gst_breakup.html", dict(doc=doc)
     )
+    if not gst_breakup_html:
+        return
+
+    doc.gst_breakup_table = gst_breakup_html.replace("\n", "").replace("    ", "")
 
 
 def update_taxable_values(doc, valid_accounts):

--- a/india_compliance/patches.txt
+++ b/india_compliance/patches.txt
@@ -3,7 +3,7 @@ execute:import frappe; frappe.delete_doc_if_exists("DocType", "GSTIN")
 
 [post_model_sync]
 india_compliance.patches.v14.set_default_for_overridden_accounts_setting
-execute:from india_compliance.gst_india.setup import create_custom_fields; create_custom_fields() #45
+execute:from india_compliance.gst_india.setup import create_custom_fields; create_custom_fields() #46
 execute:from india_compliance.gst_india.setup import create_property_setters; create_property_setters() #7
 execute:from india_compliance.income_tax_india.setup import create_custom_fields; create_custom_fields() #1
 india_compliance.patches.post_install.remove_old_fields #1

--- a/india_compliance/templates/gst_breakup.html
+++ b/india_compliance/templates/gst_breakup.html
@@ -31,7 +31,7 @@
                         {% else %}
                             <td class="text-right">
                                 {% if value.tax_rate or not value.tax_amount %}
-                                    ({{ value.tax_rate }}%)
+                                    ({{ value.tax_rate }}%)&nbsp;
                                 {% endif %}
 
                                 {% if doc.get('is_return') %}


### PR DESCRIPTION
closes: https://github.com/frappe/frappe/issues/25574
replicated from: https://github.com/frappe/erpnext/pull/40563