### PR TITLE
fix: validate for cess non-advol

### DIFF
--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -124,14 +124,14 @@ def validate_item_wise_tax_detail(doc, gst_accounts):
         return
 
     item_taxable_values = defaultdict(float)
+    item_qty_map = defaultdict(float)
 
     cess_non_advol_account = get_gst_accounts_by_tax_type(doc.company, "cess_non_advol")
-    item_qty = defaultdict(float)
 
     for row in doc.items:
         item_key = row.item_code or row.item_name
         item_taxable_values[item_key] += row.taxable_value
-        item_qty[item_key] += row.qty
+        item_qty_map[item_key] += row.qty
 
     for row in doc.taxes:
         if row.account_head not in gst_accounts:
@@ -154,24 +154,25 @@ def validate_item_wise_tax_detail(doc, gst_accounts):
 
             # Sales Invoice is created with manual tax amount. So, when a sales return is created,
             # the tax amount is not recalculated, causing the issue.
+
+            is_cess_non_advol = row.account_head in cess_non_advol_account
             multiplier = (
-                item_qty.get(item_name, 0)
-                if row.account_head in cess_non_advol_account
+                item_qty_map.get(item_name, 0)
+                if is_cess_non_advol
                 else item_taxable_values.get(item_name, 0) / 100
             )
             tax_difference = abs(multiplier * tax_rate - tax_amount)
 
-            column = (
-                "cess non-advol"
-                if row.account_head in cess_non_advol_account
-                else "Net Total"
-            )
             if tax_difference > 1:
+                correct_charge_type = (
+                    "On Item Quantity" if is_cess_non_advol else "On Net Total"
+                )
+
                 frappe.throw(
                     _(
-                        "Tax Row #{0}: Charge Type is set to Actual. However, Tax Amount {1}"
-                        " is incorrect. Try setting the Charge Type to On {2}."
-                    ).format(row.idx, tax_amount, column)
+                        "Tax Row #{0}: Charge Type is set to Actual. However, Tax Amount {1} as computed for Item {2}"
+                        " is incorrect. Try setting the Charge Type to {3}"
+                    ).format(row.idx, tax_amount, bold(item_name), correct_charge_type)
                 )
 
 
@@ -470,7 +471,7 @@ def validate_charge_type_for_cess_non_advol_accounts(cess_non_advol_accounts, ta
     ):
         frappe.throw(
             _(
-                "Row #{0}: Charge Type must be <strong>On Item Quantity</strong>"
+                "Row #{0}: Charge Type must be <strong>On Item Quantity / Actual</strong>"
                 " as it is a Cess Non Advol Account"
             ).format(tax_row.idx),
             title=_("Invalid Charge Type"),


### PR DESCRIPTION
Validation for cess non-advol where charge type is actual.
closes #1884