### PR TITLE
test: fix failing test cases related to UOM validation in ERPNext

### DIFF
--- a/india_compliance/gst_india/overrides/test_transaction.py
+++ b/india_compliance/gst_india/overrides/test_transaction.py
@@ -266,6 +266,7 @@ class TestTransaction(FrappeTestCase):
             },
         )
         item_without_hsn.flags.ignore_validate = True
+        item_without_hsn.add_default_uom_in_conversion_factor_table()
         item_without_hsn.insert()
 
         # create transaction

--- a/india_compliance/gst_india/overrides/test_transaction.py
+++ b/india_compliance/gst_india/overrides/test_transaction.py
@@ -263,11 +263,11 @@ class TestTransaction(FrappeTestCase):
                 "item_code": "_Test Item Without HSN",
                 "item_name": "_Test Item Without HSN",
                 "valuation_rate": 100,
+                "is_sales_item": 0,
             },
         )
-        item_without_hsn.flags.ignore_validate = True
-        item_without_hsn.add_default_uom_in_conversion_factor_table()
         item_without_hsn.insert()
+        item_without_hsn.db_set("is_sales_item", 1)
 
         # create transaction
         doc = create_transaction(

--- a/india_compliance/gst_india/utils/test_e_waybill.py
+++ b/india_compliance/gst_india/utils/test_e_waybill.py
@@ -325,6 +325,7 @@ class TestEWaybill(FrappeTestCase):
                     item_name="Test Item {}".format(i),
                     rate=100,
                     gst_hsn_code=hsn_code,
+                    uom="Nos"
                 ),
             )
 
@@ -354,7 +355,7 @@ class TestEWaybill(FrappeTestCase):
                     "taxable_value": 100.0,
                     "hsn_code": "61149090",
                     "item_name": "Test Trading Goods 1",
-                    "uom": "NOS",
+                    "uom": "Nos",
                     "cgst_amount": 0,
                     "cgst_rate": 0,
                     "sgst_amount": 0,
@@ -384,7 +385,7 @@ class TestEWaybill(FrappeTestCase):
             [
                 {
                     "hsn_code": "61149090",
-                    "uom": "NOS",
+                    "uom": "Nos",
                     "item_name": "",
                     "cgst_rate": 9.0,
                     "sgst_rate": 9.0,

--- a/india_compliance/gst_india/utils/test_e_waybill.py
+++ b/india_compliance/gst_india/utils/test_e_waybill.py
@@ -305,6 +305,7 @@ class TestEWaybill(FrappeTestCase):
         - check if item details are generated correctly
         """
         si = create_sales_invoice(do_not_submit=True)
+        item_code = si.items[0].item_code
 
         hsn_codes = frappe.get_file_json(
             frappe.get_app_path(
@@ -321,11 +322,10 @@ class TestEWaybill(FrappeTestCase):
             append_item(
                 si,
                 frappe._dict(
-                    item_code=hsn_code,
+                    item_code=item_code,
                     item_name="Test Item {}".format(i),
                     rate=100,
                     gst_hsn_code=hsn_code,
-                    uom="Nos"
                 ),
             )
 
@@ -338,13 +338,7 @@ class TestEWaybill(FrappeTestCase):
         )
 
         # Assert get_all_item_details
-        to_remove = [
-            d
-            for d in si.items
-            if d.gst_hsn_code != "61149090" and d.item_code != "_Test Trading Goods 1"
-        ]
-        for item in to_remove:
-            si.remove(item)
+        si.items = si.items[:1]
         si.save()
 
         self.assertListEqual(
@@ -355,7 +349,7 @@ class TestEWaybill(FrappeTestCase):
                     "taxable_value": 100.0,
                     "hsn_code": "61149090",
                     "item_name": "Test Trading Goods 1",
-                    "uom": "Nos",
+                    "uom": "NOS",
                     "cgst_amount": 0,
                     "cgst_rate": 0,
                     "sgst_amount": 0,
@@ -385,7 +379,7 @@ class TestEWaybill(FrappeTestCase):
             [
                 {
                     "hsn_code": "61149090",
-                    "uom": "Nos",
+                    "uom": "NOS",
                     "item_name": "",
                     "cgst_rate": 9.0,
                     "sgst_rate": 9.0,

--- a/india_compliance/gst_india/utils/tests.py
+++ b/india_compliance/gst_india/utils/tests.py
@@ -103,7 +103,7 @@ def append_item(transaction, data=None, company_abbr="_TIRC"):
         {
             "item_code": data.item_code or "_Test Trading Goods 1",
             "qty": data.qty or 1,
-            "uom": data.uom,
+            "uom": data.uom or "NOS",
             "rate": data.rate or 100,
             "cost_center": f"Main - {company_abbr}",
             "item_tax_template": data.item_tax_template,

--- a/india_compliance/gst_india/utils/tests.py
+++ b/india_compliance/gst_india/utils/tests.py
@@ -103,7 +103,7 @@ def append_item(transaction, data=None, company_abbr="_TIRC"):
         {
             "item_code": data.item_code or "_Test Trading Goods 1",
             "qty": data.qty or 1,
-            "uom": data.uom or "NOS",
+            "uom": data.uom or "Nos",
             "rate": data.rate or 100,
             "cost_center": f"Main - {company_abbr}",
             "item_tax_template": data.item_tax_template,

--- a/india_compliance/gst_india/utils/tests.py
+++ b/india_compliance/gst_india/utils/tests.py
@@ -103,7 +103,7 @@ def append_item(transaction, data=None, company_abbr="_TIRC"):
         {
             "item_code": data.item_code or "_Test Trading Goods 1",
             "qty": data.qty or 1,
-            "uom": data.uom or "Nos",
+            "uom": data.uom,
             "rate": data.rate or 100,
             "cost_center": f"Main - {company_abbr}",
             "item_tax_template": data.item_tax_template,


### PR DESCRIPTION
Added Default `UOM` In Conversion Factor Table For  `Test Cases`

Reason : 
- https://github.com/frappe/erpnext/pull/40586