### PR TITLE
fix: Document Type as `CHL` in case of return Invoice with Nil-rated

### DIFF
--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -1474,7 +1474,7 @@ class EWaybillData(GSTTransactionData):
             item.gst_treatment in ("Nil-Rated", "Exempted", "Non-GST")
             for item in doc.items
         ):
-            document_type = "BIL" if not doc.is_return else "CHL"
+            document_type = "CHL" if doc.is_return else "BIL"
             self.transaction_details.update(document_type=document_type)
 
         if self.doc.doctype == "Purchase Invoice" and not self.doc.is_return:

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -1470,14 +1470,15 @@ class EWaybillData(GSTTransactionData):
             if not doc.is_export_with_gst:
                 self.transaction_details.update(document_type="BIL")
 
-        if doc.doctype in ("Sales Invoice", "Purchase Invoice") and all(
-            item.gst_treatment in ("Nil-Rated", "Exempted", "Non-GST")
-            for item in doc.items
+        if (
+            doc.doctype in ("Sales Invoice", "Purchase Invoice")
+            and not doc.is_return
+            and all(
+                item.gst_treatment in ("Nil-Rated", "Exempted", "Non-GST")
+                for item in doc.items
+            )
         ):
-            document_type = "BIL"
-            if doc.is_return:
-                document_type = "OTH" if doc.doctype == "Purchase Invoice" else "CHL"
-            self.transaction_details.update(document_type=document_type)
+            self.transaction_details.update(document_type="BIL")
 
         if self.doc.doctype == "Purchase Invoice" and not self.doc.is_return:
             self.transaction_details.name = self.doc.bill_no or self.doc.name

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -1474,7 +1474,8 @@ class EWaybillData(GSTTransactionData):
             item.gst_treatment in ("Nil-Rated", "Exempted", "Non-GST")
             for item in doc.items
         ):
-            self.transaction_details.update(document_type="BIL")
+            document_type = "BIL" if not doc.is_return else "CHL"
+            self.transaction_details.update(document_type=document_type)
 
         if self.doc.doctype == "Purchase Invoice" and not self.doc.is_return:
             self.transaction_details.name = self.doc.bill_no or self.doc.name

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -1474,7 +1474,9 @@ class EWaybillData(GSTTransactionData):
             item.gst_treatment in ("Nil-Rated", "Exempted", "Non-GST")
             for item in doc.items
         ):
-            document_type = "CHL" if doc.is_return else "BIL"
+            document_type = "BIL"
+            if doc.is_return:
+                document_type = "OTH" if doc.doctype == "Purchase Invoice" else "CHL"
             self.transaction_details.update(document_type=document_type)
 
         if self.doc.doctype == "Purchase Invoice" and not self.doc.is_return:


### PR DESCRIPTION
**Issue**
Document type was mapped incorrect in case of Sales and Purchase Return.

**Before**

https://github.com/resilient-tech/india-compliance/assets/54097382/7778eba7-0692-4b1d-867c-bbd9375162b1

**After**

https://github.com/resilient-tech/india-compliance/assets/54097382/d2f65194-4447-4235-a85a-5918e7b8c000

