### PR TITLE
fix: cancel sales invoice if e-Invoice is cancelled

### DIFF
--- a/india_compliance/gst_india/client_scripts/e_invoice_actions.js
+++ b/india_compliance/gst_india/client_scripts/e_invoice_actions.js
@@ -151,7 +151,7 @@ function show_cancel_e_invoice_dialog(frm, callback) {
     const d = new frappe.ui.Dialog({
         title: frm.doc.ewaybill
             ? __("Cancel e-Invoice and e-Waybill")
-            : __("Cancel e-Invoice"),
+            : __("Cancel e-Invoice") + "<br>" + __("Sales Invoice will also be Cancelled"),
         fields: get_cancel_e_invoice_dialog_fields(frm),
         primary_action_label: frm.doc.ewaybill
             ? __("Cancel IRN & e-Waybill")

--- a/india_compliance/gst_india/client_scripts/e_invoice_actions.js
+++ b/india_compliance/gst_india/client_scripts/e_invoice_actions.js
@@ -151,11 +151,11 @@ function show_cancel_e_invoice_dialog(frm, callback) {
     const d = new frappe.ui.Dialog({
         title: frm.doc.ewaybill
             ? __("Cancel e-Invoice and e-Waybill")
-            : __("Cancel e-Invoice") + "<br>" + __("Sales Invoice will also be Cancelled"),
+            : __("Cancel e-Invoice"),
         fields: get_cancel_e_invoice_dialog_fields(frm),
         primary_action_label: frm.doc.ewaybill
-            ? __("Cancel IRN & e-Waybill")
-            : __("Cancel IRN"),
+            ? __("Cancel IRN & e-Waybill & Invoice")
+            : __("Cancel IRN & Invoice"),
         primary_action(values) {
             frappe.call({
                 method: "india_compliance.gst_india.utils.e_invoice.cancel_e_invoice",
@@ -174,6 +174,12 @@ function show_cancel_e_invoice_dialog(frm, callback) {
 
     india_compliance.primary_to_danger_btn(d);
     d.show();
+
+    $(`
+        <div class="alert alert-warning" role="alert">
+            Sales invoice will be cancelled along with the IRN.
+        </div>
+    `).prependTo(d.wrapper);
 }
 
 function show_mark_e_invoice_as_cancelled_dialog(frm) {

--- a/india_compliance/gst_india/client_scripts/e_invoice_actions.js
+++ b/india_compliance/gst_india/client_scripts/e_invoice_actions.js
@@ -154,7 +154,7 @@ function show_cancel_e_invoice_dialog(frm, callback) {
             : __("Cancel e-Invoice"),
         fields: get_cancel_e_invoice_dialog_fields(frm),
         primary_action_label: frm.doc.ewaybill
-            ? __("Cancel IRN & e-Waybill & Invoice")
+            ? __("Cancel IRN, e-Waybill & Invoice")
             : __("Cancel IRN & Invoice"),
         primary_action(values) {
             frappe.call({

--- a/india_compliance/gst_india/utils/e_invoice.py
+++ b/india_compliance/gst_india/utils/e_invoice.py
@@ -256,6 +256,7 @@ def cancel_e_invoice(docname, values):
         doc, values, result, "e-Invoice cancelled successfully"
     )
 
+    doc.cancel()
     return send_updated_doc(doc)
 
 


### PR DESCRIPTION
cancel `Sales Invoice` when e-invoice is cancelled
closes #2029

## Objective

Once e-Invoice is cancelled, it cannot be re-generated for the same invoice.
Hence ideally, it should be cancelled and reported as cancelled in GSTR-1 document summary.