### PR TITLE
fix: Remove check digit validation for transporter id

### DIFF
--- a/india_compliance/gst_india/utils/__init__.py
+++ b/india_compliance/gst_india/utils/__init__.py
@@ -171,7 +171,7 @@ def validate_gstin(
             title=_("Invalid {0}").format(label),
         )
 
-    if not (is_transporter_id and gstin.startswith("88")):
+    if not is_transporter_id:
         validate_gstin_check_digit(gstin, label)
 
     if is_tcs_gstin and not TCS.match(gstin):


### PR DESCRIPTION
Only call `validate_gstin_check_digit` if GSTIN is not Transporter ID