### PR TITLE
fix: avoid duplicate address keys in gstin info based on key priority

### DIFF
--- a/india_compliance/gst_india/utils/gstin_info.py
+++ b/india_compliance/gst_india/utils/gstin_info.py
@@ -22,6 +22,11 @@ GST_CATEGORIES = {
     "URP": "Unregistered",
 }
 
+# order of address keys is important
+KEYS_TO_SANITIZE = ("dst", "stcd", "pncd", "bno", "flno", "bnm", "st", "loc", "city")
+KEYS_TO_FILTER_DUPLICATES = frozenset(("dst", "bnm", "st", "loc", "city"))
+CHARACTERS_TO_STRIP = f"{whitespace},"
+
 
 @frappe.whitelist()
 def get_gstin_info(gstin, *, throw_error=True):
@@ -122,14 +127,20 @@ def _get_address(address):
 def _extract_address_lines(address):
     """merge and divide address into exactly two lines"""
     unique_values = set()
-    # key list as per priority
-    keys = ["dst", "stcd", "pncd", "bno", "flno", "bnm", "st", "loc", "city"]
 
-    for key in keys:
-        value = address.get(key, "")
-        value = value.strip(f"{whitespace},")
-        address[key] = value if value not in unique_values else ""
-        unique_values.add(value)
+    for key in KEYS_TO_SANITIZE:
+        value = address.get(key, "").strip(CHARACTERS_TO_STRIP)
+
+        if key not in KEYS_TO_FILTER_DUPLICATES:
+            address[key] = value
+            continue
+
+        if value not in unique_values:
+            address[key] = value
+            unique_values.add(value)
+            continue
+
+        address[key] = ""
 
     address_line1 = ", ".join(
         titlecase(value)

--- a/india_compliance/gst_india/utils/gstin_info.py
+++ b/india_compliance/gst_india/utils/gstin_info.py
@@ -121,11 +121,14 @@ def _get_address(address):
 
 def _extract_address_lines(address):
     """merge and divide address into exactly two lines"""
-
     unique_values = set()
-    for key, value in address.items():
+    # key list as per priority
+    keys = ["dst", "stcd", "pncd", "bno", "flno", "bnm", "st", "loc", "city"]
+
+    for key in keys:
+        value = address.get(key, "")
         value = value.strip(f"{whitespace},")
-        address[key] = value if value not in unique_values else None
+        address[key] = value if value not in unique_values else ""
         unique_values.add(value)
 
     address_line1 = ", ".join(

--- a/india_compliance/gst_india/utils/test_gstin_info.py
+++ b/india_compliance/gst_india/utils/test_gstin_info.py
@@ -14,7 +14,7 @@ class TestGstinInfo(unittest.TestCase):
                     "addr": {
                         "bnm": "",
                         "bno": "8-A",
-                        "city": "",
+                        "city": "Vadodara",
                         "dst": "Vadodara",
                         "flno": "Saimee society No.2",
                         "lg": "",


### PR DESCRIPTION
Closes: #2093 
Before
<img width="492" alt="image" src="https://github.com/resilient-tech/india-compliance/assets/108322669/7b97e8ce-3773-4ccf-aa67-3c9e31f38d47">
After
<img width="451" alt="after" src="https://github.com/resilient-tech/india-compliance/assets/108322669/8bf4fff7-1eae-4a04-aa88-4e7af1dbefff">
