### PR TITLE
fix: handle empty place of supply in GST Sales Register Beta Report

### DIFF
--- a/india_compliance/gst_india/utils/gstr_1/gstr_1_data.py
+++ b/india_compliance/gst_india/utils/gstr_1/gstr_1_data.py
@@ -152,7 +152,7 @@ class GSTR1Query:
                 self.si.customer_name,
                 self.si.name.as_("invoice_no"),
                 self.si.posting_date,
-                self.si.place_of_supply,
+                IfNull(self.si.place_of_supply, "").as_("place_of_supply"),
                 self.si.is_reverse_charge,
                 self.si.is_export_with_gst,
                 self.si.is_return,
@@ -288,6 +288,10 @@ class GSTR1Conditions:
 
     @cache_invoice_condition
     def is_inter_state(self, invoice):
+        # if pos is not avaialble default to False
+        if not invoice.place_of_supply:
+            return False
+
         return invoice.company_gstin[:2] != invoice.place_of_supply[:2]
 
     @cache_invoice_condition


### PR DESCRIPTION
Frappe Support: https://support.frappe.io/app/hd-ticket/14816
If the Place of supply is not set we will assume it as intra-state for conditions check and show it as empty.
