### PR TITLE
fix: modify the download history when switching the `company_gstin` from a specific GSTIN to All.

### DIFF
--- a/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.js
+++ b/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.js
@@ -1214,10 +1214,8 @@ class ImportDialog {
         });
 
         // TODO: modify HTML for case: company_gstin == "All"
-        if (!message || this.company_gstin == "All") return;
-        this.dialog.fields_dict.history.html(
-            frappe.render_template("gstr_download_history", message)
-        );
+        let html = (!message || this.company_gstin == "All") ? '' : frappe.render_template("gstr_download_history", message)
+        this.dialog.fields_dict.history.html(html);
     }
 
     async update_return_period() {


### PR DESCRIPTION
When I change `company_gstin` from a specific `company_gstin` to `All`, the Download History does not update accordingly.