### PR TITLE
fix: add description and hide progress bar in purchase reconciliation tool

### DIFF
--- a/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.js
+++ b/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.js
@@ -80,6 +80,7 @@ frappe.ui.form.on("Purchase Reconciliation Tool", {
         if (frm.doc.is_modified) frm.doc.reconciliation_data = null;
         frm.trigger("company");
         add_gstr2b_alert(frm);
+        set_date_range_description(frm);
     },
 
     async company(frm) {
@@ -141,19 +142,19 @@ frappe.ui.form.on("Purchase Reconciliation Tool", {
         frm.doc.reconciliation_data = null;
     },
 
-    purchase_period(frm) {
-        fetch_date_range(frm, "purchase");
+    async purchase_period(frm) {
+        await fetch_date_range(frm, "purchase");
+        set_date_range_description(frm, "purchase");
     },
 
     async inward_supply_period(frm) {
-
         await fetch_date_range(
             frm,
             "inward_supply",
             "get_date_range_and_check_missing_documents"
         );
+        set_date_range_description(frm, "inward_supply");
         add_gstr2b_alert(frm);
-
     },
 
     after_save(frm) {
@@ -1174,18 +1175,36 @@ class ImportDialog {
             if (this.return_type === ReturnType.GSTR2A) {
                 this.dialog.$wrapper.find(".btn-secondary").removeClass("hidden");
                 this.dialog.set_primary_action(__("Download All"), () => {
-                    download_gstr(this.frm, this.date_range, this.return_type, this.company_gstin, false);
+                    download_gstr(
+                        this.frm,
+                        this.date_range,
+                        this.return_type,
+                        this.company_gstin,
+                        false
+                    );
                     this.dialog.hide();
                 });
                 this.dialog.set_secondary_action_label(__("Download Missing"));
                 this.dialog.set_secondary_action(() => {
-                    download_gstr(this.frm, this.date_range, this.return_type, this.company_gstin, true);
+                    download_gstr(
+                        this.frm,
+                        this.date_range,
+                        this.return_type,
+                        this.company_gstin,
+                        true
+                    );
                     this.dialog.hide();
                 });
             } else if (this.return_type === ReturnType.GSTR2B) {
                 this.dialog.$wrapper.find(".btn-secondary").addClass("hidden");
                 this.dialog.set_primary_action(__("Download"), () => {
-                    download_gstr(this.frm, this.date_range, this.return_type, this.company_gstin, true);
+                    download_gstr(
+                        this.frm,
+                        this.date_range,
+                        this.return_type,
+                        this.company_gstin,
+                        true
+                    );
                     this.dialog.hide();
                 });
             }
@@ -1215,7 +1234,10 @@ class ImportDialog {
         });
 
         // TODO: modify HTML for case: company_gstin == "All"
-        let html = (!message || this.company_gstin == "All") ? '' : frappe.render_template("gstr_download_history", message)
+        let html =
+            !message || this.company_gstin == "All"
+                ? ""
+                : frappe.render_template("gstr_download_history", message);
         this.dialog.fields_dict.history.html(html);
     }
 
@@ -1283,7 +1305,7 @@ class ImportDialog {
                 onchange: () => {
                     this.company_gstin = this.dialog.get_value("company_gstin");
                     this.fetch_import_history();
-                }
+                },
             },
             {
                 fieldtype: "Column Break",
@@ -1431,19 +1453,30 @@ class EmailDialog {
 async function fetch_date_range(frm, field_prefix, method) {
     const from_date_field = field_prefix + "_from_date";
     const to_date_field = field_prefix + "_to_date";
-    const period = frm.doc[field_prefix + "_period"];
-    const field_name = field_prefix + "_period"
-    if (!period || period == "Custom") {
-        frm.get_field(field_name).set_description("");
-        return;
-    }
-    const { message } = await frm.call(method || "get_date_range", { period });
 
-    const description = frappe.datetime.str_to_user(message[0]) +' to '+ frappe.datetime.str_to_user(message[1])
-    frm.get_field(field_name).set_description(description);
+    const period = frm.doc[field_prefix + "_period"];
+    if (!period || period == "Custom") return;
+
+    const { message } = await frm.call(method || "get_date_range", { period });
 
     frm.set_value(from_date_field, message[0]);
     frm.set_value(to_date_field, message[1]);
+}
+
+function set_date_range_description(frm, field_prefixs) {
+    if (!field_prefixs) field_prefixs = ["inward_supply", "purchase"];
+
+    field_prefixs.forEach(prefix => {
+        const period_field = prefix + "_period";
+        const period = frm.doc[period_field];
+
+        if (!period || period == "Custom")
+            return frm.get_field(period_field).set_description("");
+
+        const from_date = frappe.datetime.str_to_user(frm.doc[prefix + "_from_date"]);
+        const to_date = frappe.datetime.str_to_user(frm.doc[prefix + "_to_date"]);
+        frm.get_field(period_field).set_description(`${from_date} to ${to_date}`);
+    });
 }
 
 function get_icon(value, column, data, icon) {

--- a/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.js
+++ b/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.js
@@ -36,6 +36,12 @@ const ReturnType = {
     GSTR2B: "GSTR2b",
 };
 
+let last_year = frappe.datetime.add_months(frappe.datetime.get_today(),-12)
+let fiscal_year = erpnext.utils.get_fiscal_year(last_year, true)
+let fiscal_start = frappe.datetime.str_to_user(fiscal_year[1], null,  frappe.datetime.get_user_date_fmt())
+let fiscal_end = frappe.datetime.str_to_user(fiscal_year[2], null,  frappe.datetime.get_user_date_fmt())
+
+
 function remove_gstr2b_alert(alert) {
     if (alert.length === 0) return;
     $(alert).remove();
@@ -143,9 +149,14 @@ frappe.ui.form.on("Purchase Reconciliation Tool", {
 
     purchase_period(frm) {
         fetch_date_range(frm, "purchase");
+        let description = frm.doc.purchase_period == "Last Fiscal Year" ? fiscal_start +' to '+ fiscal_end : ""
+        frm.get_field("purchase_period").set_description(description);
     },
 
     async inward_supply_period(frm) {
+        let description = frm.doc.inward_supply_period == "Last Fiscal Year" ? fiscal_start +' to '+ fiscal_end : ""
+        frm.get_field("inward_supply_period").set_description(description);
+
         await fetch_date_range(
             frm,
             "inward_supply",

--- a/india_compliance/gst_india/utils/gstr_2/__init__.py
+++ b/india_compliance/gst_india/utils/gstr_2/__init__.py
@@ -47,6 +47,7 @@ def download_gstr_2a(gstin, return_periods, otp=None, gst_categories=None):
     total_expected_requests = len(return_periods) * len(ACTIONS)
     requests_made = 0
     queued_message = False
+    flag = True
     settings = frappe.get_cached_doc("GST Settings")
 
     return_type = ReturnType.GSTR2A
@@ -121,15 +122,21 @@ def download_gstr_2a(gstin, return_periods, otp=None, gst_categories=None):
             json_data[action.lower()] = data
 
         save_gstr_2a(gstin, return_period, json_data)
+        if return_period == return_periods[-1]:
+            flag = False
 
     if queued_message:
         show_queued_message()
+
+    if flag:
+        end_transaction_progress(return_periods[-1])
 
 
 def download_gstr_2b(gstin, return_periods, otp=None):
     total_expected_requests = len(return_periods)
     requests_made = 0
     queued_message = False
+    flag = True
 
     api = GSTR2bAPI(gstin)
     for return_period in return_periods:
@@ -179,9 +186,27 @@ def download_gstr_2b(gstin, return_periods, otp=None):
             continue  # skip first response if file_count is greater than 1
 
         save_gstr_2b(gstin, return_period, response)
+        if return_period == return_periods[-1]:
+            flag = False
 
     if queued_message:
         show_queued_message()
+
+    if flag:
+        end_transaction_progress(return_periods[-1])
+
+
+def end_transaction_progress(return_period):
+    frappe.publish_realtime(
+        "update_transactions_progress",
+        {
+            "current_progress": 100,
+            "return_period": return_period,
+            "is_last_period": True,
+        },
+        user=frappe.session.user,
+        doctype="Purchase Reconciliation Tool",
+    )
 
 
 def save_gstr_2a(gstin, return_period, json_data):


### PR DESCRIPTION
Add description when `Purchase Period` or `Inward Supply Period` is selected as `Last Fiscal year` in purchase reconciliation tool.
Remove progress bar if it is there after completion of function
