### PR TITLE
fix: resolved discrepancy in function arguments for depreciation calcu…

### DIFF
--- a/india_compliance/income_tax_india/overrides/asset_depreciation_schedule.py
+++ b/india_compliance/income_tax_india/overrides/asset_depreciation_schedule.py
@@ -42,7 +42,7 @@ def get_wdv_or_dd_depr_amount(
             prev_depreciation_amount,
             has_wdv_or_dd_non_yearly_pro_rata,
             asset_depr_schedule,
-            prev_per_day_depr=0,
+            prev_per_day_depr=prev_per_day_depr,
         )
 
     asset_depr_schedule.flags.wdv_it_act_applied = True

--- a/india_compliance/income_tax_india/overrides/asset_depreciation_schedule.py
+++ b/india_compliance/income_tax_india/overrides/asset_depreciation_schedule.py
@@ -27,6 +27,7 @@ def get_wdv_or_dd_depr_amount(
     prev_depreciation_amount,
     has_wdv_or_dd_non_yearly_pro_rata,
     asset_depr_schedule,
+    prev_per_day_depr=0,
 ):
     # As per IT act, if the asset is purchased in the 2nd half of fiscal year, then rate is divided by 2 for the first year
 
@@ -41,6 +42,7 @@ def get_wdv_or_dd_depr_amount(
             prev_depreciation_amount,
             has_wdv_or_dd_non_yearly_pro_rata,
             asset_depr_schedule,
+            prev_per_day_depr=0,
         )
 
     asset_depr_schedule.flags.wdv_it_act_applied = True
@@ -122,7 +124,7 @@ def get_wdv_or_dd_depr_amount(
     else:
         frappe.throw(_("Only monthly and yearly depreciations allowed yet."))
 
-    return depreciation_amount
+    return depreciation_amount, None
 
 
 def cancel_depreciation_entries(asset_doc, date):


### PR DESCRIPTION
This pull request addresses an issue where a function override caused by the regional compliance module results in a TypeError during asset creation.
The "get_wdv_or_dd_depr_amount" function, modified in erpnext, is overridden by india_compliance, resulting in a mismatch in the number of arguments.

**Fix**
Modified the india_compliance function to match the signature expected by erpnext, ensuring consistency in the number and type of arguments.