### PR TITLE
fix: exclude place of supply for impg in purchase reco

### DIFF
--- a/india_compliance/gst_india/data/test_purchase_reconciliation_tool.json
+++ b/india_compliance/gst_india/data/test_purchase_reconciliation_tool.json
@@ -37,7 +37,7 @@
                     "classification": "IMPG",
                     "doc_type": "Bill of Entry",
                     "supply_type": "",
-                    "place_of_supply": "24-Gujarat",
+                    "place_of_supply": null,
                     "items": [
                         {
                             "taxable_value": 10000,

--- a/india_compliance/gst_india/doctype/purchase_reconciliation_tool/__init__.py
+++ b/india_compliance/gst_india/doctype/purchase_reconciliation_tool/__init__.py
@@ -613,16 +613,12 @@ class BillOfEntry:
             self.BOE.posting_date,
             self.BOE.company_gstin,
             self.PI.supplier_name,
-            self.PI.place_of_supply,
             self.PI.is_reverse_charge,
             *tax_fields,
         ]
 
         # In IMPGSEZ supplier details are avaialble in 2A
-        purchase_fields = [
-            "supplier_gstin",
-            "gst_category",
-        ]
+        purchase_fields = ["supplier_gstin", "gst_category", "place_of_supply"]
 
         for field in purchase_fields:
             fields.append(


### PR DESCRIPTION
The place of supply is not available for IMPG transactions.
Frappe Support: https://support.frappe.io/app/hd-ticket/15193

Before
![image](https://github.com/resilient-tech/india-compliance/assets/108322669/2be2b2b6-ef81-482d-835b-561405ef6259)

After
![image](https://github.com/resilient-tech/india-compliance/assets/108322669/b3da1d85-58b1-4c8e-ad2f-c8d2c1ba6794)

