### PR TITLE
fix: do not include exports without payment Purchase Invoices in GSTR3b.

### DIFF
--- a/india_compliance/gst_india/doctype/gstr_3b_report/gstr_3b_report.py
+++ b/india_compliance/gst_india/doctype/gstr_3b_report/gstr_3b_report.py
@@ -267,6 +267,7 @@ class GSTR3BReport(Document):
             and (i.gst_treatment != 'Taxable' or p.gst_category = 'Registered Composition') and
             month(p.posting_date) = %s and year(p.posting_date) = %s
             and p.company = %s and p.company_gstin = %s
+            and p.gst_category != "Overseas"
             """,
             (self.month_no, self.year, self.company, self.gst_details.get("gstin")),
             as_dict=1,

--- a/india_compliance/gst_india/report/gstr_3b_details/gstr_3b_details.py
+++ b/india_compliance/gst_india/report/gstr_3b_details/gstr_3b_details.py
@@ -409,6 +409,7 @@ class GSTR3B_Inward_Nil_Exempt(BaseGSTR3BDetails):
                     purchase_invoice.company_gstin
                     != IfNull(purchase_invoice.supplier_gstin, "")
                 )
+                & (purchase_invoice.gst_category != "Overseas")
             )
             .groupby(purchase_invoice.name)
         )


### PR DESCRIPTION
Export Without Payment of GST will be shown from BIll of Entry only.
closes : #2189