### PR TITLE
fix: handle cases where public key is invalided

### DIFF
--- a/india_compliance/gst_india/api_classes/base.py
+++ b/india_compliance/gst_india/api_classes/base.py
@@ -154,6 +154,10 @@ class BaseAPI:
                     )
 
             response_json = self.process_response(response_json)
+
+            if response_json.get("error_type") == "invalid_public_key":
+                return self._make_request(method, endpoint, params, headers, json)
+
             return response_json.get("result", response_json)
 
         except Exception as e:


### PR DESCRIPTION
Error handled from GSTR-1:

```
{
    "error": {
        "error_cd": "TEC4002",
        "message": "Invalid Data Format"
    },
    "status_cd": 0
}
```

## Issue

GSTN updated public key every year. It may support 2 keys simultaneously for some duration.
GSP also updates the public key and may not support 2 keys simultaneously.

Hence this will help users update the key even if it's not expired and throws error.