### PR TITLE
fix: specify parenttype for purchase taxes

### DIFF
--- a/india_compliance/gst_india/doctype/purchase_reconciliation_tool/__init__.py
+++ b/india_compliance/gst_india/doctype/purchase_reconciliation_tool/__init__.py
@@ -434,6 +434,7 @@ class PurchaseInvoice:
             .where(self.PI.docstatus == 1)
             .where(IfNull(self.PI.reconciliation_status, "") != "Not Applicable")
             .where(self.PI.is_opening == "NO")
+            .where(self.PI_TAX.parenttype == "Purchase Invoice")
             .groupby(self.PI.name)
             .select(
                 *fields,

--- a/india_compliance/gst_india/report/gstr_3b_details/gstr_3b_details.py
+++ b/india_compliance/gst_india/report/gstr_3b_details/gstr_3b_details.py
@@ -526,6 +526,7 @@ class IneligibleITC:
                 IfNull(pi.ineligibility_reason, "") == "ITC restricted due to PoS rules"
             )
             .where(pi.name.isin(ineligible_transactions))
+            .where(taxes.parenttype == "Purchase Invoice")
             .groupby(pi[group_by])
             .run(as_dict=True)
         )


### PR DESCRIPTION
taxes table have multiple rows with same parent but different parenttype

Frappe Support Issue: https://support.frappe.io/app/hd-ticket/17339

