### PR TITLE
chore: switch to ruff for python formatting/linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,21 +15,15 @@ repos:
           - id: check-merge-conflict
           - id: check-ast
 
-    - repo: https://github.com/psf/black
-      rev: 24.1.1
+    - repo: https://github.com/astral-sh/ruff-pre-commit
+      rev: v0.4.0
       hooks:
-          - id: black
+          - id: ruff
+            name: "Run ruff linter and apply fixes"
+            args: ["--fix"]
 
-    - repo: https://github.com/PyCQA/isort
-      rev: 5.13.2
-      hooks:
-          - id: isort
-
-    - repo: https://github.com/PyCQA/flake8
-      rev: 7.0.0
-      hooks:
-          - id: flake8
-            additional_dependencies: [flake8-isort, flake8-bugbear]
+          - id: ruff-format
+            name: "Run ruff formatter"
 
 ci:
     autoupdate_schedule: weekly

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,13 +19,51 @@ dependencies = [
 requires = ["flit_core >=3.4,<4"]
 build-backend = "flit_core.buildapi"
 
-[tool.isort]
-profile = "black"
-known_frappe = "frappe"
-known_erpnext = "erpnext"
-no_lines_before = ["ERPNEXT"]
-sections = ["FUTURE", "STDLIB", "THIRDPARTY", "FRAPPE", "ERPNEXT", "FIRSTPARTY", "LOCALFOLDER"]
-
 [tool.bench.dev-dependencies]
 parameterized = "~=0.8.1"
 time-machine = "~=2.10.0"
+
+[tool.ruff]
+line-length = 110
+target-version = "py310"
+
+[tool.ruff.lint.isort.sections]
+frappe = ["frappe"]
+erpnext = ["erpnext"]
+
+[tool.ruff.lint.isort]
+no-lines-before = ["erpnext"]
+section-order = ["future", "standard-library", "third-party", "frappe", "erpnext", "first-party", "local-folder"]
+
+[tool.ruff.lint]
+select = [
+    "F",
+    "E",
+    "W",
+    "I",
+    "UP",
+    "B",
+    "RUF",
+]
+ignore = [
+    "B017", # assertRaises(Exception) - should be more specific
+    "B018", # useless expression, not assigned to anything
+    "B023", # function doesn't bind loop variable - will have last iteration's value
+    "B904", # raise inside except without from
+    "E101", # indentation contains mixed spaces and tabs
+    "E402", # module level import not at top of file
+    "E501", # line too long
+    "E741", # ambiguous variable name
+    "F401", # "unused" imports
+    "F403", # can't detect undefined names from * import
+    "F405", # can't detect undefined names from * import
+    "F722", # syntax error in forward type annotation
+    "W191", # indentation contains tabs
+    "RUF001", # string contains ambiguous unicode character
+    "B905", # `zip()` without an explicit `strict=` parameter
+]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+docstring-code-format = true


### PR DESCRIPTION
Switch to ruff, in order to stay consistent with the framework. It's a replacement for black, isort and flake8.