### PR TITLE
fix: do not execute patch if field does not exists

### DIFF
--- a/india_compliance/patches/v15/migrate_print_options_to_new_field.py
+++ b/india_compliance/patches/v15/migrate_print_options_to_new_field.py
@@ -2,6 +2,9 @@ import frappe
 
 
 def execute():
+    if not frappe.db.has_column("Company Print Options", "autofield"):
+        return
+
     doc = frappe.qb.DocType("Company Print Options")
 
     (


### PR DESCRIPTION
Error on migration from v14 to v15
```
patch = 'india_compliance.patches.v15.migrate_print_options_to_new_field'
  File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 62, in run_patch
    if not run_single(patchmodule=patch):
      patch = 'india_compliance.patches.v15.migrate_print_options_to_new_field'
      skip_failing = False
  File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 152, in run_single
    return execute_patch(patchmodule, method, methodargs)
      patchmodule = 'india_compliance.patches.v15.migrate_print_options_to_new_field'
      method = None
      methodargs = None
      force = False
      conf = <LocalProxy unbound>
  File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 188, in execute_patch
    _patch()
      patchmodule = 'india_compliance.patches.v15.migrate_print_options_to_new_field'
      method = None
      methodargs = None
      has_patch_file = True
      patch = 'india_compliance.patches.v15.migrate_print_options_to_new_field.execute'
      docstring = ''
      _patch = <function execute at 0x7f2905828900>
      start_time = 2371102.479421797
  File "/home/frappe/frappe-bench/apps/india_compliance/india_compliance/patches/v15/migrate_print_options_to_new_field.py", line 11, in execute
    .run()
      doc = Table('tabCompany Print Options')
  File "/home/frappe/frappe-bench/apps/frappe/frappe/query_builder/utils.py", line 87, in execute_query
    result = frappe.db.sql(query, params, *args, **kwargs)  # nosemgrep
      query = 'UPDATE `tabCompany Print Options` SET `print_label`=`autofield`,`print_value`=`autofield_value`'
      args = ()
      kwargs = {}
      child_queries = []
      params = {}
      execute_child_queries = <function patch_query_execute.<locals>.execute_child_queries at 0x7f290a9328e0>
      prepare_query = <function patch_query_execute.<locals>.prepare_query at 0x7f290a932980>
  File "/home/frappe/frappe-bench/apps/frappe/frappe/database/database.py", line 234, in sql
    self._cursor.execute(query, values)
      self = <frappe.database.mariadb.database.MariaDBDatabase object at 0x7f290a863810>
      query = 'UPDATE `tabCompany Print Options` SET `print_label`=`autofield`,`print_value`=`autofield_value`'
      values = {}
      as_dict = 0
      as_list = 0
      debug = False
      ignore_ddl = 0
      auto_commit = 0
      update = None
      explain = False
      run = True
      pluck = False
      as_iterator = False
      trace_id = None
  File "/home/frappe/frappe-bench/env/lib/python3.11/site-packages/pymysql/cursors.py", line 153, in execute
    result = self._query(query)
      self = <pymysql.cursors.Cursor object at 0x7f290ab7add0>
      query = 'UPDATE `tabCompany Print Options` SET `print_label`=`autofield`,`print_value`=`autofield_value`'
      args = {}
  File "/home/frappe/frappe-bench/env/lib/python3.11/site-packages/pymysql/cursors.py", line 322, in _query
    conn.query(q)
      self = <pymysql.cursors.Cursor object at 0x7f290ab7add0>
      q = 'UPDATE `tabCompany Print Options` SET `print_label`=`autofield`,`print_value`=`autofield_value`'
      conn = <pymysql.connections.Connection object at 0x7f290bd8a710>
  File "/home/frappe/frappe-bench/env/lib/python3.11/site-packages/pymysql/connections.py", line 563, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
      self = <pymysql.connections.Connection object at 0x7f290bd8a710>
      sql = b'UPDATE `tabCompany Print Options` SET `print_label`=`autofield`,`print_value`=`autofield_value`'
      unbuffered = False
  File "/home/frappe/frappe-bench/env/lib/python3.11/site-packages/pymysql/connections.py", line 825, in _read_query_result
    result.read()
      self = <pymysql.connections.Connection object at 0x7f290bd8a710>
      unbuffered = False
      result = <pymysql.connections.MySQLResult object at 0x7f290588ba50>
  File "/home/frappe/frappe-bench/env/lib/python3.11/site-packages/pymysql/connections.py", line 1199, in read
    first_packet = self.connection._read_packet()
      self = <pymysql.connections.MySQLResult object at 0x7f290588ba50>
  File "/home/frappe/frappe-bench/env/lib/python3.11/site-packages/pymysql/connections.py", line 775, in _read_packet
    packet.raise_for_error()
      self = <pymysql.connections.Connection object at 0x7f290bd8a710>
      packet_type = <class 'pymysql.protocol.MysqlPacket'>
      buff = bytearray(b"\xff\x1e\x04#42S22Unknown column \'autofield\' in \'field list\'")
      packet_header = b'3\x00\x00\x01'
      btrl = 51
      btrh = 0
      packet_number = 1
      bytes_to_read = 51
      recv_data = b"\xff\x1e\x04#42S22Unknown column 'autofield' in 'field list'"
      packet = <pymysql.protocol.MysqlPacket object at 0x7f2905e46290>
  File "/home/frappe/frappe-bench/env/lib/python3.11/site-packages/pymysql/protocol.py", line 219, in raise_for_error
    err.raise_mysql_exception(self._data)
      self = <pymysql.protocol.MysqlPacket object at 0x7f2905e46290>
      errno = 1054
  File "/home/frappe/frappe-bench/env/lib/python3.11/site-packages/pymysql/err.py", line 150, in raise_mysql_exception
    raise errorclass(errno, errval)
      data = b"\xff\x1e\x04#42S22Unknown column 'autofield' in 'field list'"
      errno = 1054
      errval = "Unknown column 'autofield' in 'field list'"
      errorclass = <class 'pymysql.err.OperationalError'>
pymysql.err.OperationalError: (1054, "Unknown column 'autofield' in 'field list'")
```
Frappe Support Issue: https://support.frappe.io/app/hd-ticket/18168