### PR TITLE
fix: Update Taxes for Items

### DIFF
--- a/india_compliance/gst_india/doctype/gst_hsn_code/gst_hsn_code.js
+++ b/india_compliance/gst_india/doctype/gst_hsn_code/gst_hsn_code.js
@@ -3,7 +3,7 @@
 
 frappe.ui.form.on('GST HSN Code', {
 	refresh: function(frm) {
-		if(! frm.doc.__islocal && frm.doc.taxes.length){
+		if(!frm.doc.__islocal){
 			frm.add_custom_button(__('Update Taxes for Items'), function(){
 				frappe.confirm(
 					'Are you sure? It will overwrite taxes for all items with HSN Code <b>'+frm.doc.name+'</b>.',


### PR DESCRIPTION
**Version 15**

fixes: https://github.com/frappe/erpnext/issues/42241

**Before:**

- If you remove all taxes from the GST HSN Code, the "Update Taxes for Items" button disappears. This means you can't update taxes for all items at once and have to remove taxes from each item individually, which is a time-consuming process.

https://github.com/resilient-tech/india-compliance/assets/141945075/58316bff-437a-4b79-8fd2-deb10efe833d


**After:**

- remove `frm.doc.taxes.length` from `if condition`

https://github.com/resilient-tech/india-compliance/assets/141945075/524bae18-2ae4-4451-ad55-f0e3ad3b721f

