### PR TITLE
ci: configuration for codecov to avoid incorrect flag of failures

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,33 @@
+codecov:
+  require_ci_to_pass: true
+
+comment:
+  behavior: default
+  layout: reach,diff,flags,tree,reach
+  show_carryforward_flags: false
+
+coverage:
+  precision: 2
+  round: down
+  status:
+    changes: false
+    default_rules:
+      flag_coverage_not_uploaded_behavior: include
+    
+    patch:
+      default:
+        base: auto
+        branches:
+        - ^develop$
+        if_ci_failed: ignore
+        only_pulls: true
+        target: 85%
+        threshold: 1%
+    
+    project: 
+      default:
+        base: auto
+        threshold: 20%
+
+github_checks:
+  annotations: true


### PR DESCRIPTION
Project Threshold of 20% will allow coverage less by 20% from last coverage.

<sub><a href="https://huly.app/guest/resilienttech?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjkyNmIwMDIwOTUyNGNjNGY5ZTY2OTEiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6Inctc21pdHZvcmEyMDMtcmVzaWxpZW50dGVjLTY2N2U0MjkxLWEwNWMwNjY4N2EtNjM4MjY3IiwicHJvZHVjdElkIjoiIn0.n4pAxTQhLwcOO4DsCqtGw0Py2n4Rh3Fp6njWOBStJAU">Huly&reg;: <b>IC-2541</b></a></sub>