### PR TITLE
fix: sub supply type "Others" for e-waybill in DN

### DIFF
--- a/india_compliance/gst_india/client_scripts/e_waybill_actions.js
+++ b/india_compliance/gst_india/client_scripts/e_waybill_actions.js
@@ -378,7 +378,6 @@ function get_generate_e_waybill_dialog(opts, frm) {
                     : "",
             onchange: () => validate_gst_transporter_id(d),
         },
-        // Sub Supply Type will be visible here for Delivery Note
         {
             label: "Part B",
             fieldname: "section_part_b",
@@ -444,6 +443,33 @@ function get_generate_e_waybill_dialog(opts, frm) {
             default: options[0],
             read_only: options.length === 1,
             reqd: 1,
+        },{
+            label: "Sub Supply Description",
+            fieldname: "sub_supply_desc",
+            fieldtype: "Data",
+            depends_on: "eval: doc.sub_supply_type == 'Others'",
+            mandatory_depends_on: "eval: doc.sub_supply_type == 'Others'",
+        });
+    }
+    else{
+        const default_supply_types = {
+            "Sales Invoice_0": { sub_supply_type: "Supply" },
+            "Sales Invoice_1": { sub_supply_type: "Sales Return" },
+            "Purchase Invoice_0": { sub_supply_type: "Supply" },
+            "Purchase Invoice_1": { sub_supply_type: "Others" },
+            "Purchase Receipt_0": { sub_supply_type: "Supply" },
+            "Purchase Receipt_1": { sub_supply_type: "Others" },
+        };
+
+        const key = `${frm.doctype}_${frm.doc.is_return}`;
+        const default_sub_supply_type = default_supply_types[key].sub_supply_type;
+
+        fields.splice(5, 0, {
+            label: "Sub Supply Type",
+            fieldname: "sub_supply_type",
+            fieldtype: "Data",
+            default: default_sub_supply_type,
+            read_only: 1,
         });
     }
 
@@ -488,9 +514,9 @@ function get_sub_suppy_type_options(frm) {
 
         if (frm.doc.is_return) {
             if (same_gstin) {
-                options = ["For Own Use", "Exhibition or Fairs"];
+                options = ["For Own Use", "Exhibition or Fairs","Others"];
             } else {
-                options = ["Job Work Returns", "SKD/CKD"];
+                options = ["Job Work Returns", "SKD/CKD","Others"];
             }
         } else {
             if (same_gstin) {
@@ -499,9 +525,10 @@ function get_sub_suppy_type_options(frm) {
                     "Exhibition or Fairs",
                     "Line Sales",
                     "Recipient Not Known",
+                    "Others",
                 ];
             } else {
-                options = ["Job Work", "SKD/CKD"];
+                options = ["Job Work", "SKD/CKD","Others"];
             }
         }
     } else if (frm.doctype === "Stock Entry") {

--- a/india_compliance/gst_india/constants/e_waybill.py
+++ b/india_compliance/gst_india/constants/e_waybill.py
@@ -1,15 +1,6 @@
 # Just for reference
-# SUPPLY_TYPES = {"Inward": "I", "Outward": "O"}
-#
-# DOCUMENT_TYPES = {
-#     "Tax Invoice": "INV",
-#     "Bill of Supply": "BIL",
-#     "Bill of Entry": "BOE",
-#     "Delivery Challan": "CHL",
-#     "Others": "OTH",
-# }
-#
 # DATETIME_FORMAT = "%d/%m/%Y %I:%M:%S %p"
+
 selling_address = {
     "bill_from": "company_address",
     "bill_to": "customer_address",
@@ -61,6 +52,14 @@ EXTEND_VALIDITY_REASON_CODES = {
     "Transshipment": 4,
     "Accident": 5,
     "Others": 99,
+}
+
+DOCUMENT_TYPES = {
+    "Tax Invoice": "INV",
+    "Bill of Supply": "BIL",
+    "Bill of Entry": "BOE",
+    "Delivery Challan": "CHL",
+    "Others": "OTH",
 }
 
 SUPPLY_TYPES = {

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -999,6 +999,8 @@ def update_transaction(doc, values):
 
     if doc.doctype in ("Delivery Note", "Stock Entry", "Subcontracting Receipt"):
         doc._sub_supply_type = SUB_SUPPLY_TYPES[values.sub_supply_type]
+    if doc.doctype == "Delivery Note":
+        doc._sub_supply_desc = values.sub_supply_desc
 
 
 def get_e_waybill_info(doc):
@@ -1450,11 +1452,13 @@ class EWaybillData(GSTTransactionData):
             ("Delivery Note", 0): {
                 "supply_type": "O",
                 "sub_supply_type": doc.get("_sub_supply_type", ""),
+                "sub_supply_desc": doc.get("_sub_supply_desc", ""),
                 "document_type": "CHL",
             },
             ("Delivery Note", 1): {
                 "supply_type": "I",
                 "sub_supply_type": doc.get("_sub_supply_type", ""),
+                "sub_supply_desc": doc.get("_sub_supply_desc", ""),
                 "document_type": "CHL",
             },
             ("Purchase Invoice", 0): {


### PR DESCRIPTION
closes: #2212

### Add more verbosity for default options

![image_2024-07-24_16-23-05](https://github.com/user-attachments/assets/325da25e-cf3b-4bc6-a85b-8e78e25a37b2)

<sub><a href="https://huly.app/guest/resilienttech?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NjlmYjQzYzdmMDllZGM1NjA2MTk5NzgiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6Inctc21pdHZvcmEyMDMtcmVzaWxpZW50dGVjLTY2N2U0MjkxLWEwNWMwNjY4N2EtNjM4MjY3IiwicHJvZHVjdElkIjoiIn0.1V6RSX8HVVfgbBuYfI9zT3ce3Wcg-fzo3F-omaV5P90">Huly&reg;: <b>IC-2581</b></a></sub>