### PR TITLE
fix: Use Job Worker instead of Supplier for Subcontracting

### DIFF
--- a/india_compliance/gst_india/constants/custom_fields.py
+++ b/india_compliance/gst_india/constants/custom_fields.py
@@ -71,7 +71,7 @@ CUSTOM_FIELDS = {
     ("Subcontracting Order", "Subcontracting Receipt"): [
         {
             "fieldname": "supplier_gstin",
-            "label": "Supplier GSTIN",
+            "label": "Job Worker GSTIN",
             "fieldtype": "Data",
             "insert_after": "address_display",
             "fetch_from": "supplier_address.gstin",


### PR DESCRIPTION
Related changes for erpnext:
https://github.com/frappe/erpnext/pull/42383

<sub><a href="https://huly.app/guest/resilienttech?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NmExZWNhZTdmMDllZGM1NjA2MWNjMTgiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6Inctc21pdHZvcmEyMDMtcmVzaWxpZW50dGVjLTY2N2U0MjkxLWEwNWMwNjY4N2EtNjM4MjY3IiwicHJvZHVjdElkIjoiIn0.mXPeut5dx4EtWfTAjB_Lg2GBv0tcHOkNaIOQEF3CkT8">Huly&reg;: <b>IC-2585</b></a></sub>