### PR TITLE
fix: always use `frappe.get_meta` in `set_tax_amount_precisions`

### DIFF
--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -1230,7 +1230,7 @@ class ItemGSTDetails:
         return response
 
     def set_tax_amount_precisions(self, doctype):
-        doc_meta = self.doc.meta if self.doc.meta else frappe.get_meta(doctype)
+        doc_meta = getattr(self, "doc", {}).get("meta", frappe.get_meta(doctype))
         item_doctype = doc_meta.get_field("items").options
 
         meta = frappe.get_meta(item_doctype)

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -1230,8 +1230,7 @@ class ItemGSTDetails:
         return response
 
     def set_tax_amount_precisions(self, doctype):
-        doc_meta = getattr(self, "doc", {}).get("meta", frappe.get_meta(doctype))
-        item_doctype = doc_meta.get_field("items").options
+        item_doctype = frappe.get_meta(doctype).get_field("items").options
 
         meta = frappe.get_meta(item_doctype)
 


### PR DESCRIPTION
Traceback :

```
Traceback with variables (most recent call last):
  File "apps/frappe/frappe/commands/site.py", line 445, in install_app
    _install_app(app, verbose=context.verbose, force=force)
      context = {'sites': ['hkmvizagerp.frappe.cloud'], 'force': False, 'verbose': False, 'profile': False}
      apps = ('india_compliance',)
      force = True
      _install_app = <function install_app at 0x7f61eddb5800>
      filelock = <function filelock at 0x7f61edfa6a20>
      exit_code = 0
      site = 'hkmvizagerp.frappe.cloud'
      app = 'india_compliance'
      err = AttributeError("'ItemGSTDetails' object has no attribute 'doc'")
  File "apps/frappe/frappe/installer.py", line 311, in install_app
    frappe.get_attr(after_install)()
      name = 'india_compliance'
      verbose = False
      set_as_patched = True
      force = True
      sync_jobs = <function sync_jobs at 0x7f61ecda2c00>
      sync_for = <function sync_for at 0x7f61ecda3a60>
      sync_customizations = <function sync_customizations at 0x7f61edf43240>
      sync_fixtures = <function sync_fixtures at 0x7f61ecda3d80>
      app_hooks = {'accounting_dimension_doctypes': ['Bill of Entry', 'Bill of Entry Item'], 'after_app_install': ['india_compliance.install.after_app_install'], 'after_install': ['india_compliance.install.after_install'], 'after_migrate': ['india_compliance.audit_trail.setup.after_migrate'], 'app_color': ['grey'], 'app_description': ['ERPNext app to simplify compliance with Indian Rules and Regulations'], 'app_email': ['hello@indiacompliance.app'], 'app_icon': ['octicon octicon-file-directory'], 'app_include_css': ['india_compliance.bundle.css'], 'app_include_js': ['india_compliance.bundle.js'], 'app_license': ['GNU General Public License (v3)'], 'app_name': ['india_compliance'], 'app_publisher': ['Resilient Tech'], 'app_title': ['India Compliance'], 'audit_trail_doctypes': ['Accounts Settings', 'Dunning', 'Invoice Discounting', 'Journal Entry', 'Payment Entry', 'Period Closing Voucher', 'Process Deferred Accounting', 'Purchase Invoice', 'Sales Invoice', 'Asset', 'Asset Capitalization', 'Asset Repair',...
      installed_apps = ['frappe', 'erpnext', 'bizmaphkm', 'hkm', 'non_profit', 'education', 'healthcare', 'hrms', 'payments', 'india_compliance']
      app = 'frappe/erpnext'
      required_app = 'erpnext'
      before_install = 'india_compliance.patches.check_version_compatibility.execute'
      out = None
      after_install = 'india_compliance.install.after_install'
  File "apps/india_compliance/india_compliance/install.py", line 74, in after_install
    raise e
  File "apps/india_compliance/india_compliance/install.py", line 63, in after_install
    run_post_install_patches()
  File "apps/india_compliance/india_compliance/install.py", line 87, in run_post_install_patches
    frappe.get_attr(f"india_compliance.patches.post_install.{patch}.execute")()
      patch = 'improve_item_tax_template'
  File "apps/india_compliance/india_compliance/patches/post_install/improve_item_tax_template.py", line 63, in execute
    update_gst_details_for_transactions(companies)
      companies = ['Touchstone Foundation Visakhapatnam', 'Hare Krishna Movement India', 'Touchstone Charities Visakhapatnam', 'Hare Krishna Movement Visakhapatnam']
      templates = {'Nil-Rated': ['Nil-Rated - HKMV', 'Nil-Rated - TSF', 'Nil-Rated - TSC', 'Nil-Rated - HKMI'], 'Exempted': ['Exempted - HKMV', 'Exempted - TSF', 'Exempted - TSC', 'Exempted - HKMI'], 'Non-GST': ['Non-GST - HKMV', 'Non-GST - TSF', 'Non-GST - TSC', 'Non-GST - HKMI']}
  File "apps/india_compliance/india_compliance/patches/post_install/improve_item_tax_template.py", line 339, in update_gst_details_for_transactions
    _update_gst_details(company, doctype, is_sales_doctype, docs)
      companies = ['Touchstone Foundation Visakhapatnam', 'Hare Krishna Movement India', 'Touchstone Charities Visakhapatnam', 'Hare Krishna Movement Visakhapatnam']
      company = 'Touchstone Foundation Visakhapatnam'
      gst_accounts = ['Input Tax CGST - TSF', 'Input Tax SGST - TSF', 'Input Tax IGST - TSF', None, None, 'Output Tax CGST - TSF', 'Output Tax SGST - TSF', 'Output Tax IGST - TSF', None, None]
      account_type = 'Output'
      doctype = 'Sales Invoice'
      is_sales_doctype = True
      docs = ['SI/24-25/F0056', 'SI/24-25/F0063', 'SI/24-25/F0163', 'SI/24-25/F0167', 'SI/24-25/F0065', 'SI/24-25/F0067', 'SI/24-25/F0097', 'SI/24-25/F0129', 'SI/24-25/F0149', 'SI/24-25/F0153', 'SI/24-25/F0222', 'SI/24-25/F0237', 'SI/24-25/F0253']
  File "apps/india_compliance/india_compliance/patches/post_install/improve_item_tax_template.py", line 360, in _update_gst_details
    gst_details = ItemGSTDetails().get(complied_docs.values(), doctype, company)
      company = 'Touchstone Foundation Visakhapatnam'
      doctype = 'Sales Invoice'
      is_sales_doctype = True
      docs = ['SI/24-25/F0056', 'SI/24-25/F0063', 'SI/24-25/F0163', 'SI/24-25/F0167', 'SI/24-25/F0065', 'SI/24-25/F0067', 'SI/24-25/F0097', 'SI/24-25/F0129', 'SI/24-25/F0149', 'SI/24-25/F0153', 'SI/24-25/F0222', 'SI/24-25/F0237', 'SI/24-25/F0253']
      chunk_size = 100
      total_docs = 13
      bar = <click._termui_impl.ProgressBar object at 0x7f61eae38dd0>
      index = 0
      chunk = ['SI/24-25/F0056', 'SI/24-25/F0063', 'SI/24-25/F0163', 'SI/24-25/F0167', 'SI/24-25/F0065', 'SI/24-25/F0067', 'SI/24-25/F0097', 'SI/24-25/F0129', 'SI/24-25/F0149', 'SI/24-25/F0153', 'SI/24-25/F0222', 'SI/24-25/F0237', 'SI/24-25/F0253']
      taxes = [{'base_tax_amount_after_discount_amount': 1314.6431, 'gst_tax_type': 'cgst', 'parent': 'SI/24-25/F0056', 'item_wise_tax_detail': '{"STO-ITEM-2024-00005":[6.0,1314.6430679999999]}'}, {'base_tax_amount_after_discount_amount': 1314.6431, 'gst_tax_type': 'sgst', 'parent': 'SI/24-25/F0056', 'item_wise_tax_detail': '{"STO-ITEM-2024-00005":[6.0,1314.6430679999999]}'}, {'base_tax_amount_after_discount_amount': 87.0345, 'gst_tax_type': 'cgst', 'parent': 'SI/24-25/F0063', 'item_wise_tax_detail': '{"FNG-00035":[2.5,31.5],"FNG-00130":[2.5,4.5],"FNG-00040":[2.5,6.0],"FNG-00099":[2.5,12.5],"FNG-00018":[2.5,10.0],"FNG-00055":[2.5,9.784500000000001],"FNG-00038":[2.5,12.75]}'}, {'base_tax_amount_after_discount_amount': 87.0345, 'gst_tax_type': 'sgst', 'parent': 'SI/24-25/F0063', 'item_wise_tax_detail': '{"FNG-00035":[2.5,31.5],"FNG-00130":[2.5,4.5],"FNG-00040":[2.5,6.0],"FNG-00099":[2.5,12.5],"FNG-00018":[2.5,10.0],"FNG-00055":[2.5,9.784500000000001],"FNG-00038":[2.5,12.75]}'}, {'base_tax_amount_after...
      items = [{'name': '774bdab989', 'parent': 'SI/24-25/F0056', 'item_code': 'STO-ITEM-2024-00005', 'item_name': 'Sale of Gift articles 12%', 'qty': 606.0, 'taxable_value': 21910.7178}, {'name': '14a05dde8a', 'parent': 'SI/24-25/F0063', 'item_code': 'FNG-00040', 'item_name': 'SAMBAR - 1KG', 'qty': 2.0, 'taxable_value': 240.0}, {'name': '6014f57bfd', 'parent': 'SI/24-25/F0063', 'item_code': 'FNG-00038', 'item_name': 'CURD RICE -1KG', 'qty': 3.0, 'taxable_value': 510.0}, {'name': 'b175da5fc2', 'parent': 'SI/24-25/F0063', 'item_code': 'FNG-00018', 'item_name': 'BORRELU - POORNALU - 1KG', 'qty': 20.0, 'taxable_value': 400.0}, {'name': 'c44d662ebc', 'parent': 'SI/24-25/F0063', 'item_code': 'FNG-00099', 'item_name': 'VADA / MINAPA GARELU', 'qty': 20.0, 'taxable_value': 500.0}, {'name': 'dfea94b4f3', 'parent': 'SI/24-25/F0063', 'item_code': 'FNG-00055', 'item_name': 'SWEET PONGAL - 1KG', 'qty': 2.0, 'taxable_value': 391.38}, {'name': 'fb9f983369', 'parent': 'SI/24-25/F0063', 'item_code': 'FNG-00035', 'it...
      complied_docs = {'SI/24-25/F0056': {'taxes': [{'base_tax_amount_after_discount_amount': 1314.6431, 'gst_tax_type': 'cgst', 'parent': 'SI/24-25/F0056', 'item_wise_tax_detail': '{"STO-ITEM-2024-00005":[6.0,1314.6430679999999]}'}, {'base_tax_amount_after_discount_amount': 1314.6431, 'gst_tax_type': 'sgst', 'parent': 'SI/24-25/F0056', 'item_wise_tax_detail': '{"STO-ITEM-2024-00005":[6.0,1314.6430679999999]}'}], 'items': [{'name': '774bdab989', 'parent': 'SI/24-25/F0056', 'item_code': 'STO-ITEM-2024-00005', 'item_name': 'Sale of Gift articles 12%', 'qty': 606.0, 'taxable_value': 21910.7178}], 'doctype': 'Sales Invoice'}, 'SI/24-25/F0063': {'taxes': [{'base_tax_amount_after_discount_amount': 87.0345, 'gst_tax_type': 'cgst', 'parent': 'SI/24-25/F0063', 'item_wise_tax_detail': '{"FNG-00035":[2.5,31.5],"FNG-00130":[2.5,4.5],"FNG-00040":[2.5,6.0],"FNG-00099":[2.5,12.5],"FNG-00018":[2.5,10.0],"FNG-00055":[2.5,9.784500000000001],"FNG-00038":[2.5,12.75]}'}, {'base_tax_amount_after_discount_amount': 87.0345, 'gst_t...
  File "apps/india_compliance/india_compliance/gst_india/overrides/transaction.py", line 1185, in get
    self.set_tax_amount_precisions(doctype)
      self = <india_compliance.gst_india.overrides.transaction.ItemGSTDetails object at 0x7f61e9685850>
      docs = dict_values([{'taxes': [{'base_tax_amount_after_discount_amount': 1314.6431, 'gst_tax_type': 'cgst', 'parent': 'SI/24-25/F0056', 'item_wise_tax_detail': '{"STO-ITEM-2024-00005":[6.0,1314.6430679999999]}'}, {'base_tax_amount_after_discount_amount': 1314.6431, 'gst_tax_type': 'sgst', 'parent': 'SI/24-25/F0056', 'item_wise_tax_detail': '{"STO-ITEM-2024-00005":[6.0,1314.6430679999999]}'}], 'items': [{'name': '774bdab989', 'parent': 'SI/24-25/F0056', 'item_code': 'STO-ITEM-2024-00005', 'item_name': 'Sale of Gift articles 12%', 'qty': 606.0, 'taxable_value': 21910.7178}], 'doctype': 'Sales Invoice'}, {'taxes': [{'base_tax_amount_after_discount_amount': 87.0345, 'gst_tax_type': 'cgst', 'parent': 'SI/24-25/F0063', 'item_wise_tax_detail': '{"FNG-00035":[2.5,31.5],"FNG-00130":[2.5,4.5],"FNG-00040":[2.5,6.0],"FNG-00099":[2.5,12.5],"FNG-00018":[2.5,10.0],"FNG-00055":[2.5,9.784500000000001],"FNG-00038":[2.5,12.75]}'}, {'base_tax_amount_after_discount_amount': 87.0345, 'gst_tax_type': 'sgst', 'paren...
      doctype = 'Sales Invoice'
      company = 'Touchstone Foundation Visakhapatnam'
  File "apps/india_compliance/india_compliance/gst_india/overrides/transaction.py", line 1352, in set_tax_amount_precisions
    doc_meta = self.doc.meta if self.doc.meta else frappe.get_meta(doctype)
      self = <india_compliance.gst_india.overrides.transaction.ItemGSTDetails object at 0x7f61e9685850>
      doctype = 'Sales Invoice'
builtins.AttributeError: 'ItemGSTDetails' object has no attribute 'doc'
```

<sub><a href="https://huly.app/guest/resilienttech?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NmFjODE1YTA0Mzg2NzIxODQ0NzMzMjQiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6Inctc21pdHZvcmEyMDMtcmVzaWxpZW50dGVjLTY2N2U0MjkxLWEwNWMwNjY4N2EtNjM4MjY3IiwicHJvZHVjdElkIjoiIn0._nJxbDOElCAJgl3BUwgCuk622h2lcqR-KIEpE4eaN0o">Huly&reg;: <b>IC-2612</b></a></sub>