### PR TITLE
fix: Respect Company Filter in Purchase Reconciliation Tool

### DIFF
--- a/india_compliance/gst_india/data/test_purchase_reconciliation_tool.json
+++ b/india_compliance/gst_india/data/test_purchase_reconciliation_tool.json
@@ -110,17 +110,17 @@
         "TEST_DIFFERENT_COMPANY_GSTIN_MISMATCH": [
             {
                 "PURCHASE_INVOICE": {
-                    "bill_no": "BILL-23-00021",
+                    "bill_no": "BILLXYZ-23-00021",
                     "company_gstin": "24AAQCA8719H1ZC"
                 },
                 "INWARD_SUPPLY": {
-                    "bill_no": "BILL-23-00021",
+                    "bill_no": "BILLXYZ-23-00021",
                     "company_gstin": "29AABCR1718E1ZL"
                 },
                 "RECONCILED_DATA": {
                     "action": "No Action",
                     "bill_date": "2023-12-11",
-                    "bill_no": "BILL-23-00021",
+                    "bill_no": "BILLXYZ-23-00021",
                     "classification": "B2B",
                     "differences": "COMPANY_GSTIN",
                     "inward_supply_company_gstin": "29AABCR1718E1ZL",

--- a/india_compliance/gst_india/doctype/purchase_reconciliation_tool/__init__.py
+++ b/india_compliance/gst_india/doctype/purchase_reconciliation_tool/__init__.py
@@ -439,6 +439,9 @@ class PurchaseInvoice:
             )
         )
 
+        if self.company:
+            query = query.where(self.company == self.PI.company)
+
         if self.company_gstin == "All":
             query = query.where(self.PI.company_gstin.notnull())
         else:
@@ -586,6 +589,14 @@ class BillOfEntry:
             .groupby(self.BOE.name)
             .select(*fields, ConstantColumn("Bill of Entry").as_("doctype"))
         )
+
+        if self.company:
+            query = query.where(self.company == self.BOE.company)
+
+        if self.company_gstin == "All":
+            query = query.where(self.BOE.company_gstin.notnull())
+        else:
+            query = query.where(self.company_gstin == self.BOE.company_gstin)
 
         if self.include_ignored == 0:
             query = query.where(IfNull(self.BOE.reconciliation_status, "") != "Ignored")

--- a/india_compliance/gst_india/doctype/purchase_reconciliation_tool/__init__.py
+++ b/india_compliance/gst_india/doctype/purchase_reconciliation_tool/__init__.py
@@ -13,7 +13,7 @@ from frappe.query_builder.functions import Abs, IfNull, Sum
 from frappe.utils import add_months, format_date, getdate, rounded
 
 from india_compliance.gst_india.constants import GST_TAX_TYPES
-from india_compliance.gst_india.utils import get_party_for_gstin
+from india_compliance.gst_india.utils import get_gstin_list, get_party_for_gstin
 from india_compliance.gst_india.utils.gstr_2 import IMPORT_CATEGORY, ReturnType
 
 
@@ -306,7 +306,12 @@ class InwardSupply:
         )
 
         if self.company_gstin == "All":
-            query = query.where(self.GSTR2.company_gstin.notnull())
+            if self.company:
+                gstin_list = get_gstin_list(self.company)
+                query = query.where(self.GSTR2.company_gstin.isin(gstin_list))
+            else:
+                query = query.where(self.GSTR2.company_gstin.notnull())
+
         else:
             query = query.where(self.company_gstin == self.GSTR2.company_gstin)
 
@@ -679,6 +684,7 @@ class BaseReconciliation:
         self, additional_fields=None, names=None, only_names=False
     ):
         return InwardSupply(
+            company=self.company,
             company_gstin=self.company_gstin,
             from_date=self.inward_supply_from_date,
             to_date=self.inward_supply_to_date,
@@ -688,6 +694,7 @@ class BaseReconciliation:
 
     def get_unmatched_inward_supply(self, category, amended_category):
         return InwardSupply(
+            company=self.company,
             company_gstin=self.company_gstin,
             from_date=self.inward_supply_from_date,
             to_date=self.inward_supply_to_date,
@@ -697,6 +704,7 @@ class BaseReconciliation:
 
     def query_inward_supply(self, additional_fields=None):
         query = InwardSupply(
+            company=self.company,
             company_gstin=self.company_gstin,
             from_date=self.inward_supply_from_date,
             to_date=self.inward_supply_to_date,

--- a/india_compliance/gst_india/doctype/purchase_reconciliation_tool/test_purchase_reconciliation_tool.py
+++ b/india_compliance/gst_india/doctype/purchase_reconciliation_tool/test_purchase_reconciliation_tool.py
@@ -80,7 +80,7 @@ class TestPurchaseReconciliationTool(FrappeTestCase):
         purchase_reconciliation_tool = frappe.get_doc("Purchase Reconciliation Tool")
         purchase_reconciliation_tool.update(
             {
-                "company": "_Test Indian Registered Company",
+                # Reconcile all companies
                 "company_gstin": "All",
                 "purchase_from_date": "2023-11-01",
                 "purchase_to_date": "2023-12-31",


### PR DESCRIPTION
closes: #2450

<sub><a href="https://huly.app/guest/resilienttech?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NmIzNjdhZDMxNzgzMzIwZjc3ZTgzM2YiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6Inctc21pdHZvcmEyMDMtcmVzaWxpZW50dGVjLTY2N2U0MjkxLWEwNWMwNjY4N2EtNjM4MjY3IiwicHJvZHVjdElkIjoiIn0.5SPAmQ6Juy40JXtLeDGdca9KElFjcTZBYI28qJz7Awk">Huly&reg;: <b>IC-2623</b></a></sub>