### PR TITLE
fix: better permission check for viewing pending vouchers

### DIFF
--- a/india_compliance/gst_india/report/gst_balance/gst_balance.py
+++ b/india_compliance/gst_india/report/gst_balance/gst_balance.py
@@ -39,7 +39,7 @@ def execute(filters=None):
 
 @frappe.whitelist()
 def get_pending_voucher_types(company=None):
-    frappe.has_permission("GST Settings", "write", throw=True)
+    frappe.has_permission("GST Settings", "read", throw=True)
 
     company_accounts = ""
     if company:


### PR DESCRIPTION
https://discuss.frappe.io/t/gst-setting-write-access-for-gst-balance-report/131260

This ensures that someone with read permissions will still be able to update the docs with Company GSTIN with appropriate doc permissions.

This can finally be then executed by someone with write permissions for the doc.

<sub><a href="https://huly.app/guest/resilienttech?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NmM2ZjI2NjhjMmMxOTBhN2E0ZDE2YWIiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6Inctc21pdHZvcmEyMDMtcmVzaWxpZW50dGVjLTY2N2U0MjkxLWEwNWMwNjY4N2EtNjM4MjY3IiwicHJvZHVjdElkIjoiIn0.O6F7iluKtJAFnk-LYsuuMuD8khYyKU0YKWbxW8H4kqA">Huly&reg;: <b>IC-2651</b></a></sub>