### PR TITLE
fix: adjust depreciation when daily pro-rata is enabled

### DIFF
--- a/india_compliance/income_tax_india/overrides/asset_depreciation_schedule.py
+++ b/india_compliance/income_tax_india/overrides/asset_depreciation_schedule.py
@@ -89,7 +89,7 @@ def get_wdv_or_dd_depr_amount(
                 flt(fb_row.rate_of_depreciation) / 100
             )
             # if leap year, then consider 366 days
-            if cint(schedule_date.year) % 4 == 0:
+            if cint(schedule_date.year) % 4 == 0 and fb_row.daily_prorata_based:
                 depreciation_amount = depreciation_amount * 366 / 365
     elif fb_row.frequency_of_depreciation == 1:
         if fb_row.daily_prorata_based:


### PR DESCRIPTION
The leap year depreciation adjustments should happen only when the daily pro-rata checkbox is enabled.

<sub><a href="https://huly.app/guest/resilienttech?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NmM4ZGVlMThjMmMxOTBhN2E1ZmVkNzciLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6Inctc21pdHZvcmEyMDMtcmVzaWxpZW50dGVjLTY2N2U0MjkxLWEwNWMwNjY4N2EtNjM4MjY3IiwicHJvZHVjdElkIjoiIn0.iV2XeyquezKbr9U8AmnilPqZcf8Dre_lW3DscC2ytRE">Huly&reg;: <b>IC-2680</b></a></sub>