### PR TITLE
fix: Remove unused "reason_for_issuing_document" field

### DIFF
--- a/india_compliance/gst_india/constants/custom_fields.py
+++ b/india_compliance/gst_india/constants/custom_fields.py
@@ -953,21 +953,6 @@ CUSTOM_FIELDS = {
             ),
             "translatable": 0,
         },
-        {
-            "fieldname": "reason_for_issuing_document",
-            "label": "Reason For Issuing Document",
-            "fieldtype": "Select",
-            "insert_after": "return_against",
-            "print_hide": 1,
-            "depends_on": "eval:doc.is_return == 1",
-            "length": 45,
-            "options": (
-                "\n01-Sales Return\n02-Post Sale Discount\n03-Deficiency in"
-                " services\n04-Correction in Invoice\n05-Change in POS\n06-Finalization"
-                " of Provisional assessment\n07-Others"
-            ),
-            "translatable": 0,
-        },
     ],
     (
         "Sales Taxes and Charges",

--- a/india_compliance/gst_india/overrides/test_advance_payment_entry.py
+++ b/india_compliance/gst_india/overrides/test_advance_payment_entry.py
@@ -107,7 +107,6 @@ class TestAdvancePaymentEntry(FrappeTestCase):
             is_in_state=1,
             is_return=1,
             qty=-1,
-            reason_for_issuing_document="01-Sales Return",
             return_against=invoice_doc.name,
         )
 

--- a/india_compliance/gst_india/report/gstr_1/gstr_1.py
+++ b/india_compliance/gst_india/report/gstr_1/gstr_1.py
@@ -78,7 +78,6 @@ class Gstr1Report:
             port_code,
             shipping_bill_number,
             shipping_bill_date,
-            reason_for_issuing_document,
             company_gstin,
             (
                 CASE

--- a/india_compliance/patches.txt
+++ b/india_compliance/patches.txt
@@ -7,7 +7,7 @@ india_compliance.patches.v14.set_default_for_overridden_accounts_setting
 execute:from india_compliance.gst_india.setup import create_custom_fields; create_custom_fields() #54
 execute:from india_compliance.gst_india.setup import create_property_setters; create_property_setters() #8
 execute:from india_compliance.income_tax_india.setup import create_custom_fields; create_custom_fields() #2
-india_compliance.patches.post_install.remove_old_fields #1
+india_compliance.patches.post_install.remove_old_fields #2
 india_compliance.patches.post_install.set_gst_tax_type
 india_compliance.patches.post_install.set_gst_tax_type_in_journal_entry
 india_compliance.patches.post_install.update_company_gstin

--- a/india_compliance/patches/post_install/remove_old_fields.py
+++ b/india_compliance/patches/post_install/remove_old_fields.py
@@ -19,6 +19,7 @@ def execute():
     delete_old_fields("pan_details", "Company")
     delete_old_fields("export_type", ("Customer", "Supplier"))
     delete_old_fields("company_address", "Journal Entry")
+    delete_old_fields("reason_for_issuing_document", "Sales Invoice")
 
     # Field renamed post release
     delete_old_fields(


### PR DESCRIPTION
<sub><a href="https://huly.app/guest/resilienttech?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NmM5NmI0ZDhjMmMxOTBhN2E2MjY0YjkiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6Inctc21pdHZvcmEyMDMtcmVzaWxpZW50dGVjLTY2N2U0MjkxLWEwNWMwNjY4N2EtNjM4MjY3IiwicHJvZHVjdElkIjoiIn0.81sL2-cXq15i-jegdvqQhXx5s0sq_j422DdkXufw7I0">Huly&reg;: <b>IC-2686</b></a></sub>