### PR TITLE
fix: changed `doctype` column in audit trail report from Link to Data

### DIFF
--- a/india_compliance/audit_trail/report/audit_trail/audit_trail.py
+++ b/india_compliance/audit_trail/report/audit_trail/audit_trail.py
@@ -152,9 +152,8 @@ class DetailedReport(BaseAuditTrail):
             },
             {
                 "label": _("DocType"),
-                "fieldtype": "Link",
+                "fieldtype": "Data",
                 "fieldname": "doctype",
-                "options": "DocType",
                 "width": 120,
             },
             {
@@ -172,10 +171,9 @@ class DetailedReport(BaseAuditTrail):
             },
             {
                 "label": _("Party Type"),
-                "fieldtype": "Link",
+                "fieldtype": "Data",
                 "fieldname": "party_type",
                 "width": 100,
-                "options": "DocType",
             },
             {
                 "label": _("Party Name"),
@@ -302,9 +300,8 @@ class DocTypeReport(BaseAuditTrail):
         columns = [
             {
                 "label": _("DocType"),
-                "fieldtype": "Link",
+                "fieldtype": "Data",
                 "fieldname": "doctype",
-                "options": "DocType",
                 "width": 150,
             },
             {


### PR DESCRIPTION
Only the System Manager has permission to read doctype "Doctype".
Also, frappe doesn't allow giving permission for Doctype.

https://support.frappe.io/app/hd-ticket/21253