### PR TITLE
fix: use `get_gstin_list` function for fetching list of gstins in GSTR1 Report

### DIFF
--- a/india_compliance/gst_india/report/gstr_1/gstr_1.py
+++ b/india_compliance/gst_india/report/gstr_1/gstr_1.py
@@ -22,7 +22,11 @@ from india_compliance.gst_india.report.hsn_wise_summary_of_outward_supplies.hsn_
     get_hsn_data,
     get_hsn_wise_json_data,
 )
-from india_compliance.gst_india.utils import get_escaped_name, get_gst_accounts_by_type
+from india_compliance.gst_india.utils import (
+    get_escaped_name,
+    get_gst_accounts_by_type,
+    get_gstin_list,
+)
 from india_compliance.gst_india.utils.exporter import ExcelExporter
 from india_compliance.gst_india.utils.gstr_1 import SUPECOM
 
@@ -2199,19 +2203,7 @@ def get_company_gstin_number(company, address=None, all_gstins=False):
         gstin = frappe.db.get_value("Address", address, "gstin")
 
     if not gstin:
-        filters = [
-            ["is_your_company_address", "=", 1],
-            ["Dynamic Link", "link_doctype", "=", "Company"],
-            ["Dynamic Link", "link_name", "=", company],
-            ["Dynamic Link", "parenttype", "=", "Address"],
-            ["gstin", "!=", ""],
-        ]
-        gstin = frappe.get_all(
-            "Address",
-            filters=filters,
-            pluck="gstin",
-            order_by="is_primary_address desc",
-        )
+        gstin = get_gstin_list(company)
         if gstin and not all_gstins:
             gstin = gstin[0]
 


### PR DESCRIPTION
* default GSTIN was not fetched while setting GSTINs  in GSTR-1 report (old)
* Using the common utility to fetch GSTINs.

Frappe Support Issue: https://support.frappe.io/app/hd-ticket/21481

<sub><a href="https://huly.app/guest/resilienttech?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NmQ5ODczNzNiYjU3YTg1ZTg1M2Q1ZTEiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6Inctc21pdHZvcmEyMDMtcmVzaWxpZW50dGVjLTY2N2U0MjkxLWEwNWMwNjY4N2EtNjM4MjY3In0.yQ3B1W8NEuhkn-bABd2GPliGbhpe8r0yB2xhDePtOn0">Huly&reg;: <b>IC-2712</b></a></sub>