### PR TITLE
fix: fiscal year start-end date in GST Balance

### DIFF
--- a/india_compliance/gst_india/report/gst_balance/gst_balance.js
+++ b/india_compliance/gst_india/report/gst_balance/gst_balance.js
@@ -29,13 +29,13 @@ frappe.query_reports["GST Balance"] = {
             fieldname: "from_date",
             label: __("From Date"),
             fieldtype: "Date",
-            default: erpnext.utils.get_fiscal_year(frappe.datetime.get_today(), true)[1],
+            default: india_compliance.last_month_start(),
         },
         {
             fieldname: "to_date",
             label: __("To Date"),
             fieldtype: "Date",
-            default: erpnext.utils.get_fiscal_year(frappe.datetime.get_today(), true)[2],
+            default: india_compliance.last_month_end(),
         },
         {
             fieldname: "show_summary",

--- a/india_compliance/gst_india/report/gst_balance/gst_balance.js
+++ b/india_compliance/gst_india/report/gst_balance/gst_balance.js
@@ -29,13 +29,13 @@ frappe.query_reports["GST Balance"] = {
             fieldname: "from_date",
             label: __("From Date"),
             fieldtype: "Date",
-            default: frappe.defaults.get_user_default("year_start_date"),
+            default: erpnext.utils.get_fiscal_year(frappe.datetime.get_today(), true)[1],
         },
         {
             fieldname: "to_date",
             label: __("To Date"),
             fieldtype: "Date",
-            default: frappe.defaults.get_user_default("year_end_date"),
+            default: erpnext.utils.get_fiscal_year(frappe.datetime.get_today(), true)[2],
         },
         {
             fieldname: "show_summary",


### PR DESCRIPTION
Version 15 and 14

* fix the fiscal year start date and end date in the report filter.

<sub><a href="https://huly.app/guest/resilienttech?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NmRhYmEzNDNiYjU3YTg1ZThhNDkxOTAiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6Inctc21pdHZvcmEyMDMtcmVzaWxpZW50dGVjLTY2N2U0MjkxLWEwNWMwNjY4N2EtNjM4MjY3In0.mo21nnJZD-5Nh8gIxqDK-ozjvmOVI5O4qstcVNMswL4">Huly&reg;: <b>IC-2718</b></a></sub>