### PR TITLE
fix: show doc issued summary in filed tab

### DIFF
--- a/india_compliance/gst_india/utils/gstr_1/gstr_1_json_map.py
+++ b/india_compliance/gst_india/utils/gstr_1/gstr_1_json_map.py
@@ -1821,6 +1821,14 @@ class RETSUM(GovDataMapper):
 
         return {"summary": output}
 
+    def format_data(self, data, default_data=None, for_gov=False):
+        response = super().format_data(data, default_data, for_gov)
+
+        if data.get("sec_nm") == "DOC_ISSUE":
+            response["no_of_records"] = data.get("net_doc_issued", 0)
+
+        return response
+
     def format_subsection_data(self, section, subsection_data):
         subsection = subsection_data.get("typ") or subsection_data.get("sec_nm")
         formatted_data = self.format_data(subsection_data)
@@ -1935,6 +1943,7 @@ def summarize_retsum_data(input_data):
 
     summarized_data = []
     total_values_keys = [
+        "no_of_records",
         "total_igst_amount",
         "total_cgst_amount",
         "total_sgst_amount",


### PR DESCRIPTION
closes: #2596

<sub><a href="https://huly.app/guest/resilienttech?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NmUxNjQ0YzUxYWRhNGYzOTdhZjZjNGMiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6Inctc21pdHZvcmEyMDMtcmVzaWxpZW50dGVjLTY2N2U0MjkxLWEwNWMwNjY4N2EtNjM4MjY3In0.9C68AGUjthPdHHobbJ4ESW3ovhIArSK2wvlZvEUe0qc">Huly&reg;: <b>IC-2733</b></a></sub>