### PR TITLE
fix: do not set options for non Autocomplete field

### DIFF
--- a/india_compliance/gst_india/client_scripts/party.js
+++ b/india_compliance/gst_india/client_scripts/party.js
@@ -149,6 +149,7 @@ async function set_gstin_options(frm) {
 
     frm._gstin_options_set_for = frm.doc.name;
     const field = frm.get_field("gstin");
+    if (!field || field.df.fieldtype != "Autocomplete") return;
     field.df.ignore_validation = true;
     field.set_data(await india_compliance.get_gstin_options(frm.doc.name, frm.doctype));
 }


### PR DESCRIPTION
Traceback

```
Uncaught (in promise) TypeError: field.set_data is not a function
    set_gstin_options address__js:270
    refresh address__js:244
    _handler script_manager.js:30
    runner script_manager.js:109
    trigger script_manager.js:127
    promise callback*frappe.run_serially/< dom.js:276
    run_serially dom.js:274
    trigger script_manager.js:141
    render_form form.js:620
    promise callback*frappe.run_serially/< dom.js:276
    run_serially dom.js:274
    render_form form.js:610
    initialize_new_doc form.js:579
    promise callback*initialize_new_doc form.js:576
    trigger_onload form.js:557
    refresh form.js:441
    render formview.js:107
    fetch_and_render formview.js:91
    callback model.js:332
    callback request.js:86
    200 request.js:134
    call request.js:306
    jQuery 6
    call request.js:280
    call request.js:110
    with_doc model.js:324
    with_doc model.js:314
    fetch_and_render formview.js:80
```

Error:
![image](https://github.com/user-attachments/assets/02119c17-5a6b-46c5-aad3-10630c0b0f90)

<sub><a href="https://huly.app/guest/resilienttech?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NmYyZjY3MWMyNDM5YjlmMjQ1OTRlNTYiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6Inctc21pdHZvcmEyMDMtcmVzaWxpZW50dGVjLTY2N2U0MjkxLWEwNWMwNjY4N2EtNjM4MjY3In0.NOgkLtg6aRHnY57erqzUSE61Y4K9_knWis1ZgvWqAuQ">Huly&reg;: <b>IC-2754</b></a></sub>