### PR TITLE
fix: calculate taxes after mapping

### DIFF
--- a/india_compliance/gst_india/overrides/purchase_receipt.py
+++ b/india_compliance/gst_india/overrides/purchase_receipt.py
@@ -1,3 +1,6 @@
+import frappe
+from frappe import _
+
 from india_compliance.gst_india.overrides.purchase_invoice import (
     set_ineligibility_reason,
 )
@@ -5,6 +8,7 @@ from india_compliance.gst_india.overrides.sales_invoice import (
     update_dashboard_with_gst_logs,
 )
 from india_compliance.gst_india.overrides.transaction import (
+    get_taxes_and_charges,
     ignore_gst_validations,
     validate_mandatory_fields,
     validate_transaction,
@@ -18,6 +22,31 @@ def get_dashboard_data(data):
         "e-Waybill Log",
         "Integration Request",
     )
+
+
+def after_mapping(doc, method, source_doc):
+    if not source_doc.doctype == "Subcontracting Receipt":
+        return
+
+    if not source_doc.items:
+        frappe.throw(
+            _(
+                "Purchase Order Item reference is missing in Subcontracting Receipt {0}"
+            ).format(source_doc.name)
+        )
+
+    po_name = source_doc.items[0].purchase_order
+    po_taxes_and_charges = frappe.db.get_value(
+        "Purchase Order", po_name, fieldname="taxes_and_charges"
+    )
+
+    doc.taxes_and_charges = po_taxes_and_charges
+    taxes = get_taxes_and_charges(
+        "Purchase Taxes and Charges Template", po_taxes_and_charges
+    )
+
+    for tax_row in taxes:
+        doc.append("taxes", tax_row)
 
 
 def onload(doc, method=None):

--- a/india_compliance/hooks.py
+++ b/india_compliance/hooks.py
@@ -193,6 +193,7 @@ doc_events = {
         "before_submit": [
             "india_compliance.gst_india.overrides.transaction.update_gst_details",
         ],
+        "after_mapping": "india_compliance.gst_india.overrides.purchase_receipt.after_mapping",
     },
     "Sales Invoice": {
         "onload": [


### PR DESCRIPTION
<img width="1147" src="https://github.com/user-attachments/assets/6103bb02-3dd7-4b50-b31f-e1c51a776397" alt="Screenshot 2024-10-18 at 12 07 35 PM">

When enabling the `Auto Create Purchase Receipt`, the GST is not being automatically calculated, requiring manual entry of the purchase taxes and charges.

<sub><a href="https://huly.app/guest/resilienttech?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzEyMDM3ZGNlNzQ0ODdkZDQzZGFmMDgiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6Inctc21pdHZvcmEyMDMtcmVzaWxpZW50dGVjLTY2N2U0MjkxLWEwNWMwNjY4N2EtNjM4MjY3In0.eBlocV3E0cEHC9XH1PDDvuVYzP0xy4q3yapl7-iudZI">Huly&reg;: <b>IC-2794</b></a></sub>