### PR TITLE
fix: include "140" pincode series for chandigarh

### DIFF
--- a/india_compliance/gst_india/constants/__init__.py
+++ b/india_compliance/gst_india/constants/__init__.py
@@ -146,7 +146,7 @@ STATE_PINCODE_MAPPING = {
     "Jammu and Kashmir": (180, 194),
     "Himachal Pradesh": (171, 177),
     "Punjab": (140, 160),
-    "Chandigarh": (160, 160),
+    "Chandigarh": ((140, 140), (160, 160)),
     "Uttarakhand": (244, 263),
     "Haryana": (121, 136),
     "Delhi": (110, 110),


### PR DESCRIPTION
"140", pincode series is also mapped to Chandigarh.

![image](https://github.com/user-attachments/assets/9f67ca9e-a095-4221-b590-91ada80a07b0)

Frappe Support Issue: https://support.frappe.io/app/hd-ticket/25325

<sub><a href="https://huly.app/guest/resilienttech?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzM0Njc3NWU3Y2M1YTc4NTQyYzBjMWMiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6Inctc21pdHZvcmEyMDMtcmVzaWxpZW50dGVjLTY2N2U0MjkxLWEwNWMwNjY4N2EtNjM4MjY3In0.a8PhvHQPT7_2VHsFS_yLkkmQF-HtjEY3rD0AsZrWORg">Huly&reg;: <b>IC-2842</b></a></sub>