### PR TITLE
fix: pos from shipping address based on account settings

### DIFF
--- a/india_compliance/gst_india/overrides/test_transaction.py
+++ b/india_compliance/gst_india/overrides/test_transaction.py
@@ -1243,6 +1243,7 @@ class TestItemUpdate(IntegrationTestCase):
 
 class TestPlaceOfSupply(IntegrationTestCase):
     def test_pos_sales_invoice(self):
+        # Sales Invoice with Shipping Address
         doc_args = {
             "doctype": "Sales Invoice",
             "customer": "_Test Registered Composition Customer",
@@ -1260,3 +1261,26 @@ class TestPlaceOfSupply(IntegrationTestCase):
         frappe.db.set_value(*settings, "Billing Address")
         doc = create_transaction(**doc_args)
         self.assertEqual(doc.place_of_supply, "29-Karnataka")
+
+        frappe.db.set_value(*settings, "Shipping Address")
+
+        # Sales Invoice with only Billing Address
+        doc_args = {
+            "doctype": "Sales Invoice",
+            "customer": "_Test Registered Composition Customer",
+        }
+
+        settings = ["Accounts Settings", None, "determine_address_tax_category_from"]
+
+        # (from Billing Address)
+        doc = create_transaction(**doc_args)
+        self.assertEqual(doc.place_of_supply, "29-Karnataka")  # Billing Address
+
+        # Sales Invoice for Unregistered Customer
+        doc_args = {
+            "doctype": "Sales Invoice",
+            "customer": "_Test Unregistered Customer",
+        }
+
+        doc = create_transaction(**doc_args)
+        self.assertEqual(doc.place_of_supply, "24-Gujarat")  # Company GSTIN

--- a/india_compliance/gst_india/overrides/test_transaction.py
+++ b/india_compliance/gst_india/overrides/test_transaction.py
@@ -1246,6 +1246,7 @@ class TestPlaceOfSupply(IntegrationTestCase):
         doc_args = {
             "doctype": "Sales Invoice",
             "customer": "_Test Registered Composition Customer",
+            "shipping_address_name": "_Test Indian Registered Company-Billing",
         }
 
         settings = ["Accounts Settings", None, "determine_address_tax_category_from"]

--- a/india_compliance/gst_india/setup/property_setters.py
+++ b/india_compliance/gst_india/setup/property_setters.py
@@ -93,9 +93,15 @@ def get_property_setters(*, include_defaults=False):
         },
         {
             "doctype": "Accounts Settings",
+            "fieldname": "add_taxes_from_item_tax_template",
+            "property": "description",
+            "value": "Overridden by India Compliance",
+        },
+        {
+            "doctype": "Accounts Settings",
             "fieldname": "tax_settings_section",
             "property": "label",
-            "value": "Tax Settings (Overridden by India Compliance)",
+            "value": "Tax Settings",
         },
         {
             "doctype": "Accounts Settings",

--- a/india_compliance/gst_india/setup/property_setters.py
+++ b/india_compliance/gst_india/setup/property_setters.py
@@ -107,7 +107,7 @@ def get_property_setters(*, include_defaults=False):
             "doctype": "Accounts Settings",
             "fieldname": "tax_settings_section",
             "property": "collapsible",
-            "value": "1",
+            "value": "0",
         },
         {
             "doctype": "Purchase Reconciliation Tool",

--- a/india_compliance/patches.txt
+++ b/india_compliance/patches.txt
@@ -5,7 +5,7 @@ india_compliance.patches.v15.remove_duplicate_web_template
 [post_model_sync]
 india_compliance.patches.v14.set_default_for_overridden_accounts_setting
 execute:from india_compliance.gst_india.setup import create_custom_fields; create_custom_fields() #59
-execute:from india_compliance.gst_india.setup import create_property_setters; create_property_setters() #9
+execute:from india_compliance.gst_india.setup import create_property_setters; create_property_setters() #10
 execute:from india_compliance.income_tax_india.setup import create_custom_fields; create_custom_fields() #2
 india_compliance.patches.post_install.remove_old_fields #2
 india_compliance.patches.post_install.set_gst_tax_type


### PR DESCRIPTION
set `place of supply` from shipping address based on account settings and Minor UI change.

**Before**
<img width="911" src="https://github.com/user-attachments/assets/ddec8d48-5444-4a54-9a13-58a28ff095d2" alt="before">

**After**
<img width="911" src="https://github.com/user-attachments/assets/4afe7fb4-ff9c-4d1a-81f2-8b4fe841aaf8" alt="Screenshot 2024-11-14 at 4 09 08 PM">

<sub><a href="https://huly.app/guest/resilienttech?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzM4NjA0M2U3Y2M1YTc4NTQyZDQxOTMiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6Inctc21pdHZvcmEyMDMtcmVzaWxpZW50dGVjLTY2N2U0MjkxLWEwNWMwNjY4N2EtNjM4MjY3In0.9Rp1NK3H4cF5LupGvVgHVjSRtqKmwKCKMJkaNhXfDxc">Huly&reg;: <b>IC-2848</b></a></sub>