### PR TITLE
fix: validate hsn code for both e-waybill and e-invoice

### DIFF
--- a/india_compliance/gst_india/overrides/purchase_invoice.py
+++ b/india_compliance/gst_india/overrides/purchase_invoice.py
@@ -272,6 +272,7 @@ def validate_reverse_charge(doc):
 
 
 def validate_hsn_codes(doc):
+    # To determine whether BOE is applicable or not.
     if doc.gst_category != "Overseas":
         return
 

--- a/india_compliance/gst_india/overrides/sales_invoice.py
+++ b/india_compliance/gst_india/overrides/sales_invoice.py
@@ -4,6 +4,7 @@ from frappe.utils import flt, fmt_money
 
 from india_compliance.gst_india.overrides.payment_entry import get_taxes_summary
 from india_compliance.gst_india.overrides.transaction import (
+    _validate_hsn_codes,
     ignore_gst_validations,
     validate_backdated_transaction,
     validate_mandatory_fields,
@@ -22,7 +23,6 @@ from india_compliance.gst_india.utils import (
 from india_compliance.gst_india.utils.e_invoice import (
     get_e_invoice_info,
     validate_e_invoice_applicability,
-    validate_hsn_codes_for_e_invoice,
 )
 from india_compliance.gst_india.utils.e_waybill import get_e_waybill_info
 from india_compliance.gst_india.utils.transaction_data import (
@@ -99,7 +99,12 @@ def validate_fields_and_set_status_for_e_invoice(doc, gst_settings=None):
         _("{0} is a mandatory field for generating e-Invoices"),
     )
 
-    validate_hsn_codes_for_e_invoice(doc)
+    # Mandatory for e-Invoice before save
+    _validate_hsn_codes(
+        doc,
+        valid_hsn_length=[6, 8],
+        message=_("Since HSN/SAC Code is mandatory for generating e-Invoices.<br>"),
+    )
 
     if is_foreign_doc(doc):
         country = frappe.db.get_value("Address", doc.customer_address, "country")

--- a/india_compliance/gst_india/utils/e_invoice.py
+++ b/india_compliance/gst_india/utils/e_invoice.py
@@ -32,10 +32,7 @@ from india_compliance.gst_india.constants.e_invoice import (
 from india_compliance.gst_india.doctype.gst_settings.gst_settings import (
     get_e_invoice_applicability_date,
 )
-from india_compliance.gst_india.overrides.transaction import (
-    _validate_hsn_codes,
-    validate_mandatory_fields,
-)
+from india_compliance.gst_india.overrides.transaction import validate_mandatory_fields
 from india_compliance.gst_india.utils import (
     are_goods_supplied,
     handle_server_errors,
@@ -498,14 +495,6 @@ def validate_e_invoice_applicability(doc, gst_settings=None, throw=True):
     return True
 
 
-def validate_hsn_codes_for_e_invoice(doc):
-    _validate_hsn_codes(
-        doc,
-        valid_hsn_length=[6, 8],
-        message=_("Since HSN/SAC Code is mandatory for generating e-Invoices.<br>"),
-    )
-
-
 def validate_taxable_item(doc, throw=True):
     """
     Validates that the document contains at least one GST taxable item.
@@ -621,8 +610,6 @@ class EInvoiceData(GSTTransactionData):
             "customer_address",
             _("{0} is a mandatory field for generating e-Invoices"),
         )
-
-        validate_hsn_codes_for_e_invoice(self.doc)
 
         if len(self.doc.items) > ITEM_LIMIT:
             frappe.throw(

--- a/india_compliance/gst_india/utils/transaction_data.py
+++ b/india_compliance/gst_india/utils/transaction_data.py
@@ -14,6 +14,7 @@ from india_compliance.gst_india.constants.e_waybill import (
     TRANSPORT_MODES,
     VEHICLE_TYPES,
 )
+from india_compliance.gst_india.overrides.transaction import _validate_hsn_codes
 from india_compliance.gst_india.utils import (
     get_gst_uom,
     get_validated_country_code,
@@ -282,6 +283,14 @@ class GSTTransactionData:
                 msg=_("Posting Date cannot be greater than LR Date"),
                 title=_("Invalid Data"),
             )
+
+        _validate_hsn_codes(
+            self.doc,
+            valid_hsn_length=[6, 8],
+            message=_(
+                "Since HSN/SAC Code is mandatory for generating e-Waybill/e-Invoices.<br>"
+            ),
+        )
 
     def get_all_item_details(self):
         all_item_details = []


### PR DESCRIPTION
HSN Code needs to be validated in both e-Waybill and e-Invoice data.
Currently, it is only validated in e-invoice.
Frappe Support Ticket: https://support.frappe.io/helpdesk/tickets/25604

<sub><a href="https://huly.app/guest/resilienttech?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzM4NTZiNWU3Y2M1YTc4NTQyZDQwZjYiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6Inctc21pdHZvcmEyMDMtcmVzaWxpZW50dGVjLTY2N2U0MjkxLWEwNWMwNjY4N2EtNjM4MjY3In0.qbwDNFuxyAHg9g8gz07xcMVq_hYfCjUmubkDXtRJDiQ">Huly&reg;: <b>IC-2858</b></a></sub>