### PR TITLE
fix: sub supply type "Others" for e-waybill in DN

### DIFF
--- a/india_compliance/gst_india/client_scripts/e_waybill_actions.js
+++ b/india_compliance/gst_india/client_scripts/e_waybill_actions.js
@@ -334,7 +334,49 @@ function show_generate_e_waybill_dialog(frm) {
 
 function get_generate_e_waybill_dialog(opts, frm) {
     if (!frm) frm = { doc: {} };
+    const ewaybill_defaults = get_sub_suppy_type_options(frm);
+
     const fields = [
+        {
+            label: "Document Details",
+            fieldname: "section_doc_details",
+            fieldtype: "Section Break",
+            // collapsible: ewaybill_defaults.sub_supply_type.length === 1,
+        },
+        {
+            label: "Supply Type",
+            fieldname: "supply_type",
+            fieldtype: "Data",
+            read_only: 1,
+            default: ewaybill_defaults.supply_type,
+        },
+        {
+            label: "Document Type",
+            fieldname: "document_type",
+            fieldtype: "Data",
+            read_only: 1,
+            default: ewaybill_defaults.document_type,
+        },
+        {
+            fieldtype: "Column Break",
+        },
+        {
+            label: "Sub Supply Type",
+            fieldname: "sub_supply_type",
+            fieldtype: "Select",
+            options: ewaybill_defaults.sub_supply_type.join("\n"),
+            default: ewaybill_defaults.sub_supply_type[0],
+            read_only: ewaybill_defaults.sub_supply_type.length === 1,
+            reqd: ewaybill_defaults.sub_supply_type.length !== 1,
+        },
+        {
+            label: "Sub Supply Description",
+            fieldname: "sub_supply_desc",
+            fieldtype: "Data",
+            depends_on: "eval: doc.sub_supply_type == 'Others'",
+            mandatory_depends_on: "eval: doc.sub_supply_type == 'Others'",
+            default: ewaybill_defaults.sub_supply_desc,
+        },
         {
             label: "Part A",
             fieldname: "section_part_a",
@@ -377,7 +419,6 @@ function get_generate_e_waybill_dialog(opts, frm) {
             onchange: () => validate_gst_transporter_id(d),
 
         },
-        // Sub Supply Type will be visible here for Delivery Note
         {
             label: "Part B",
             fieldname: "section_part_b",
@@ -431,41 +472,6 @@ function get_generate_e_waybill_dialog(opts, frm) {
         },
     ];
 
-    if (frm.doctype === "Delivery Note") {
-        const same_gstin = frm.doc.billing_address_gstin === frm.doc.company_gstin;
-        let options;
-
-        if (frm.doc.is_return) {
-            if (same_gstin) {
-                options = ["For Own Use", "Exhibition or Fairs"];
-            } else {
-                options = ["Job Work Returns", "SKD/CKD"];
-            }
-        } else {
-            if (same_gstin) {
-                options = [
-                    "For Own Use",
-                    "Exhibition or Fairs",
-                    "Line Sales",
-                    "Recipient Not Known",
-                ];
-            } else {
-                options = ["Job Work", "SKD/CKD"];
-            }
-        }
-
-        // Inserted at the end of Part A section
-        fields.splice(5, 0, {
-            label: "Sub Supply Type",
-            fieldname: "sub_supply_type",
-            fieldtype: "Select",
-            options: options.join("\n"),
-            default: options[0],
-            read_only: options.length === 1,
-            reqd: 1,
-        });
-    }
-
     const is_foreign_transaction =
         frm.doc.gst_category === "Overseas" &&
         frm.doc.place_of_supply === "96-Other Countries";
@@ -497,6 +503,78 @@ function get_generate_e_waybill_dialog(opts, frm) {
     frappe.ui.form.ControlData.trigger_change_on_input_event = true;
 
     return d;
+}
+
+function get_sub_suppy_type_options(frm) {
+    let supply_type, sub_supply_type, sub_supply_desc, document_type;
+
+    if (frm.doctype === "Delivery Note") {
+        const same_gstin = frm.doc.billing_address_gstin == frm.doc.company_gstin;
+
+        if (frm.doc.is_return) {
+            supply_type = "Inward";
+            document_type = "Delivery Challan";
+            if (same_gstin) {
+                sub_supply_type = ["For Own Use", "Exhibition or Fairs", "Others"];
+            } else {
+                sub_supply_type = ["Job Work Returns", "SKD/CKD", "Others"];
+            }
+        } else {
+            supply_type = "Outward";
+            document_type = "Delivery Challan";
+            if (same_gstin) {
+                sub_supply_type = [
+                    "For Own Use",
+                    "Exhibition or Fairs",
+                    "Line Sales",
+                    "Recipient Not Known",
+                    "Others",
+                ];
+            } else {
+                sub_supply_type = ["Job Work", "SKD/CKD", "Others"];
+            }
+        }
+    } else {
+        const key = `${frm.doctype}_${frm.doc.is_return || 0}`;
+        const default_supply_types = {
+            "Sales Invoice_0": {
+                supply_type: "Outward",
+                sub_supply_type: ["Supply"],
+                document_type: "Tax Invoice",
+            },
+            "Sales Invoice_1": {
+                supply_type: "Inward",
+                sub_supply_type: ["Sales Return"],
+                document_type: "Delivery Challan",
+            },
+            "Purchase Invoice_0": {
+                supply_type: "Inward",
+                sub_supply_type: ["Supply"],
+                document_type: "Tax Invoice",
+            },
+            "Purchase Invoice_1": {
+                supply_type: "Outward",
+                sub_supply_type: ["Others"],
+                sub_supply_desc: "Purchase Return",
+                document_type: "Others",
+            },
+            "Purchase Receipt_0": {
+                supply_type: "Inward",
+                sub_supply_type: ["Supply"],
+                document_type: "Tax Invoice",
+            },
+            "Purchase Receipt_1": {
+                supply_type: "Outward",
+                sub_supply_type: ["Others"],
+                sub_supply_desc: "Purchase Return",
+                document_type: "Delivery Challan",
+            }
+        };
+
+        return default_supply_types[key]
+    }
+
+    return { supply_type, sub_supply_type, sub_supply_desc, document_type };
 }
 
 function show_fetch_if_generated_dialog(frm) {

--- a/india_compliance/gst_india/constants/e_waybill.py
+++ b/india_compliance/gst_india/constants/e_waybill.py
@@ -1,15 +1,6 @@
 # Just for reference
-# SUPPLY_TYPES = {"Inward": "I", "Outward": "O"}
-#
-# DOCUMENT_TYPES = {
-#     "Tax Invoice": "INV",
-#     "Bill of Supply": "BIL",
-#     "Bill of Entry": "BOE",
-#     "Delivery Challan": "CHL",
-#     "Others": "OTH",
-# }
-#
 # DATETIME_FORMAT = "%d/%m/%Y %I:%M:%S %p"
+
 selling_address = {
     "bill_from": "company_address",
     "bill_to": "customer_address",
@@ -52,6 +43,14 @@ EXTEND_VALIDITY_REASON_CODES = {
     "Transshipment": 4,
     "Accident": 5,
     "Others": 99,
+}
+
+DOCUMENT_TYPES = {
+    "Tax Invoice": "INV",
+    "Bill of Supply": "BIL",
+    "Bill of Entry": "BOE",
+    "Delivery Challan": "CHL",
+    "Others": "OTH",
 }
 
 SUPPLY_TYPES = {

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -996,6 +996,7 @@ def update_transaction(doc, values):
 
     if doc.doctype == "Delivery Note":
         doc._sub_supply_type = SUB_SUPPLY_TYPES[values.sub_supply_type]
+        doc._sub_supply_desc = values.sub_supply_desc
 
 
 def get_e_waybill_info(doc):
@@ -1440,11 +1441,13 @@ class EWaybillData(GSTTransactionData):
             ("Delivery Note", 0): {
                 "supply_type": "O",
                 "sub_supply_type": doc.get("_sub_supply_type", ""),
+                "sub_supply_desc": doc.get("_sub_supply_desc", ""),
                 "document_type": "CHL",
             },
             ("Delivery Note", 1): {
                 "supply_type": "I",
                 "sub_supply_type": doc.get("_sub_supply_type", ""),
+                "sub_supply_desc": doc.get("_sub_supply_desc", ""),
                 "document_type": "CHL",
             },
             ("Purchase Invoice", 0): {


### PR DESCRIPTION
manual backport of #2467

<sub><a href="https://huly.app/guest/resilienttech?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzNjOWE0Y2U3Y2M1YTc4NTQyZTEwMDAiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6Inctc21pdHZvcmEyMDMtcmVzaWxpZW50dGVjLTY2N2U0MjkxLWEwNWMwNjY4N2EtNjM4MjY3In0.ekNtiwJLczxqcmOAP-I9qNURR1w6FcOeGGmAz8RMwWw">Huly&reg;: <b>IC-2878</b></a></sub>