### PR TITLE
fix: auto set link doctype and docname in address dialog for lead

### DIFF
--- a/india_compliance/public/js/quick_entry.js
+++ b/india_compliance/public/js/quick_entry.js
@@ -308,6 +308,7 @@ class AddressQuickEntryForm extends GSTQuickEntryForm {
                 "Customer",
                 "Supplier",
                 "Company",
+                "Lead"
             ].includes(doc.doctype)
         )
             return;


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/efcda118-1ad7-454d-8b9a-58bbc7ebc737)

After:
![image](https://github.com/user-attachments/assets/7c60e9f8-0bf4-4b29-bd7c-e103dca1c9e3)

Frappe Support Issue: https://support.frappe.io/app/hd-ticket/22228

<sub><a href="https://huly.app/guest/resilienttech?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzQ3MWNlZmQyZWY0Y2JjYzQ2YmM5ZmIiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6Inctc21pdHZvcmEyMDMtcmVzaWxpZW50dGVjLTY2N2U0MjkxLWEwNWMwNjY4N2EtNjM4MjY3In0.2eINB12abPNQ6nxrhm5GCTtS0y7DRqarQ_Uh1Xqji2k">Huly&reg;: <b>IC-2911</b></a></sub>