### PR TITLE
fix: give full width view to purchase reconciliation tool

### DIFF
--- a/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.css
+++ b/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.css
@@ -8,6 +8,10 @@ div[data-page-route="Purchase Reconciliation Tool"]
     margin-top: 0;
 }
 
+div[data-page-route="Purchase Reconciliation Tool"] .section-body {
+    max-width: 100% !important;
+}
+
 div[data-page-route="Purchase Reconciliation Tool"]
     [data-fieldname="reconciliation_html"]
     .form-tabs-list {
@@ -29,7 +33,8 @@ div[data-page-route="Purchase Reconciliation Tool"]
 div[data-page-route="Purchase Reconciliation Tool"]
     [data-fieldname="reconciliation_html"]
     .form-tabs-list
-    .inner-group-button, .filter-selector {
+    .inner-group-button,
+.filter-selector {
     margin-bottom: 8px;
     margin-left: 8px;
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/fc91833a-785a-4d20-b282-793f7401867a)

<sub><a href="https://huly.app/guest/resilienttech?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzQ4MDU3M2QyZWY0Y2JjYzQ2YmU0NzUiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6Inctc21pdHZvcmEyMDMtcmVzaWxpZW50dGVjLTY2N2U0MjkxLWEwNWMwNjY4N2EtNjM4MjY3In0.Bkt-UP6p0Ep0dsKnnSKsyXYWK39oQOYvTYdcBm5Hc2o">Huly&reg;: <b>IC-2917</b></a></sub>