### PR TITLE
fix: show correct number of documents for purchase recon tool for missing in 2A/2B

### DIFF
--- a/india_compliance/gst_india/doctype/purchase_reconciliation_tool/__init__.py
+++ b/india_compliance/gst_india/doctype/purchase_reconciliation_tool/__init__.py
@@ -748,6 +748,8 @@ class Reconciler(BaseReconciliation):
         """
         Reconcile purchases and inward supplies for given category.
         """
+        self.category = category
+
         # GSTIN Level matching
         purchases = self.get_unmatched_purchase_or_bill_of_entry(category)
         inward_supplies = self.get_unmatched_inward_supply(category, amended_category)
@@ -792,12 +794,13 @@ class Reconciler(BaseReconciliation):
                 for inward_supply_name, inward_supply in (
                     inward_supplies[supplier_gstin].copy().items()
                 ):
-                    if match_status == "Residual Match":
-                        if (
-                            abs((purchase.bill_date - inward_supply.bill_date).days)
-                            > 10
-                        ):
-                            continue
+                    if (
+                        match_status == "Residual Match"
+                        and self.category != "CDNR"
+                        and abs((purchase.bill_date - inward_supply.bill_date).days)
+                        > 10
+                    ):
+                        continue
 
                     if not self.is_doc_matching(purchase, inward_supply, rules):
                         continue

--- a/india_compliance/gst_india/doctype/purchase_reconciliation_tool/__init__.py
+++ b/india_compliance/gst_india/doctype/purchase_reconciliation_tool/__init__.py
@@ -349,6 +349,7 @@ class PurchaseInvoice:
 
     def get_all(self, additional_fields=None, names=None, only_names=False):
         query = self.get_query(additional_fields)
+        match_found = ("Reconciled", "Match Found")
 
         if only_names and not names:
             return
@@ -360,7 +361,7 @@ class PurchaseInvoice:
             query = query.where(
                 (
                     (self.PI.posting_date[self.from_date : self.to_date])
-                    & (IfNull(self.PI.reconciliation_status, "") != "Reconciled")
+                    & (IfNull(self.PI.reconciliation_status, "").notin(match_found))
                 )
                 | (self.PI.name.isin(names))
             )
@@ -368,7 +369,7 @@ class PurchaseInvoice:
         else:
             query = query.where(
                 (self.PI.posting_date[self.from_date : self.to_date])
-                & (IfNull(self.PI.reconciliation_status, "") != "Reconciled")
+                & (IfNull(self.PI.reconciliation_status, "").notin(match_found))
             )
 
         return query.run(as_dict=True)
@@ -503,6 +504,7 @@ class BillOfEntry:
 
     def get_all(self, additional_fields=None, names=None, only_names=False):
         query = self.get_query(additional_fields)
+        match_found = ("Reconciled", "Match Found")
 
         if only_names and not names:
             return
@@ -514,7 +516,7 @@ class BillOfEntry:
             query = query.where(
                 (
                     (self.BOE.posting_date[self.from_date : self.to_date])
-                    & (IfNull(self.BOE.reconciliation_status, "") != "Reconciled")
+                    & (IfNull(self.BOE.reconciliation_status, "").notin(match_found))
                 )
                 | (self.BOE.name.isin(names))
             )
@@ -522,7 +524,7 @@ class BillOfEntry:
         else:
             query = query.where(
                 (self.BOE.posting_date[self.from_date : self.to_date])
-                & (IfNull(self.BOE.reconciliation_status, "") != "Reconciled")
+                & (IfNull(self.BOE.reconciliation_status, "").notin(match_found))
             )
 
         return query.run(as_dict=True)

--- a/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_detail_comparision.html
+++ b/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_detail_comparision.html
@@ -4,7 +4,7 @@
 			<tr class="text-center">
 				<th></th>
 				<th>2A / 2B</th>
-				<th>Purchase</th>
+				<th>{{ purchase.doctype }}</th>
 			</tr>
 		</thead>
 		<tbody data-label="detail-view-content">

--- a/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.js
+++ b/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.js
@@ -1807,6 +1807,7 @@ async function create_new_purchase_invoice(row, company, company_gstin) {
             bill_no: doc.bill_no,
             bill_date: doc.bill_date,
             is_reverse_charge: ["Yes", 1].includes(doc.is_reverse_charge) ? 1 : 0,
+            is_return: ["CDNR", "CDNRA"].includes(doc.classification) ? 1 : 0,
         };
 
         _set_value({

--- a/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.js
+++ b/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.js
@@ -744,7 +744,7 @@ class PurchaseReconciliationTool {
                 label: "GST Inward <br>Supply",
                 fieldname: "inward_supply_name",
                 fieldtype: "Link",
-                doctype: "GST Inward Supply",
+                options: "GST Inward Supply",
                 align: "center",
                 width: 120,
             },

--- a/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.js
+++ b/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.js
@@ -449,47 +449,39 @@ class PurchaseReconciliationTool {
             me.dm = new EmailDialog(me.frm, row);
         });
 
-        this.tabs.summary_tab.$datatable.on(
-            "click",
-            ".match-status",
-            async function (e) {
-                e.preventDefault();
+        const filter_map = {
+            // TAB: { SELECTOR: FIELDNAME }
+            summary: { ".match-status": "match_status" },
+            supplier: { ".supplier-gstin": "supplier_gstin" },
+            invoice: {
+                ".match-status": "match_status",
+                ".action-performed": "action",
+                ".supplier-gstin": "supplier_gstin",
+            },
+        };
 
-                const match_status = $(this).text();
-                await me.filter_group.push_new_filter([
-                    "Purchase Reconciliation Tool",
-                    "match_status",
-                    "=",
-                    match_status,
-                ]);
-                me.filter_group.apply();
-            }
-        );
+        Object.keys(filter_map).forEach(tab => {
+            Object.keys(filter_map[tab]).forEach(selector => {
+                this.tabs[`${tab}_tab`].$datatable.on(
+                    "click",
+                    selector,
+                    async function (e) {
+                        e.preventDefault();
+                        const value = $(this).text().trim();
+                        const field = filter_map[tab][selector];
 
-        this.tabs.supplier_tab.$datatable.on(
-            "click",
-            ".supplier-gstin",
-            add_supplier_gstin_filter
-        );
+                        await me.filter_group.push_new_filter([
+                            "Purchase Reconciliation Tool",
+                            field,
+                            "=",
+                            value,
+                        ]);
 
-        this.tabs.invoice_tab.$datatable.on(
-            "click",
-            ".supplier-gstin",
-            add_supplier_gstin_filter
-        );
-
-        async function add_supplier_gstin_filter(e) {
-            e.preventDefault();
-
-            const supplier_gstin = $(this).text().trim();
-            await me.filter_group.push_new_filter([
-                "Purchase Reconciliation Tool",
-                "supplier_gstin",
-                "=",
-                supplier_gstin,
-            ]);
-            me.filter_group.apply();
-        }
+                        me.filter_group.apply();
+                    }
+                );
+            });
+        });
     }
 
     export_data(selected_row) {
@@ -739,6 +731,9 @@ class PurchaseReconciliationTool {
                 label: "Match Status",
                 fieldname: "match_status",
                 width: 120,
+                _value: (...args) => {
+                    return `<a href="#" class='match-status'>${args[0]}</a>`;
+                },
             },
             {
                 label: "GST Inward <br>Supply",
@@ -783,6 +778,9 @@ class PurchaseReconciliationTool {
             {
                 label: "Action",
                 fieldname: "action",
+                _value: (...args) => {
+                    return `<a href="#" class='action-performed'>${args[0]}</a>`;
+                },
             },
         ];
     }
@@ -1234,8 +1232,7 @@ class ImportDialog {
     download_gstr_by_period(only_missing) {
         if (only_missing && this.has_no_pending_download) {
             frappe.msgprint({
-                message:
-                    "There are no pending downloads for the selected period.",
+                message: "There are no pending downloads for the selected period.",
                 title: "No Pending Downloads",
                 indicator: "orange",
             });
@@ -1455,7 +1452,6 @@ async function download_gstr(
     let company_gstins;
     if (company_gstin == "All")
         company_gstins = await india_compliance.get_gstin_options(frm.doc.company);
-
     else company_gstins = [company_gstin];
 
     company_gstins.forEach(async gstin => {

--- a/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.js
+++ b/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.js
@@ -373,6 +373,12 @@ class PurchaseReconciliationTool {
                 fieldname: "is_reverse_charge",
                 fieldtype: "Check",
             },
+            {
+                label: "DocType",
+                fieldname: "purchase_doctype",
+                fieldtype: "Select",
+                options: ["Purchase Invoice", "Bill of Entry"],
+            },
         ];
 
         fields.forEach(field => (field.parent = "Purchase Reconciliation Tool"));


### PR DESCRIPTION
Multiple fixes related to Purchase Reconciliation Tool

closes: https://github.com/resilient-tech/india-compliance/issues/2533
closes: #1580

<sub><a href="https://huly.app/guest/resilienttech?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzQ5N2FiM2QyZWY0Y2JjYzQ2YzUyODYiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6Inctc21pdHZvcmEyMDMtcmVzaWxpZW50dGVjLTY2N2U0MjkxLWEwNWMwNjY4N2EtNjM4MjY3In0.xJ_00Eipi_1vRfG3m2Y0GIU1L5sfhdup_KjIRNXyqP0">Huly&reg;: <b>IC-2926</b></a></sub>