### PR TITLE
fix: handle `Actions` button for smaller screens

### DIFF
--- a/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.js
+++ b/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.js
@@ -20,8 +20,8 @@ const ALERT_HTML = `
         ? `<a id="download-gstr2b-button" href="#" class="alert-link">
                     Download 2B
                 </a>`
-        : ""
-    }
+                : ""
+        }
     </div>
 `;
 
@@ -98,6 +98,8 @@ frappe.ui.form.on("Purchase Reconciliation Tool", {
             frm.save();
         });
 
+        const action_group = __("Actions");
+
         // add custom buttons
         api_enabled
             ? frm.add_custom_button(__("Download 2A/2B"), () => new ImportDialog(frm))
@@ -111,15 +113,15 @@ frappe.ui.form.on("Purchase Reconciliation Tool", {
             frm.add_custom_button(
                 __("Unlink"),
                 () => unlink_documents(frm),
-                __("Actions")
+                action_group
             );
-            frm.add_custom_button(__("dropdown-divider"), () => { }, __("Actions"));
+            frm.add_custom_button(__("dropdown-divider"), () => { }, action_group);
         }
         ["Accept", "Pending", "Ignore"].forEach(action =>
             frm.add_custom_button(
                 __(action),
                 () => apply_action(frm, action),
-                __("Actions")
+                action_group
             )
         );
         frm.$wrapper
@@ -140,7 +142,7 @@ frappe.ui.form.on("Purchase Reconciliation Tool", {
             $(button)
                 .find("button")
                 .html(
-                    `<span class="hidden-xs">Actions</span>
+                    `<span class="button-label hidden-xs">${action_group}</span>
                     ${frappe.utils.icon("select")}`
                 );
 

--- a/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.js
+++ b/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.js
@@ -16,12 +16,13 @@ const ALERT_HTML = `
         <div>
             You have missing GSTR-2B downloads
         </div>
-        ${api_enabled
-        ? `<a id="download-gstr2b-button" href="#" class="alert-link">
+        ${
+            api_enabled
+                ? `<a id="download-gstr2b-button" href="#" class="alert-link">
                     Download 2B
                 </a>`
-        : ""
-    }
+                : ""
+        }
     </div>
 `;
 
@@ -104,9 +105,9 @@ frappe.ui.form.on("Purchase Reconciliation Tool", {
         api_enabled
             ? frm.add_custom_button(__("Download 2A/2B"), () => new ImportDialog(frm))
             : frm.add_custom_button(
-                __("Upload 2A/2B"),
-                () => new ImportDialog(frm, false)
-            );
+                  __("Upload 2A/2B"),
+                  () => new ImportDialog(frm, false)
+              );
 
         if (!frm.purchase_reconciliation_tool?.data?.length) return;
         if (frm.get_active_tab()?.df.fieldname == "invoice_tab") {
@@ -115,7 +116,7 @@ frappe.ui.form.on("Purchase Reconciliation Tool", {
                 () => unlink_documents(frm),
                 action_group
             );
-            frm.add_custom_button(__("dropdown-divider"), () => { }, action_group);
+            frm.add_custom_button(__("dropdown-divider"), () => {}, action_group);
         }
         ["Accept", "Pending", "Ignore"].forEach(action =>
             frm.add_custom_button(
@@ -134,8 +135,10 @@ frappe.ui.form.on("Purchase Reconciliation Tool", {
         );
 
         // move actions button next to filters
-        for (let button of $(".custom-actions .inner-group-button")) {
-            if (button.innerText?.trim() != action_group) continue;
+        for (const group_div of $(".custom-actions .inner-group-button")) {
+            const btn_label = group_div.querySelector("button").innerText?.trim();
+            if (btn_label != action_group) continue;
+
             $(".custom-button-group .inner-group-button").remove();
 
             // to hide `Actions` text on small screens
@@ -149,9 +152,9 @@ frappe.ui.form.on("Purchase Reconciliation Tool", {
             </div>
             `;
 
-            $(button).find("button").html(actions_btn_html);
+            $(group_div).find("button").html(actions_btn_html);
 
-            $(button).appendTo($(".custom-button-group"));
+            $(group_div).appendTo($(".custom-button-group"));
         }
     },
 
@@ -208,8 +211,8 @@ frappe.ui.form.on("Purchase Reconciliation Tool", {
                 method == "update_api_progress"
                     ? __("Fetching data from GSTN")
                     : __("Updating Inward Supply for Return Period {0}", [
-                        data.return_period,
-                    ]);
+                          data.return_period,
+                      ]);
 
             frm.dashboard.show_progress(
                 "Import GSTR Progress",
@@ -937,8 +940,9 @@ class DetailViewDialog {
                         ? ["GST Inward Supply"]
                         : ["Purchase Invoice", "Bill of Entry"],
 
-                read_only_depends_on: `eval: ${this.missing_doctype == "GST Inward Supply"
-                    }`,
+                read_only_depends_on: `eval: ${
+                    this.missing_doctype == "GST Inward Supply"
+                }`,
 
                 onchange: () => {
                     const doctype = this.dialog.get_value("doctype");

--- a/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.js
+++ b/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.js
@@ -135,6 +135,15 @@ frappe.ui.form.on("Purchase Reconciliation Tool", {
         for (let button of $(".custom-actions .inner-group-button")) {
             if (button.innerText?.trim() != "Actions") continue;
             $(".custom-button-group .inner-group-button").remove();
+
+            // to hide `Actions` text on small screens
+            $(button)
+                .find("button")
+                .html(
+                    `<span class="hidden-xs">Actions</span>
+                    ${frappe.utils.icon("select")}`
+                );
+
             $(button).appendTo($(".custom-button-group"));
         }
     },

--- a/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.js
+++ b/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.js
@@ -139,12 +139,17 @@ frappe.ui.form.on("Purchase Reconciliation Tool", {
             $(".custom-button-group .inner-group-button").remove();
 
             // to hide `Actions` text on small screens
-            $(button)
-                .find("button")
-                .html(
-                    `<span class="button-label hidden-xs">${action_group}</span>
-                    ${frappe.utils.icon("select")}`
-                );
+            const actions_btn_html = `
+            <div class="d-none d-sm-block">
+                <span class="button-label">${action_group}</span>
+                ${frappe.utils.icon("select")}
+            </div>
+            <div class="d-block d-sm-none">
+                ${frappe.utils.icon("dot-horizontal")}
+            </div>
+            `;
+
+            $(button).find("button").html(actions_btn_html);
 
             $(button).appendTo($(".custom-button-group"));
         }

--- a/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.js
+++ b/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.js
@@ -156,6 +156,15 @@ frappe.ui.form.on("Purchase Reconciliation Tool", {
 
             $(group_div).appendTo($(".custom-button-group"));
         }
+
+        // remove `Actions` from page actions menu
+        for (const action of frm.$wrapper.find(".user-action")) {
+            const innerText = action?.innerText;
+
+            if (innerText && innerText.includes(action_group)) {
+                $(action).remove();
+            }
+        }
     },
 
     before_save(frm) {

--- a/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.js
+++ b/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.js
@@ -20,8 +20,8 @@ const ALERT_HTML = `
         ? `<a id="download-gstr2b-button" href="#" class="alert-link">
                     Download 2B
                 </a>`
-                : ""
-        }
+        : ""
+    }
     </div>
 `;
 
@@ -135,7 +135,7 @@ frappe.ui.form.on("Purchase Reconciliation Tool", {
 
         // move actions button next to filters
         for (let button of $(".custom-actions .inner-group-button")) {
-            if (button.innerText?.trim() != "Actions") continue;
+            if (button.innerText?.trim() != action_group) continue;
             $(".custom-button-group .inner-group-button").remove();
 
             // to hide `Actions` text on small screens

--- a/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.js
+++ b/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.js
@@ -141,29 +141,10 @@ frappe.ui.form.on("Purchase Reconciliation Tool", {
 
             $(".custom-button-group .inner-group-button").remove();
 
-            // to hide `Actions` text on small screens
-            const actions_btn_html = `
-            <div class="d-none d-sm-block">
-                <span class="button-label">${action_group}</span>
-                ${frappe.utils.icon("select")}
-            </div>
-            <div class="d-block d-sm-none">
-                ${frappe.utils.icon("dot-horizontal")}
-            </div>
-            `;
-
-            $(group_div).find("button").html(actions_btn_html);
+            // to hide `Actions` button group on smaller screens
+            $(group_div).addClass("hidden-md");
 
             $(group_div).appendTo($(".custom-button-group"));
-        }
-
-        // remove `Actions` from page actions menu
-        for (const action of frm.$wrapper.find(".user-action")) {
-            const innerText = action?.innerText;
-
-            if (innerText && innerText.includes(action_group)) {
-                $(action).remove();
-            }
         }
     },
 


### PR DESCRIPTION
- closes: #2595

**Before:**

![before-actions](https://github.com/user-attachments/assets/9a6a09aa-8c22-408b-8e05-176bf03a8064)

**After:**

![after-action-2](https://github.com/user-attachments/assets/a2e4d6d4-2ba7-41a0-ad71-38585c810500)

<sub><a href="https://huly.app/guest/resilienttech?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzRjMGU5OGQyZWY0Y2JjYzQ2Y2ZjMTIiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6Inctc21pdHZvcmEyMDMtcmVzaWxpZW50dGVjLTY2N2U0MjkxLWEwNWMwNjY4N2EtNjM4MjY3In0.D2lYpIgDEfGqanbZoqwmxt0av-3XburJyZqeP167HHk">Huly&reg;: <b>IC-2932</b></a></sub>