### PR TITLE
fix: add documentation links in help

### DIFF
--- a/india_compliance/public/js/help_links.js
+++ b/india_compliance/public/js/help_links.js
@@ -2,6 +2,7 @@ frappe.provide("frappe.help.help_links");
 
 const docsUrl = "https://docs.indiacompliance.app/docs/";
 
+//India Compliance Account
 frappe.help.help_links["india-compliance-account"] = [
 	{
 		label: "India Compliance Account",
@@ -9,20 +10,41 @@ frappe.help.help_links["india-compliance-account"] = [
 	},
 ];
 
+//GST Settings
+frappe.help.help_links["Form/GST Settings"] = [
+	{
+		label: "GSTIN Verification",
+		url: docsUrl + "miscellaneous/gstin_verification",
+	},
+];
+
+//Doctypes
+//Sales Invoice
 if (!frappe.help.help_links["Form/Sales Invoice"]) {
 	frappe.help.help_links["Form/Sales Invoice"] = [];
 }
 
-frappe.help.help_links["Form/Sales Invoice"].push({
-	label: "Sales Transaction",
-	url: docsUrl + "configuration/sales_transaction",
-});
+frappe.help.help_links["Form/Sales Invoice"].push(
+	{
+		label: "Sales Transaction",
+		url: docsUrl + "configuration/sales_transaction",
+	},
+	{
+		label: "e-Waybill",
+		url: docsUrl + "ewaybill-and-einvoice/generating_e_waybill",
+	},
+	{
+		label: "e-Invoice",
+		url: docsUrl + "ewaybill-and-einvoice/generating_e_invoice",
+	},
+);
 
 frappe.help.help_links["List/Sales Invoice"].push({
 	label: "Sales Transaction",
 	url: docsUrl + "configuration/sales_transaction",
 });
 
+//Purchase Invoice
 frappe.help.help_links["Form/Purchase Invoice"] = [
 	{
 		label: "Purchase Transaction",
@@ -39,6 +61,43 @@ frappe.help.help_links["List/Purchase Invoice"].push({
 	url: docsUrl + "configuration/purchase_transaction",
 })
 
+//Delivery Note
+frappe.help.help_links["Form/Delivery Note"].push({
+	label: "e-Waybill",
+	url: docsUrl + "ewaybill-and-einvoice/generating_e_waybill",
+})
+
+//Purchase Receipt
+frappe.help.help_links["Form/Purchase Receipt"] = [
+	{
+		label: "e-Waybill",
+		url: docsUrl + "ewaybill-and-einvoice/generating_e_waybill",
+	}
+]
+
+//Stock Entry
+frappe.help.help_links["Form/Stock Entry"].push({
+	label: "e-Waybill",
+	url: docsUrl + "ewaybill-and-einvoice/generating_e_waybill",
+})
+
+//Subcontracting Receipt
+frappe.help.help_links["Form/Subcontracting Receipt"] = [
+	{
+		label: "e-Waybill",
+		url: docsUrl + "ewaybill-and-einvoice/generating_e_waybill",
+	}
+]
+
+//Journal Entry
+frappe.help.help_links["Form/Journal Entry"] = [
+	{
+		label: "Reversal of Input Tax Credit",
+		url: docsUrl + "configuration/other_transaction#reversal-of-input-tax-credit",
+	}
+]
+
+// GST Reports
 frappe.help.help_links["Form/GSTR-1 Beta"] = [
 	{
 		label: "GSTR-1 Beta",
@@ -60,6 +119,8 @@ frappe.help.help_links["List/GSTR 3B Report"] = [
 	},
 ];
 
+
+//Query Reports
 frappe.help.help_links["query-report/GST Job Work Stock Movement"] = [
 	{
 		label: "GST Job Work Stock Movement",
@@ -88,6 +149,7 @@ frappe.help.help_links["query-report/GST Purchase Register"] = [
 	},
 ];
 
+//Purchase Reconciliation
 frappe.help.help_links["Form/Purchase Reconciliation Tool"] = [
 	{
 		label: "Setup Purchase Reconciliation Tool",
@@ -103,6 +165,7 @@ frappe.help.help_links["Form/Purchase Reconciliation Tool"] = [
 	},
 ];
 
+//Miscellaneous
 frappe.help.help_links["Form/Audit Trail"] = [
 	{
 		label: "Audit Trail",

--- a/india_compliance/public/js/help_links.js
+++ b/india_compliance/public/js/help_links.js
@@ -1,6 +1,7 @@
 frappe.provide("frappe.help.help_links");
 
 const docsUrl = "https://docs.indiacompliance.app/docs/";
+const blogUrl = "https://docs.indiacompliance.app/blog/";
 
 //India Compliance Account
 frappe.help.help_links["india-compliance-account"] = [
@@ -17,15 +18,15 @@ frappe.help.help_links["Form/GST Settings"] = [
         url: docsUrl + "configuration/gst_setup#gst-accounts"
     },
     {
-        label: "GSTIN Verification",
-        url: docsUrl + "miscellaneous/gstin_verification",
+        label: "Setting Up API",
+        url: docsUrl + "ewaybill-and-einvoice/gst_settings"
     },
 ];
 
 //Company
 frappe.help.help_links["Form/Company"] = [
     {
-        label: "Print Format",
+        label: "Print Settings",
         url: docsUrl + "configuration/gst_setup#print-format",
     }
 ];
@@ -39,10 +40,6 @@ if (!frappe.help.help_links["Form/Sales Invoice"]) {
 
 frappe.help.help_links["Form/Sales Invoice"].push(
     {
-        label: "Sales Transaction",
-        url: docsUrl + "configuration/sales_transaction",
-    },
-    {
         label: "e-Waybill",
         url: docsUrl + "ewaybill-and-einvoice/generating_e_waybill",
     },
@@ -52,54 +49,22 @@ frappe.help.help_links["Form/Sales Invoice"].push(
     },
 );
 
-frappe.help.help_links["List/Sales Invoice"].push({
-    label: "Sales Transaction",
-    url: docsUrl + "configuration/sales_transaction",
-});
-
-//Purchase Invoice
-frappe.help.help_links["Form/Purchase Invoice"] = [
-    {
-        label: "Purchase Transaction",
-        url: docsUrl + "configuration/purchase_transaction",
-    },
-    {
-        label: "e-Waybill",
-        url: docsUrl + "ewaybill-and-einvoice/generating_e_waybill",
-    }
-]
-
-frappe.help.help_links["List/Purchase Invoice"].push({
-    label: "Purchase Transaction",
-    url: docsUrl + "configuration/purchase_transaction",
-})
-
-//Delivery Note
-frappe.help.help_links["Form/Delivery Note"].push({
-    label: "e-Waybill",
-    url: docsUrl + "ewaybill-and-einvoice/generating_e_waybill",
-})
-
-//Purchase Receipt
-frappe.help.help_links["Form/Purchase Receipt"] = [
-    {
-        label: "e-Waybill",
-        url: docsUrl + "ewaybill-and-einvoice/generating_e_waybill",
-    }
-]
-
 //Stock Entry
 frappe.help.help_links["Form/Stock Entry"].push({
-    label: "e-Waybill",
-    url: docsUrl + "ewaybill-and-einvoice/generating_e_waybill",
+    label: "Subcontracting Workflow",
+    url: blogUrl + "posts/post5",
 })
 
 //Subcontracting Receipt
 frappe.help.help_links["Form/Subcontracting Receipt"] = [
     {
-        label: "e-Waybill",
-        url: docsUrl + "ewaybill-and-einvoice/generating_e_waybill",
-    }
+        label: "Subcontracting Workflow",
+        url: blogUrl + "posts/post5",
+    },
+    {
+        label: "GST Job Work Stock Movement report",
+        url: docsUrl + "gst-reports/miscellaneous_reports#gst-job-work-stock-movement-report",
+    },
 ]
 
 //Journal Entry
@@ -165,21 +130,13 @@ frappe.help.help_links["query-report/GST Purchase Register"] = [
 //Purchase Reconciliation
 frappe.help.help_links["Form/Purchase Reconciliation Tool"] = [
     {
-        label: "Setup Purchase Reconciliation Tool",
-        url: docsUrl + "purchase-reconciliation/purchase_reconciliation_setup",
-    },
-    {
         label: "Reconciling Purchase",
         url: docsUrl + "purchase-reconciliation/reconciling_purchase",
-    },
-    {
-        label: "Auto Reconcile",
-        url: docsUrl + "purchase-reconciliation/auto_reconcile",
     },
 ];
 
 //Miscellaneous
-frappe.help.help_links["Form/Audit Trail"] = [
+frappe.help.help_links["query-report/Audit Trail"] = [
     {
         label: "Audit Trail",
         url: docsUrl + "miscellaneous/audit_trail",

--- a/india_compliance/public/js/help_links.js
+++ b/india_compliance/public/js/help_links.js
@@ -1,0 +1,118 @@
+frappe.provide("frappe.help.help_links");
+
+const docsUrl = "https://docs.indiacompliance.app/docs/";
+
+frappe.help.help_links["india-compliance-account"] = [
+	{
+		label: "India Compliance Account",
+		url: docsUrl + "getting-started/india_compliance_account",
+	},
+];
+
+if (!frappe.help.help_links["Form/Sales Invoice"]) {
+	frappe.help.help_links["Form/Sales Invoice"] = [];
+}
+
+frappe.help.help_links["Form/Sales Invoice"].push({
+	label: "Sales Transaction",
+	url: docsUrl + "configuration/sales_transaction",
+});
+
+frappe.help.help_links["List/Sales Invoice"].push({
+	label: "Sales Transaction",
+	url: docsUrl + "configuration/sales_transaction",
+});
+
+frappe.help.help_links["Form/Purchase Invoice"] = [
+	{
+		label: "Purchase Transaction",
+		url: docsUrl + "configuration/purchase_transaction",
+	},
+	{
+		label: "e-Waybill",
+		url: docsUrl + "ewaybill-and-einvoice/generating_e_waybill",
+	}
+]
+
+frappe.help.help_links["List/Purchase Invoice"].push({
+	label: "Purchase Transaction",
+	url: docsUrl + "configuration/purchase_transaction",
+})
+
+frappe.help.help_links["Form/GSTR-1 Beta"] = [
+	{
+		label: "GSTR-1 Beta",
+		url: docsUrl + "gst-reports/gstr1",
+	},
+];
+
+frappe.help.help_links["Form/GSTR 3B Report"] = [
+	{
+		label: "GSTR 3B Report",
+		url: docsUrl + "gst-reports/gstr3b",
+	},
+];
+
+frappe.help.help_links["List/GSTR 3B Report"] = [
+	{
+		label: "GSTR 3B Report",
+		url: docsUrl + "gst-reports/gstr3b",
+	},
+];
+
+frappe.help.help_links["query-report/GST Job Work Stock Movement"] = [
+	{
+		label: "GST Job Work Stock Movement",
+		url: docsUrl + "gst-reports/miscellaneous_reports#gst-job-work-stock-movement-report",
+	},
+];
+
+frappe.help.help_links["query-report/GST Balance"] = [
+	{
+		label: "GST Balance",
+		url: docsUrl + "gst-reports/miscellaneous_reports#gst-balance-report",
+	},
+];
+
+frappe.help.help_links["query-report/GST Sales Register Beta"] = [
+	{
+		label: "GST Sales Register Beta",
+		url: docsUrl + "gst-reports/miscellaneous_reports#gst-sales-register-beta-report",
+	},
+];
+
+frappe.help.help_links["query-report/GST Purchase Register"] = [
+	{
+		label: "GST Purchase Register",
+		url: docsUrl + "gst-reports/miscellaneous_reports#gst-purchase-register-beta-report",
+	},
+];
+
+frappe.help.help_links["Form/Purchase Reconciliation Tool"] = [
+	{
+		label: "Setup Purchase Reconciliation Tool",
+		url: docsUrl + "purchase-reconciliation/purchase_reconciliation_setup",
+	},
+	{
+		label: "Reconciling Purchase",
+		url: docsUrl + "purchase-reconciliation/reconciling_purchase",
+	},
+	{
+		label: "Auto Reconcile",
+		url: docsUrl + "purchase-reconciliation/auto_reconcile",
+	},
+];
+
+frappe.help.help_links["Form/Audit Trail"] = [
+	{
+		label: "Audit Trail",
+		url: docsUrl + "miscellaneous/audit_trail",
+	},
+];
+
+frappe.help.help_links["Form/Lower Deduction Certificate"] = [
+	{
+		label: "Lower Deduction Certificate",
+		url: docsUrl + "miscellaneous/lower_deduction_certificate",
+	},
+];

--- a/india_compliance/public/js/help_links.js
+++ b/india_compliance/public/js/help_links.js
@@ -13,10 +13,23 @@ frappe.help.help_links["india-compliance-account"] = [
 //GST Settings
 frappe.help.help_links["Form/GST Settings"] = [
     {
+        label: "Setting Up GST accounts",
+        url: docsUrl + "configuration/gst_setup#gst-accounts"
+    },
+    {
         label: "GSTIN Verification",
         url: docsUrl + "miscellaneous/gstin_verification",
     },
 ];
+
+//Company
+frappe.help.help_links["Form/Company"] = [
+    {
+        label: "Print Format",
+        url: docsUrl + "configuration/gst_setup#print-format",
+    }
+];
+
 
 //Doctypes
 //Sales Invoice

--- a/india_compliance/public/js/help_links.js
+++ b/india_compliance/public/js/help_links.js
@@ -4,178 +4,178 @@ const docsUrl = "https://docs.indiacompliance.app/docs/";
 
 //India Compliance Account
 frappe.help.help_links["india-compliance-account"] = [
-	{
-		label: "India Compliance Account",
-		url: docsUrl + "getting-started/india_compliance_account",
-	},
+    {
+        label: "India Compliance Account",
+        url: docsUrl + "getting-started/india_compliance_account",
+    },
 ];
 
 //GST Settings
 frappe.help.help_links["Form/GST Settings"] = [
-	{
-		label: "GSTIN Verification",
-		url: docsUrl + "miscellaneous/gstin_verification",
-	},
+    {
+        label: "GSTIN Verification",
+        url: docsUrl + "miscellaneous/gstin_verification",
+    },
 ];
 
 //Doctypes
 //Sales Invoice
 if (!frappe.help.help_links["Form/Sales Invoice"]) {
-	frappe.help.help_links["Form/Sales Invoice"] = [];
+    frappe.help.help_links["Form/Sales Invoice"] = [];
 }
 
 frappe.help.help_links["Form/Sales Invoice"].push(
-	{
-		label: "Sales Transaction",
-		url: docsUrl + "configuration/sales_transaction",
-	},
-	{
-		label: "e-Waybill",
-		url: docsUrl + "ewaybill-and-einvoice/generating_e_waybill",
-	},
-	{
-		label: "e-Invoice",
-		url: docsUrl + "ewaybill-and-einvoice/generating_e_invoice",
-	},
+    {
+        label: "Sales Transaction",
+        url: docsUrl + "configuration/sales_transaction",
+    },
+    {
+        label: "e-Waybill",
+        url: docsUrl + "ewaybill-and-einvoice/generating_e_waybill",
+    },
+    {
+        label: "e-Invoice",
+        url: docsUrl + "ewaybill-and-einvoice/generating_e_invoice",
+    },
 );
 
 frappe.help.help_links["List/Sales Invoice"].push({
-	label: "Sales Transaction",
-	url: docsUrl + "configuration/sales_transaction",
+    label: "Sales Transaction",
+    url: docsUrl + "configuration/sales_transaction",
 });
 
 //Purchase Invoice
 frappe.help.help_links["Form/Purchase Invoice"] = [
-	{
-		label: "Purchase Transaction",
-		url: docsUrl + "configuration/purchase_transaction",
-	},
-	{
-		label: "e-Waybill",
-		url: docsUrl + "ewaybill-and-einvoice/generating_e_waybill",
-	}
+    {
+        label: "Purchase Transaction",
+        url: docsUrl + "configuration/purchase_transaction",
+    },
+    {
+        label: "e-Waybill",
+        url: docsUrl + "ewaybill-and-einvoice/generating_e_waybill",
+    }
 ]
 
 frappe.help.help_links["List/Purchase Invoice"].push({
-	label: "Purchase Transaction",
-	url: docsUrl + "configuration/purchase_transaction",
+    label: "Purchase Transaction",
+    url: docsUrl + "configuration/purchase_transaction",
 })
 
 //Delivery Note
 frappe.help.help_links["Form/Delivery Note"].push({
-	label: "e-Waybill",
-	url: docsUrl + "ewaybill-and-einvoice/generating_e_waybill",
+    label: "e-Waybill",
+    url: docsUrl + "ewaybill-and-einvoice/generating_e_waybill",
 })
 
 //Purchase Receipt
 frappe.help.help_links["Form/Purchase Receipt"] = [
-	{
-		label: "e-Waybill",
-		url: docsUrl + "ewaybill-and-einvoice/generating_e_waybill",
-	}
+    {
+        label: "e-Waybill",
+        url: docsUrl + "ewaybill-and-einvoice/generating_e_waybill",
+    }
 ]
 
 //Stock Entry
 frappe.help.help_links["Form/Stock Entry"].push({
-	label: "e-Waybill",
-	url: docsUrl + "ewaybill-and-einvoice/generating_e_waybill",
+    label: "e-Waybill",
+    url: docsUrl + "ewaybill-and-einvoice/generating_e_waybill",
 })
 
 //Subcontracting Receipt
 frappe.help.help_links["Form/Subcontracting Receipt"] = [
-	{
-		label: "e-Waybill",
-		url: docsUrl + "ewaybill-and-einvoice/generating_e_waybill",
-	}
+    {
+        label: "e-Waybill",
+        url: docsUrl + "ewaybill-and-einvoice/generating_e_waybill",
+    }
 ]
 
 //Journal Entry
 frappe.help.help_links["Form/Journal Entry"] = [
-	{
-		label: "Reversal of Input Tax Credit",
-		url: docsUrl + "configuration/other_transaction#reversal-of-input-tax-credit",
-	}
+    {
+        label: "Reversal of Input Tax Credit",
+        url: docsUrl + "configuration/other_transaction#reversal-of-input-tax-credit",
+    }
 ]
 
 // GST Reports
 frappe.help.help_links["Form/GSTR-1 Beta"] = [
-	{
-		label: "GSTR-1 Beta",
-		url: docsUrl + "gst-reports/gstr1",
-	},
+    {
+        label: "GSTR-1 Beta",
+        url: docsUrl + "gst-reports/gstr1",
+    },
 ];
 
 frappe.help.help_links["Form/GSTR 3B Report"] = [
-	{
-		label: "GSTR 3B Report",
-		url: docsUrl + "gst-reports/gstr3b",
-	},
+    {
+        label: "GSTR 3B Report",
+        url: docsUrl + "gst-reports/gstr3b",
+    },
 ];
 
 frappe.help.help_links["List/GSTR 3B Report"] = [
-	{
-		label: "GSTR 3B Report",
-		url: docsUrl + "gst-reports/gstr3b",
-	},
+    {
+        label: "GSTR 3B Report",
+        url: docsUrl + "gst-reports/gstr3b",
+    },
 ];
 
 
 //Query Reports
 frappe.help.help_links["query-report/GST Job Work Stock Movement"] = [
-	{
-		label: "GST Job Work Stock Movement",
-		url: docsUrl + "gst-reports/miscellaneous_reports#gst-job-work-stock-movement-report",
-	},
+    {
+        label: "GST Job Work Stock Movement",
+        url: docsUrl + "gst-reports/miscellaneous_reports#gst-job-work-stock-movement-report",
+    },
 ];
 
 frappe.help.help_links["query-report/GST Balance"] = [
-	{
-		label: "GST Balance",
-		url: docsUrl + "gst-reports/miscellaneous_reports#gst-balance-report",
-	},
+    {
+        label: "GST Balance",
+        url: docsUrl + "gst-reports/miscellaneous_reports#gst-balance-report",
+    },
 ];
 
 frappe.help.help_links["query-report/GST Sales Register Beta"] = [
-	{
-		label: "GST Sales Register Beta",
-		url: docsUrl + "gst-reports/miscellaneous_reports#gst-sales-register-beta-report",
-	},
+    {
+        label: "GST Sales Register Beta",
+        url: docsUrl + "gst-reports/miscellaneous_reports#gst-sales-register-beta-report",
+    },
 ];
 
 frappe.help.help_links["query-report/GST Purchase Register"] = [
-	{
-		label: "GST Purchase Register",
-		url: docsUrl + "gst-reports/miscellaneous_reports#gst-purchase-register-beta-report",
-	},
+    {
+        label: "GST Purchase Register",
+        url: docsUrl + "gst-reports/miscellaneous_reports#gst-purchase-register-beta-report",
+    },
 ];
 
 //Purchase Reconciliation
 frappe.help.help_links["Form/Purchase Reconciliation Tool"] = [
-	{
-		label: "Setup Purchase Reconciliation Tool",
-		url: docsUrl + "purchase-reconciliation/purchase_reconciliation_setup",
-	},
-	{
-		label: "Reconciling Purchase",
-		url: docsUrl + "purchase-reconciliation/reconciling_purchase",
-	},
-	{
-		label: "Auto Reconcile",
-		url: docsUrl + "purchase-reconciliation/auto_reconcile",
-	},
+    {
+        label: "Setup Purchase Reconciliation Tool",
+        url: docsUrl + "purchase-reconciliation/purchase_reconciliation_setup",
+    },
+    {
+        label: "Reconciling Purchase",
+        url: docsUrl + "purchase-reconciliation/reconciling_purchase",
+    },
+    {
+        label: "Auto Reconcile",
+        url: docsUrl + "purchase-reconciliation/auto_reconcile",
+    },
 ];
 
 //Miscellaneous
 frappe.help.help_links["Form/Audit Trail"] = [
-	{
-		label: "Audit Trail",
-		url: docsUrl + "miscellaneous/audit_trail",
-	},
+    {
+        label: "Audit Trail",
+        url: docsUrl + "miscellaneous/audit_trail",
+    },
 ];
 
 frappe.help.help_links["Form/Lower Deduction Certificate"] = [
-	{
-		label: "Lower Deduction Certificate",
-		url: docsUrl + "miscellaneous/lower_deduction_certificate",
-	},
+    {
+        label: "Lower Deduction Certificate",
+        url: docsUrl + "miscellaneous/lower_deduction_certificate",
+    },
 ];

--- a/india_compliance/public/js/india_compliance.bundle.js
+++ b/india_compliance/public/js/india_compliance.bundle.js
@@ -8,3 +8,4 @@ import "./new_gst_category_notification";
 import "./quick_info_popover";
 import "./custom_number_card";
 import "./taxes_controller";
+import "./help_links";


### PR DESCRIPTION
## Clicking Help Now will display the documentation link specific to the doctype.

Like here Clicking GSTR-1 Beta will redirect you to its documentation.

<img width="464" src="https://github.com/user-attachments/assets/d93be982-ce76-4b1e-b1a6-88ec08536a16" alt="Documentation">

<sub><a href="https://huly.app/guest/resilienttech?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzRmZTY1Y2QyZWY0Y2JjYzQ2ZTFlNTQiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6Inctc21pdHZvcmEyMDMtcmVzaWxpZW50dGVjLTY2N2U0MjkxLWEwNWMwNjY4N2EtNjM4MjY3In0.XQ_GSRxU4m2V3plr9mCXXSQndwEVnlt5HSSC7qDpLrA">Huly&reg;: <b>IC-2936</b></a></sub>