### PR TITLE
fix(patch): ignore validate when creating item tax template

### DIFF
--- a/india_compliance/patches/post_install/improve_item_tax_template.py
+++ b/india_compliance/patches/post_install/improve_item_tax_template.py
@@ -125,6 +125,7 @@ def create_or_update_item_tax_templates(companies):
         elif doc.gst_rate == 0:
             doc.gst_treatment = "Nil-Rated"
 
+        doc.flags.ignore_validate = True  # eg: account_type validation
         doc.save()
 
     # create new templates for nil rated, exempted, non gst
@@ -261,6 +262,7 @@ def remove_old_item_variant_settings():
         if field.field_name in ("is_nil_exempt", "is_non_gst"):
             item_variant.fields.remove(field)
 
+    item_variant.flags.ignore_validate = True
     item_variant.save()
 
 


### PR DESCRIPTION

<sub><a href="https://huly.app/guest/resilienttech?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzU2Y2Q3NzFlMDYzMmRkMDhlMjdhODEiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6Inctc21pdHZvcmEyMDMtcmVzaWxpZW50dGVjLTY2N2U0MjkxLWEwNWMwNjY4N2EtNjM4MjY3In0.L6kN_UNbwJvLgP_PUYyC-hmMWEqbNMUmAYWF_LhE_bA">Huly&reg;: <b>IC-2957</b></a></sub>