### PR TITLE
fix: correct categorisation of is_export and fetching taxes accordingly

### DIFF
--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -917,7 +917,12 @@ def get_gst_details(party_details, doctype, company, *, update_place_of_supply=F
                 == party_details.get(party_gstin_field)
             )  # Internal transfer
         )
-        or (is_sales_transaction and is_export_without_payment_of_gst(party_details))
+        or (
+            is_sales_transaction
+            and is_export_without_payment_of_gst(
+                frappe._dict({**party_details, "doctype": doctype})
+            )
+        )
         or (
             not is_sales_transaction
             and (


### PR DESCRIPTION
Support Issue: https://support.frappe.io/helpdesk/tickets/22715

<sub><a href="https://huly.app/guest/resilienttech?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzU5MWQyYzFlMDYzMmRkMDhlMzBhYTEiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6Inctc21pdHZvcmEyMDMtcmVzaWxpZW50dGVjLTY2N2U0MjkxLWEwNWMwNjY4N2EtNjM4MjY3In0.R8WMHxE-VKrZ8qsaIsqXk83FwqIBJsaDIvh71pqLhKs">Huly&reg;: <b>IC-2963</b></a></sub>