### PR TITLE
fix: use bulk insert to ignore validations (backport #2826)

### DIFF
--- a/india_compliance/patches/v15/migrate_boe_taxes_to_ic_taxes.py
+++ b/india_compliance/patches/v15/migrate_boe_taxes_to_ic_taxes.py
@@ -1,4 +1,6 @@
 import frappe
+from frappe.model.document import bulk_insert
+from frappe.model.naming import _generate_random_string
 
 
 def execute():
@@ -8,16 +10,33 @@ def execute():
     boe_taxes = frappe.qb.DocType("Bill of Entry Taxes")
     boe_taxes_docs = frappe.qb.from_(boe_taxes).select("*").run(as_dict=True)
 
+    ic_taxes_names = set(
+        frappe.get_all("India Compliance Taxes and Charges", pluck="name")
+    )
+    ic_taxes = []
+
     for doc in boe_taxes_docs:
         ic_taxes_doc = frappe.get_doc(
             {
                 **doc,
                 "doctype": "India Compliance Taxes and Charges",
-                "name": None,
+                "name": set_name(doc.name, ic_taxes_names),
                 "base_total": doc.total,
             }
         )
-        ic_taxes_doc.insert(ignore_if_duplicate=True)
+
+        ic_taxes.append(ic_taxes_doc)
+
+    bulk_insert("India Compliance Taxes and Charges", ic_taxes)
 
     # Drop the old table
     frappe.db.delete("Bill of Entry Taxes")
+
+
+def set_name(name, names):
+    new_name = name
+    while new_name in names:
+        new_name = _generate_random_string(10)
+
+    names.add(new_name)
+    return new_name


### PR DESCRIPTION

<sub><a href="https://huly.app/guest/resilienttech?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzVhY2Q3YTFlMDYzMmRkMDhlMzQ3ZmYiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6Inctc21pdHZvcmEyMDMtcmVzaWxpZW50dGVjLTY2N2U0MjkxLWEwNWMwNjY4N2EtNjM4MjY3In0.SUtf75MdXwqeqBwvgVg6Ifc0V5b1zPt2T5q7cJtKfB4">Huly&reg;: <b>IC-2967</b></a></sub>