### PR TITLE
fix: taxable value for invoice without qty and value (backport #2830)

### DIFF
--- a/india_compliance/gst_india/overrides/test_transaction.py
+++ b/india_compliance/gst_india/overrides/test_transaction.py
@@ -419,6 +419,41 @@ class TestTransaction(FrappeTestCase):
         doc.insert()
         self.assertDocumentEqual({"taxable_value": 100}, doc.items[0])
 
+    def test_credit_not_without_quantity(self):
+        if self.doctype != "Sales Invoice":
+            return
+
+        doc = create_transaction(
+            **self.transaction_details, is_return=True, do_not_save=True
+        )
+        append_item(doc)
+
+        for item in doc.items:
+            item.qty = 0
+            item.rate = 0
+            item.price_list_rate = 0
+
+        # Adding charges
+        doc.append(
+            "taxes",
+            {
+                "charge_type": "Actual",
+                "account_head": "Freight and Forwarding Charges - _TIRC",
+                "description": "Freight",
+                "tax_amount": 20,
+                "cost_center": "Main - _TIRC",
+            },
+        )
+
+        # Adding taxes
+        _append_taxes(
+            doc, ("CGST", "SGST"), charge_type="On Previous Row Total", row_id=1
+        )
+        doc.insert()
+
+        for item in doc.items:
+            self.assertDocumentEqual({"taxable_value": 10}, item)
+
     def test_validate_place_of_supply(self):
         doc = create_transaction(**self.transaction_details, do_not_save=True)
         doc.place_of_supply = "96-Others"

--- a/india_compliance/gst_india/overrides/test_transaction.py
+++ b/india_compliance/gst_india/overrides/test_transaction.py
@@ -419,7 +419,7 @@ class TestTransaction(FrappeTestCase):
         doc.insert()
         self.assertDocumentEqual({"taxable_value": 100}, doc.items[0])
 
-    def test_credit_not_without_quantity(self):
+    def test_credit_note_without_quantity(self):
         if self.doctype != "Sales Invoice":
             return
 
@@ -451,8 +451,11 @@ class TestTransaction(FrappeTestCase):
         )
         doc.insert()
 
+        # Ensure correct taxable_value and gst details
         for item in doc.items:
-            self.assertDocumentEqual({"taxable_value": 10}, item)
+            self.assertDocumentEqual(
+                {"taxable_value": 10, "cgst_amount": 0.9, "sgst_amount": 0.9}, item
+            )
 
     def test_validate_place_of_supply(self):
         doc = create_transaction(**self.transaction_details, do_not_save=True)

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -71,6 +71,7 @@ def update_taxable_values(doc):
     total_charges = 0
     apportioned_charges = 0
     tax_witholding_amount = 0
+    has_no_qty_value = False
 
     if doc.taxes:
         if any(
@@ -105,8 +106,10 @@ def update_taxable_values(doc):
     # base net total may be zero if invoice has zero rated items + shipping
     total_value = doc.base_net_total if doc.base_net_total else doc.total_qty
 
+    # credit note without item qty and value but with charges
     if not total_value:
-        return
+        total_value = len(doc.items)
+        has_no_qty_value = True
 
     for item in doc.items:
         item.taxable_value = item.base_net_amount
@@ -114,7 +117,12 @@ def update_taxable_values(doc):
         if not total_charges:
             continue
 
-        proportionate_value = item.base_net_amount if doc.base_net_total else item.qty
+        if has_no_qty_value:
+            proportionate_value = 1
+        elif doc.base_net_total:
+            proportionate_value = item.base_net_amount
+        else:
+            proportionate_value = item.qty
 
         applicable_charges = flt(
             proportionate_value * (total_charges / total_value),
@@ -499,7 +507,7 @@ class GSTAccounts:
                 )
 
             if row.charge_type == "On Previous Row Total":
-                previous_row_references.add(row.row_id)
+                previous_row_references.add(flt(row.row_id))
 
             # validating charge type "On Item Quantity" and non_cess_advol_account
             self.validate_charge_type_for_cess_non_advol_accounts(row)


### PR DESCRIPTION

<sub><a href="https://huly.app/guest/resilienttech?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzVhZDk3YTFlMDYzMmRkMDhlMzRjODIiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6Inctc21pdHZvcmEyMDMtcmVzaWxpZW50dGVjLTY2N2U0MjkxLWEwNWMwNjY4N2EtNjM4MjY3In0.fpgNqqOKVC-AKHJj2xgO2zLTSlPkzIzb0P_Ccazi6Es">Huly&reg;: <b>IC-2975</b></a></sub>