### PR TITLE
fix: show error message instead of throw during Purchase Invoice name validation 

### DIFF
--- a/india_compliance/gst_india/overrides/test_purchase_invoice.py
+++ b/india_compliance/gst_india/overrides/test_purchase_invoice.py
@@ -79,8 +79,9 @@ class TestPurchaseInvoice(IntegrationTestCase):
         setattr(pinv, "__newname", "INV/2022/00001/asdfsadg")  # NOQA
         pinv.meta.autoname = "prompt"
 
-        self.assertRaisesRegex(
-            frappe.exceptions.ValidationError,
+        pinv.save()
+
+        self.assertEqual(
+            frappe.parse_json(frappe.message_log[-1]).get("message"),
             "Transaction Name must be 16 characters or fewer to meet GST requirements",
-            pinv.save,
         )

--- a/india_compliance/gst_india/overrides/test_sales_invoice.py
+++ b/india_compliance/gst_india/overrides/test_sales_invoice.py
@@ -16,7 +16,9 @@ class TestSalesInvoice(IntegrationTestCase):
             "PI2021 - 001",
         ]
         for name in invalid_names:
-            doc = frappe._dict(name=name, posting_date=posting_date)
+            doc = frappe._dict(
+                name=name, posting_date=posting_date, doctype="Sales Invoice"
+            )
             self.assertRaises(frappe.ValidationError, validate_invoice_number, doc)
 
         valid_names = [

--- a/india_compliance/gst_india/utils/__init__.py
+++ b/india_compliance/gst_india/utils/__init__.py
@@ -955,11 +955,10 @@ def validate_invoice_number(doc, throw=True):
             " only contain alphanumeric characters, dash (-) and slash (/) to meet GST requirements"
         )
 
-    if doc.doctype == "Purchase Invoice":
-        frappe.msgprint(message, title=title)
-        return
+    if doc.doctype == "Sales Invoice":
+        frappe.throw(message, title=title)
 
-    frappe.throw(message, title=title)
+    frappe.msgprint(message, title=title)
 
 
 def handle_server_errors(settings, doc, document_type, error):

--- a/india_compliance/gst_india/utils/__init__.py
+++ b/india_compliance/gst_india/utils/__init__.py
@@ -940,22 +940,24 @@ def validate_invoice_number(doc, throw=True):
     if not throw:
         return is_valid_length and is_valid_format
 
+    title = _("Invalid GST Transaction Name")
+
     if not is_valid_length:
-        frappe.throw(
-            _(
-                "Transaction Name must be 16 characters or fewer to meet GST requirements"
-            ),
-            title=_("Invalid GST Transaction Name"),
+        message = _(
+            "Transaction Name must be 16 characters or fewer to meet GST requirements"
         )
+        if doc.doctype == "Purchase Invoice":
+            frappe.msgprint(message, title=title)
+            return
+
+        frappe.throw(message, title=title)
 
     if not is_valid_format:
-        frappe.throw(
-            _(
-                "Transaction Name should start with an alphanumeric character and can"
-                " only contain alphanumeric characters, dash (-) and slash (/) to meet GST requirements"
-            ),
-            title=_("Invalid GST Transaction Name"),
+        message = _(
+            "Transaction Name should start with an alphanumeric character and can"
+            " only contain alphanumeric characters, dash (-) and slash (/) to meet GST requirements"
         )
+        frappe.throw(message, title=title)
 
 
 def handle_server_errors(settings, doc, document_type, error):

--- a/india_compliance/gst_india/utils/__init__.py
+++ b/india_compliance/gst_india/utils/__init__.py
@@ -940,24 +940,26 @@ def validate_invoice_number(doc, throw=True):
     if not throw:
         return is_valid_length and is_valid_format
 
+    if is_valid_length and is_valid_format:
+        return
+
     title = _("Invalid GST Transaction Name")
 
     if not is_valid_length:
         message = _(
             "Transaction Name must be 16 characters or fewer to meet GST requirements"
         )
-        if doc.doctype == "Purchase Invoice":
-            frappe.msgprint(message, title=title)
-            return
-
-        frappe.throw(message, title=title)
-
-    if not is_valid_format:
+    else:
         message = _(
             "Transaction Name should start with an alphanumeric character and can"
             " only contain alphanumeric characters, dash (-) and slash (/) to meet GST requirements"
         )
-        frappe.throw(message, title=title)
+
+    if doc.doctype == "Purchase Invoice":
+        frappe.msgprint(message, title=title)
+        return
+
+    frappe.throw(message, title=title)
 
 
 def handle_server_errors(settings, doc, document_type, error):


### PR DESCRIPTION
Issue: [Support Ticket  - 27223](https://support.frappe.io/app/hd-ticket/27223)

<sub><a href="https://huly.app/guest/resilienttech?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzVjMjYyMjFlMDYzMmRkMDhlMzdhMTciLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6Inctc21pdHZvcmEyMDMtcmVzaWxpZW50dGVjLTY2N2U0MjkxLWEwNWMwNjY4N2EtNjM4MjY3In0.lKwXaJQObjkrman-B4lJL6H9TJMlgXZyOFK09tKWE8A">Huly&reg;: <b>IC-2991</b></a></sub>