### PR TITLE
fix: update minimum and maximum net rate field in item

### DIFF
--- a/india_compliance/gst_india/doctype/gst_hsn_code/gst_hsn_code.js
+++ b/india_compliance/gst_india/doctype/gst_hsn_code/gst_hsn_code.js
@@ -16,7 +16,7 @@ frappe.ui.form.on('GST HSN Code', {
 							method: 'india_compliance.gst_india.doctype.gst_hsn_code.gst_hsn_code.update_taxes_in_item_master',
 							callback: function(r) {
 								if(r.message){
-									frappe.show_alert(__('Item taxes updated'));
+									frappe.show_alert(__('Items with this HSN code will be updated shortly'));
 								}
 							}
 						});

--- a/india_compliance/gst_india/doctype/gst_hsn_code/gst_hsn_code.py
+++ b/india_compliance/gst_india/doctype/gst_hsn_code/gst_hsn_code.py
@@ -37,6 +37,8 @@ def update_item_document(taxes, hsn_code):
                     "item_tax_template": tax.item_tax_template,
                     "tax_category": tax.tax_category,
                     "valid_from": tax.valid_from,
+                    "minimum_net_rate": tax.minimum_net_rate,
+                    "maximum_net_rate": tax.maximum_net_rate,
                 },
             )
 

--- a/india_compliance/gst_india/overrides/item.py
+++ b/india_compliance/gst_india/overrides/item.py
@@ -43,5 +43,7 @@ def set_taxes_from_hsn_code(doc):
                 "item_tax_template": tax.item_tax_template,
                 "tax_category": tax.tax_category,
                 "valid_from": tax.valid_from,
+                "minimum_net_rate": tax.minimum_net_rate,
+                "maximum_net_rate": tax.maximum_net_rate,
             },
         )


### PR DESCRIPTION
The button given in hsn gst code doctype called update taxes for items was not updating minimum and maximum net rate at item level
Issue: [Support Ticket  - 27302](https://support.frappe.io/app/hd-ticket/27302)

<sub><a href="https://huly.app/guest/resilienttech?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzVmZGVhOWYxNDRmNTg1YWU0ZDc5M2UiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6Inctc21pdHZvcmEyMDMtcmVzaWxpZW50dGVjLTY2N2U0MjkxLWEwNWMwNjY4N2EtNjM4MjY3In0.STqKlmprXE3jDONgnzc__u32fkUHD_rqeQEY18qFrcI">Huly&reg;: <b>IC-2997</b></a></sub>