### PR TITLE
fix: validate item tax template item_name wise if item_code is not set

### DIFF
--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -587,13 +587,14 @@ def validate_items(doc):
     items_with_duplicate_taxes = []
 
     for row in doc.items:
+        item_key = row.item_code or row.item_name
         # Different Item Tax Templates should not be used for the same Item Code
-        if row.item_code not in item_tax_templates:
-            item_tax_templates[row.item_code] = row.item_tax_template
+        if item_key not in item_tax_templates:
+            item_tax_templates[item_key] = row.item_tax_template
             continue
 
-        if row.item_tax_template != item_tax_templates[row.item_code]:
-            items_with_duplicate_taxes.append(bold(row.item_code))
+        if row.item_tax_template != item_tax_templates[item_key]:
+            items_with_duplicate_taxes.append(bold(item_key))
 
     if items_with_duplicate_taxes:
         frappe.throw(


### PR DESCRIPTION
If an invoice is created without item_code validation is raised.

![image](https://github.com/user-attachments/assets/64c2483b-6034-4a2c-bfc6-d6dd25bdee37)

https://support.frappe.io/app/hd-ticket/27407

<sub><a href="https://huly.app/guest/resilienttech?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzYzZjE2NGYxNDRmNTg1YWU0ZTM3ZDQiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6Inctc21pdHZvcmEyMDMtcmVzaWxpZW50dGVjLTY2N2U0MjkxLWEwNWMwNjY4N2EtNjM4MjY3In0.HqL3BTKLeFpjL1oNcxJG9rPd1wD-pOggQ4QjDtdtqqU">Huly&reg;: <b>IC-3006</b></a></sub>