### PR TITLE
fix: sub-category filtering for Nil-Rated, Exempted and Non-GST

### DIFF
--- a/india_compliance/gst_india/report/gst_sales_register_beta/test_sales_register_beta.py
+++ b/india_compliance/gst_india/report/gst_sales_register_beta/test_sales_register_beta.py
@@ -18,6 +18,25 @@ FILTERS = {
 
 EXPECTED_SUMMARY_BY_HSN = [
     {
+        "item_code": "_Test Non GST Item",
+        "gst_hsn_code": "27131100",
+        "billing_address_gstin": None,
+        "company_gstin": "24AAQCA8719H1ZC",
+        "customer_name": "_Test Unregistered Customer",
+        "place_of_supply": "24-Gujarat",
+        "invoice_total": 5000.0,
+        "returned_invoice_total": 0.0,
+        "gst_category": "Unregistered",
+        "gst_treatment": "Non-GST",
+        "gst_rate": 0.0,
+        "taxable_value": 5000.0,
+        "total_amount": 5000.0,
+        "total_tax_amount": 0.0,
+        "invoice_category": "Nil-Rated, Exempted, Non-GST",
+        "invoice_sub_category": "Non-GST",
+        "invoice_type": "Intra-State supplies to unregistered persons",
+    },
+    {
         "item_code": "_Test Service Item",
         "gst_hsn_code": "999900",
         "billing_address_gstin": None,
@@ -167,7 +186,7 @@ EXPECTED_SUMMARY_BY_HSN = [
         "total_tax_amount": 0.0,
         "invoice_category": "Nil-Rated, Exempted, Non-GST",
         "invoice_type": "Inter-State supplies to registered persons",
-        "invoice_sub_category": "Nil-Rated, Exempted, Non-GST",
+        "invoice_sub_category": "Nil-Rated",
     },
     {
         "item_code": "_Test Service Item",
@@ -205,7 +224,7 @@ EXPECTED_SUMMARY_BY_HSN = [
         "total_tax_amount": 0.0,
         "invoice_category": "Nil-Rated, Exempted, Non-GST",
         "invoice_type": "Inter-State supplies to registered persons",
-        "invoice_sub_category": "Nil-Rated, Exempted, Non-GST",
+        "invoice_sub_category": "Nil-Rated",
     },
     {
         "item_code": "_Test Service Item",
@@ -242,7 +261,7 @@ EXPECTED_SUMMARY_BY_HSN = [
         "total_tax_amount": 0.0,
         "invoice_category": "Nil-Rated, Exempted, Non-GST",
         "invoice_type": "Intra-State supplies to unregistered persons",
-        "invoice_sub_category": "Nil-Rated, Exempted, Non-GST",
+        "invoice_sub_category": "Nil-Rated",
     },
     {
         "item_code": "_Test Service Item",
@@ -279,7 +298,7 @@ EXPECTED_SUMMARY_BY_HSN = [
         "total_tax_amount": 0.0,
         "invoice_category": "Nil-Rated, Exempted, Non-GST",
         "invoice_type": "Intra-State supplies to unregistered persons",
-        "invoice_sub_category": "Nil-Rated, Exempted, Non-GST",
+        "invoice_sub_category": "Nil-Rated",
     },
     {
         "item_code": "_Test Service Item",
@@ -316,7 +335,7 @@ EXPECTED_SUMMARY_BY_HSN = [
         "total_tax_amount": 0.0,
         "invoice_category": "Nil-Rated, Exempted, Non-GST",
         "invoice_type": "Inter-State supplies to unregistered persons",
-        "invoice_sub_category": "Nil-Rated, Exempted, Non-GST",
+        "invoice_sub_category": "Nil-Rated",
     },
 ]
 
@@ -423,7 +442,7 @@ EXPECTED_OVERVIEW = [
     {
         "description": "B2C (Others)",
         "indent": 0,
-        "taxable_value": 121000.0,
+        "taxable_value": 121000,
         "igst_amount": 1800.0,
         "cgst_amount": 9990.0,
         "sgst_amount": 9990.0,
@@ -441,6 +460,15 @@ EXPECTED_OVERVIEW = [
     {
         "description": "Nil-Rated, Exempted, Non-GST",
         "indent": 0,
+        "taxable_value": 50000.0,
+        "igst_amount": 0.0,
+        "cgst_amount": 0.0,
+        "sgst_amount": 0.0,
+        "total_cess_amount": 0.0,
+    },
+    {
+        "description": "Nil-Rated",
+        "indent": 1,
         "taxable_value": 45000.0,
         "igst_amount": 0.0,
         "cgst_amount": 0.0,
@@ -448,9 +476,18 @@ EXPECTED_OVERVIEW = [
         "total_cess_amount": 0.0,
     },
     {
-        "description": "Nil-Rated, Exempted, Non-GST",
+        "description": "Exempted",
         "indent": 1,
-        "taxable_value": 45000.0,
+        "taxable_value": 0,
+        "igst_amount": 0.0,
+        "cgst_amount": 0.0,
+        "sgst_amount": 0.0,
+        "total_cess_amount": 0.0,
+    },
+    {
+        "description": "Non-GST",
+        "indent": 1,
+        "taxable_value": 5000.0,
         "igst_amount": 0.0,
         "cgst_amount": 0.0,
         "sgst_amount": 0.0,
@@ -638,6 +675,18 @@ INVOICES = [
                 "rate": 2000,
                 "qty": -150,
             },
+        ],
+    },
+    {
+        "company_gstin": "24AAQCA8719H1ZC",
+        "customer": "_Test Unregistered Customer",
+        "place_of_supply": "24-Gujarat",
+        "items": [
+            {
+                "item_code": "_Test Non GST Item",
+                "rate": 100,
+                "qty": 50,
+            }
         ],
     },
 ]

--- a/india_compliance/gst_india/utils/gstr_1/__init__.py
+++ b/india_compliance/gst_india/utils/gstr_1/__init__.py
@@ -41,6 +41,9 @@ class GSTR1_SubCategory(Enum):
     B2CL = "B2C (Large)"
     B2CS = "B2C (Others)"
     NIL_EXEMPT = "Nil-Rated, Exempted, Non-GST"
+    NIL_RATED = "Nil-Rated"
+    EXEMPTED = "Exempted"
+    NON_GST = "Non-GST"
     CDNR = "Credit/Debit Notes (Registered)"
     CDNUR = "Credit/Debit Notes (Unregistered)"
 
@@ -71,7 +74,11 @@ CATEGORY_SUB_CATEGORY_MAPPING = {
     GSTR1_Category.B2CL: (GSTR1_SubCategory.B2CL,),
     GSTR1_Category.EXP: (GSTR1_SubCategory.EXPWP, GSTR1_SubCategory.EXPWOP),
     GSTR1_Category.B2CS: (GSTR1_SubCategory.B2CS,),
-    GSTR1_Category.NIL_EXEMPT: (GSTR1_SubCategory.NIL_EXEMPT,),
+    GSTR1_Category.NIL_EXEMPT: (
+        GSTR1_SubCategory.NIL_RATED,
+        GSTR1_SubCategory.EXEMPTED,
+        GSTR1_SubCategory.NON_GST,
+    ),
     GSTR1_Category.CDNR: (GSTR1_SubCategory.CDNR,),
     GSTR1_Category.CDNUR: (GSTR1_SubCategory.CDNUR,),
     GSTR1_Category.AT: (GSTR1_SubCategory.AT,),
@@ -83,6 +90,16 @@ CATEGORY_SUB_CATEGORY_MAPPING = {
         GSTR1_SubCategory.SUPECOM_9_5,
     ),
 }
+
+OVERLAPPING_INVOICE_SUBCATEGORIES = frozenset(
+    (
+        GSTR1_SubCategory.NIL_RATED.value,
+        GSTR1_SubCategory.EXEMPTED.value,
+        GSTR1_SubCategory.NON_GST.value,
+        GSTR1_SubCategory.SUPECOM_52.value,
+        GSTR1_SubCategory.SUPECOM_9_5.value,
+    )
+)
 
 
 class GSTR1_DataField(Enum):


### PR DESCRIPTION

<sub><a href="https://huly.app/guest/resilienttech?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzcyNDNmYWYxNDRmNTg1YWU1MTVlOWIiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6Inctc21pdHZvcmEyMDMtcmVzaWxpZW50dGVjLTY2N2U0MjkxLWEwNWMwNjY4N2EtNjM4MjY3In0.N2JOoAFUnz3NtQKz3IK-GaudFNhKCyfq8eIQJ_ntxw8">Huly&reg;: <b>IC-3038</b></a></sub>