### PR TITLE
fix: handle multiple GSTR-1 beta requests 

### DIFF
--- a/india_compliance/gst_india/doctype/gst_return_log/gst_return_log.py
+++ b/india_compliance/gst_india/doctype/gst_return_log/gst_return_log.py
@@ -178,7 +178,7 @@ class GSTReturnLog(GenerateGSTR1, FileGSTR1, Document):
                 self.gstin,
                 self.return_period,
             )
-            self.filing_status = status
+            self.db_set("filing_status", status)
 
         return status
 


### PR DESCRIPTION
- closes: #2827 multiple requests issue

Issue: Actual db_set of status was occurring in a different queue. This could lead to incorrect status in real-time if the other queue is not processed immediately.

<sub><a href="https://huly.app/guest/resilienttech?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzczN2VjNWYxNDRmNTg1YWU1MWEwYTgiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6Inctc21pdHZvcmEyMDMtcmVzaWxpZW50dGVjLTY2N2U0MjkxLWEwNWMwNjY4N2EtNjM4MjY3In0.gKyMUQXIxLLcKlhUaR3vPkANHI9OxUj_Sw-SgSyD-6g">Huly&reg;: <b>IC-3040</b></a></sub>