### PR TITLE
fix: correct taxes for overseas customer

### DIFF
--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -933,7 +933,9 @@ def get_gst_details(party_details, doctype, company, *, update_place_of_supply=F
         or (
             is_sales_transaction
             and is_export_without_payment_of_gst(
-                frappe._dict({**party_details, "doctype": doctype})
+                party_details.copy().update(
+                    doctype=doctype, place_of_supply=gst_details.place_of_supply
+                )
             )
         )
         or (


### PR DESCRIPTION
Due to the place of supply not being passed.
Incorrect taxes were populated in overseas customers.

Support Issue: https://support.frappe.io/app/hd-ticket/28392

<sub><a href="https://huly.app/guest/resilienttech?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzczOGRkYmYxNDRmNTg1YWU1MWEyNWIiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6Inctc21pdHZvcmEyMDMtcmVzaWxpZW50dGVjLTY2N2U0MjkxLWEwNWMwNjY4N2EtNjM4MjY3In0.cJYdzL47tjIBW_-z9W5iS3X7lwVJIMQPrpnhHDF72z0">Huly&reg;: <b>IC-3041</b></a></sub>