### PR TITLE
fix: IRN generated in another portal error

### DIFF
--- a/india_compliance/gst_india/api_classes/e_invoice.py
+++ b/india_compliance/gst_india/api_classes/e_invoice.py
@@ -21,6 +21,8 @@ class EInvoiceAPI(BaseAPI):
         # Cancel IRN errors
         "9999": "Invoice is not active",
         "4002": "EwayBill is already generated for this IRN",
+        # IRN Generated in different Portal
+        "2148": "Requested IRN data is not available",
         # Invalid GSTIN error
         "3028": "GSTIN is invalid",
         "3029": "GSTIN is not active",

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -170,6 +170,11 @@ def _generate_e_waybill(doc, throw=True, force=False):
         if result.error_code == "4002":
             result = api(doc).get_e_waybill_by_irn(doc.get("irn"))
 
+        if result.error_code == "2148":
+            with_irn = False
+            data = EWaybillData(doc).get_data(with_irn=with_irn)
+            result = EWaybillAPI(doc).generate_e_waybill(data)
+
     except GSPServerError as e:
         handle_server_errors(settings, doc, "e-Waybill", e)
         return


### PR DESCRIPTION
eg:

Where IRN is generated on NIC1, e-Waybill with IRN cannot be generated on NIC2 as NIC2 may find such IRN invalid (not synced).

This change aims to generate e-Waybill without using IRN in such cases.


<sub><a href="https://huly.app/guest/resilienttech?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2Nzc2NDBjNmYxNDRmNTg1YWU1MjE3ZTYiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6Inctc21pdHZvcmEyMDMtcmVzaWxpZW50dGVjLTY2N2U0MjkxLWEwNWMwNjY4N2EtNjM4MjY3In0.8xtM4sglEr8ocVyNOugvdwrz_enGRLyv9Mw4qgP4tLE">Huly&reg;: <b>IC-3042</b></a></sub>