### PR TITLE
test: ignore test dependencies from EPRNext

### DIFF
--- a/india_compliance/gst_india/doctype/bill_of_entry/test_bill_of_entry.py
+++ b/india_compliance/gst_india/doctype/bill_of_entry/test_bill_of_entry.py
@@ -17,13 +17,23 @@ from india_compliance.gst_india.overrides.test_transaction import create_cess_ac
 from india_compliance.gst_india.utils import get_gst_accounts_by_type
 from india_compliance.gst_india.utils.tests import create_purchase_invoice
 
+IGNORE_TEST_RECORD_DEPENDENCIES = [
+    "Bill of Entry",
+    "Purchase Invoice",
+    "Cost Center",
+    # "Tax Category",
+    "Item",
+    # "UOM",
+    "Item Tax Template",
+    "Project",
+    "Company",
+    "Account",
+]
+
 
 class TestBillofEntry(IntegrationTestCase):
     @classmethod
     def setUpClass(cls):
-        # don't create test objects
-        frappe.local.test_objects["Bill of Entry"] = []
-
         super().setUpClass()
         frappe.db.set_single_value("GST Settings", "enable_overseas_transactions", 1)
 

--- a/india_compliance/gst_india/doctype/gst_hsn_code/test_gst_hsn_code.py
+++ b/india_compliance/gst_india/doctype/gst_hsn_code/test_gst_hsn_code.py
@@ -9,13 +9,12 @@ from india_compliance.gst_india.doctype.gst_hsn_code.gst_hsn_code import (
     update_taxes_in_item_master,
 )
 
+IGNORE_TEST_RECORD_DEPENDENCIES = ["Item Tax Template"]
+
 
 class TestGSTHSNCode(IntegrationTestCase):
     @classmethod
     def setUpClass(cls):
-        # don't create test objects
-        frappe.local.test_objects["GST HSN Code"] = []
-
         super().setUpClass()
 
     @change_settings("GST Settings", {"validate_hsn_code": 0})

--- a/india_compliance/gst_india/doctype/gst_settings/test_gst_settings.py
+++ b/india_compliance/gst_india/doctype/gst_settings/test_gst_settings.py
@@ -6,13 +6,12 @@ import frappe
 from frappe.tests import IntegrationTestCase, change_settings
 from frappe.utils.data import getdate
 
+IGNORE_TEST_RECORD_DEPENDENCIES = ["Company", "Account"]
+
 
 class TestGSTSettings(IntegrationTestCase):
     @classmethod
     def setUpClass(cls):
-        # don't create test objects
-        frappe.local.test_objects["GST Settings"] = []
-
         super().setUpClass()
 
     @change_settings("GST Settings", {"enable_api": 1})

--- a/india_compliance/gst_india/doctype/gstin/test_gstin.py
+++ b/india_compliance/gst_india/doctype/gstin/test_gstin.py
@@ -3,7 +3,6 @@
 import responses
 from responses import matchers
 
-import frappe
 from frappe.tests import IntegrationTestCase, change_settings
 
 from india_compliance.gst_india.doctype.gstin.gstin import validate_gst_transporter_id
@@ -28,9 +27,6 @@ TRANSPORTER_ID_API_RESPONSE = {
 class TestGSTIN(IntegrationTestCase):
     @classmethod
     def setUpClass(cls):
-        # don't create test objects
-        frappe.local.test_objects["GSTIN"] = []
-
         super().setUpClass()
 
     @responses.activate

--- a/india_compliance/gst_india/doctype/purchase_reconciliation_tool/test_purchase_reconciliation_tool.py
+++ b/india_compliance/gst_india/doctype/purchase_reconciliation_tool/test_purchase_reconciliation_tool.py
@@ -14,6 +14,8 @@ from india_compliance.gst_india.utils.tests import (
     create_purchase_invoice as _create_purchase_invoice,
 )
 
+IGNORE_TEST_RECORD_DEPENDENCIES = ["Company"]
+
 PURCHASE_INVOICE_DEFAULT_ARGS = {
     "bill_no": "BILL-23-00001",
     "bill_date": "2023-12-11",
@@ -53,9 +55,6 @@ BILL_OF_ENTRY_DEFAULT_ARGS = {
 class TestPurchaseReconciliationTool(IntegrationTestCase):
     @classmethod
     def setUpClass(cls):
-        # don't create test objects
-        frappe.local.test_objects["Purchase Reconciliation Tool"] = []
-
         super().setUpClass()
 
         # create 2023-2024 fiscal year

--- a/india_compliance/vat_india/doctype/c_form/test_c_form.py
+++ b/india_compliance/vat_india/doctype/c_form/test_c_form.py
@@ -5,6 +5,8 @@ import unittest
 
 # test_records = frappe.get_test_records('C-Form')
 
+IGNORE_TEST_RECORD_DEPENDENCIES = ["Company", "Customer", "Sales Invoice", "Territory"]
+
 
 class TestCForm(unittest.TestCase):
     pass


### PR DESCRIPTION

<sub><a href="https://huly.app/guest/resilienttech?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzdiYzcxMWYxNDRmNTg1YWU1MmQ3MzIiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6Inctc21pdHZvcmEyMDMtcmVzaWxpZW50dGVjLTY2N2U0MjkxLWEwNWMwNjY4N2EtNjM4MjY3In0.uHCoX4pCCLPjuxUn_lcP9BG6e9x25KhJg_NaZQwH4lQ">Huly&reg;: <b>IC-3048</b></a></sub>