### PR TITLE
test: restore meta for autoname as it's cached

### DIFF
--- a/india_compliance/gst_india/overrides/test_purchase_invoice.py
+++ b/india_compliance/gst_india/overrides/test_purchase_invoice.py
@@ -77,11 +77,12 @@ class TestPurchaseInvoice(IntegrationTestCase):
             do_not_save=True,
         )
         setattr(pinv, "__newname", "INV/2022/00001/asdfsadg")  # NOQA
-        pinv.meta.autoname = "prompt"
-
         pinv.save()
 
         self.assertEqual(
             frappe.parse_json(frappe.message_log[-1]).get("message"),
             "Transaction Name must be 16 characters or fewer to meet GST requirements",
         )
+
+        # Reset autoname (as it's cached)
+        pinv.meta.autoname = "naming_series:"


### PR DESCRIPTION

<sub><a href="https://huly.app/guest/resilienttech?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJsaW5rSWQiOiI2NzdlMDAzNWYxNDRmNTg1YWU1MzIzNGYiLCJndWVzdCI6InRydWUiLCJlbWFpbCI6IiNndWVzdEBoYy5lbmdpbmVlcmluZyIsIndvcmtzcGFjZSI6Inctc21pdHZvcmEyMDMtcmVzaWxpZW50dGVjLTY2N2U0MjkxLWEwNWMwNjY4N2EtNjM4MjY3In0.LaFx4QvryFd4QWzRKy2LsGcjJgHifGKEI5PUOAM00Ho">Huly&reg;: <b>IC-3058</b></a></sub>