### PR TITLE
fix: `ignore_permissions` when handeling missing gstr2a 2b transactions

### DIFF
--- a/india_compliance/gst_india/utils/gstr_2/gstr_2a.py
+++ b/india_compliance/gst_india/utils/gstr_2/gstr_2a.py
@@ -47,7 +47,9 @@ class GSTR2a(GSTR):
 
         if self.existing_transaction:
             for inward_supply_name in self.existing_transaction.values():
-                frappe.delete_doc("GST Inward Supply", inward_supply_name)
+                frappe.delete_doc(
+                    "GST Inward Supply", inward_supply_name, ignore_permissions=True
+                )
 
     def get_supplier_details(self, supplier):
         supplier_details = {

--- a/india_compliance/gst_india/utils/gstr_2/gstr_2b.py
+++ b/india_compliance/gst_india/utils/gstr_2/gstr_2b.py
@@ -58,7 +58,9 @@ class GSTR2b(GSTR):
         )
 
         for transaction_name in unmatched_transactions:
-            frappe.delete_doc("GST Inward Supply", transaction_name)
+            frappe.delete_doc(
+                "GST Inward Supply", transaction_name, ignore_permissions=True
+            )
 
     def get_transaction(self, category, supplier, invoice):
         transaction = super().get_transaction(category, supplier, invoice)


### PR DESCRIPTION
closes: #2962 