### PR TITLE
feat: extensive support for GSTR1 quarterly filing

### DIFF
--- a/india_compliance/gst_india/doctype/gst_return_log/generate_gstr_1.py
+++ b/india_compliance/gst_india/doctype/gst_return_log/generate_gstr_1.py
@@ -9,7 +9,6 @@ from frappe.utils import flt, sbool
 from india_compliance.gst_india.api_classes.taxpayer_returns import GSTR1API
 from india_compliance.gst_india.constants import STATUS_CODE_MAP
 from india_compliance.gst_india.doctype.gstr_action.gstr_action import set_gstr_actions
-from india_compliance.gst_india.utils import MONTHS
 from india_compliance.gst_india.utils.gstin_info import get_and_update_filing_preference
 from india_compliance.gst_india.utils.gstr_1 import (
     CATEGORY_SUB_CATEGORY_MAPPING,
@@ -706,14 +705,10 @@ class GenerateGSTR1(SummarizeGSTR1, ReconcileGSTR1, AggregateInvoices):
 
         _filters = frappe._dict(
             {
-                "company": filters.company,
-                "company_gstin": filters.company_gstin,
                 "from_date": from_date,
                 "to_date": to_date,
-                "month": MONTHS.index(filters.month_or_quarter) + 1,
-                "month_or_quarter": filters.month_or_quarter,
-                "year": filters.year,
                 "filing_preference": self.filing_preference,
+                **filters,
             }
         )
 

--- a/india_compliance/gst_india/doctype/gst_return_log/generate_gstr_1.py
+++ b/india_compliance/gst_india/doctype/gst_return_log/generate_gstr_1.py
@@ -711,6 +711,8 @@ class GenerateGSTR1(SummarizeGSTR1, ReconcileGSTR1, AggregateInvoices):
                 "from_date": from_date,
                 "to_date": to_date,
                 "month": MONTHS.index(filters.month_or_quarter) + 1,
+                "month_or_quarter": filters.month_or_quarter,
+                "year": filters.year,
                 "filing_preference": self.filing_preference,
             }
         )

--- a/india_compliance/gst_india/doctype/gst_return_log/generate_gstr_1.py
+++ b/india_compliance/gst_india/doctype/gst_return_log/generate_gstr_1.py
@@ -9,6 +9,7 @@ from frappe.utils import flt, sbool
 from india_compliance.gst_india.api_classes.taxpayer_returns import GSTR1API
 from india_compliance.gst_india.constants import STATUS_CODE_MAP
 from india_compliance.gst_india.doctype.gstr_action.gstr_action import set_gstr_actions
+from india_compliance.gst_india.utils import MONTHS
 from india_compliance.gst_india.utils.gstin_info import get_and_update_filing_preference
 from india_compliance.gst_india.utils.gstr_1 import (
     CATEGORY_SUB_CATEGORY_MAPPING,
@@ -40,6 +41,11 @@ class SummarizeGSTR1:
         "total_sgst_amount": 0,
         "total_cess_amount": 0,
     }
+
+    QUARTERLY_KEYS = (
+        "already_included_docs_for_quarterly",
+        "excluded_docs_for_quarterly",
+    )
 
     def get_summarized_data(self, data, is_filed=False):
         """
@@ -98,6 +104,12 @@ class SummarizeGSTR1:
             if remove_category_row:
                 cateogory_summary.remove(summary_row)
 
+        for key in self.QUARTERLY_KEYS:
+            if key not in subcategory_summary:
+                continue
+
+            cateogory_summary.append(subcategory_summary.get(key))
+
         # Round Values
         for row in cateogory_summary:
             for key, value in row.items():
@@ -149,6 +161,39 @@ class SummarizeGSTR1:
                 summary_row["no_of_records"] = count
 
             summary_row.pop("unique_records")
+
+        # summarize included / excluded docs
+        for key in self.QUARTERLY_KEYS:
+            if key not in data:
+                continue
+
+            summary_row = subcategory_summary.setdefault(
+                key, self.default_subcategory_summary(frappe.unscrub(key))
+            )
+            summary_row.update(
+                {
+                    "indent": 0,
+                    "consider_in_total_taxable_value": True,
+                    "consider_in_total_tax": True,
+                }
+            )
+
+            for row in data[key]:
+                if (
+                    row.get("sub_category")
+                    in SUBCATEGORIES_NOT_CONSIDERED_IN_TOTAL_TAXABLE_VALUE
+                ):
+                    continue
+
+                for field in self.AMOUNT_FIELDS:
+                    if (
+                        field != "total_taxable_value"
+                        and row.get("sub_category")
+                        in SUBCATEGORIES_NOT_CONSIDERED_IN_TOTAL_TAX
+                    ):
+                        continue
+
+                    summary_row[field] += row.get(field, 0)
 
         return subcategory_summary
 
@@ -674,6 +719,8 @@ class GenerateGSTR1(SummarizeGSTR1, ReconcileGSTR1, AggregateInvoices):
                 "company_gstin": filters.company_gstin,
                 "from_date": from_date,
                 "to_date": to_date,
+                "month": MONTHS.index(filters.month_or_quarter) + 1,
+                "filing_preference": filters.filing_preference,
             }
         )
 
@@ -1044,7 +1091,11 @@ def get_differing_categories(mapped_summary, gov_summary):
         },
     }
 
-    IGNORED_CATEGORIES = {"Net Liability from Amendments"}
+    IGNORED_CATEGORIES = {
+        "Net Liability from Amendments",
+        frappe.unscrub("already_included_docs_for_quarterly"),
+        frappe.unscrub("excluded_docs_for_quarterly"),
+    }
 
     gov_summary = {row["description"]: row for row in gov_summary if row["indent"] == 0}
     compared_categories = set()

--- a/india_compliance/gst_india/doctype/gst_return_log/generate_gstr_1.py
+++ b/india_compliance/gst_india/doctype/gst_return_log/generate_gstr_1.py
@@ -654,7 +654,7 @@ class GenerateGSTR1(SummarizeGSTR1, ReconcileGSTR1, AggregateInvoices):
 
         if not self.get("filing_preference"):
             self.filing_preference = get_and_update_filing_preference(
-                self.gstin, self.return_period, force=True
+                self.gstin, self.return_period
             )
 
     def generate_only_books_data(self, data, filters, callback=None):

--- a/india_compliance/gst_india/doctype/gst_return_log/generate_gstr_1.py
+++ b/india_compliance/gst_india/doctype/gst_return_log/generate_gstr_1.py
@@ -12,6 +12,7 @@ from india_compliance.gst_india.doctype.gstr_action.gstr_action import set_gstr_
 from india_compliance.gst_india.utils.gstin_info import get_and_update_filing_preference
 from india_compliance.gst_india.utils.gstr_1 import (
     CATEGORY_SUB_CATEGORY_MAPPING,
+    QUARTERLY_KEYS,
     SUBCATEGORIES_NOT_CONSIDERED_IN_TOTAL_TAX,
     SUBCATEGORIES_NOT_CONSIDERED_IN_TOTAL_TAXABLE_VALUE,
     GovJsonKey,
@@ -40,11 +41,6 @@ class SummarizeGSTR1:
         "total_sgst_amount": 0,
         "total_cess_amount": 0,
     }
-
-    QUARTERLY_KEYS = (
-        "already_included_docs_for_quarterly",
-        "excluded_docs_for_quarterly",
-    )
 
     def get_summarized_data(self, data, is_filed=False):
         """
@@ -103,7 +99,7 @@ class SummarizeGSTR1:
             if remove_category_row:
                 cateogory_summary.remove(summary_row)
 
-        for key in self.QUARTERLY_KEYS:
+        for key in QUARTERLY_KEYS:
             if key not in subcategory_summary:
                 continue
 
@@ -162,7 +158,7 @@ class SummarizeGSTR1:
             summary_row.pop("unique_records")
 
         # summarize included / excluded docs
-        for key in self.QUARTERLY_KEYS:
+        for key in QUARTERLY_KEYS:
             if key not in data:
                 continue
 
@@ -1081,8 +1077,7 @@ def get_differing_categories(mapped_summary, gov_summary):
 
     IGNORED_CATEGORIES = {
         "Net Liability from Amendments",
-        frappe.unscrub("already_included_docs_for_quarterly"),
-        frappe.unscrub("excluded_docs_for_quarterly"),
+        *[frappe.unscrub(key) for key in QUARTERLY_KEYS],
     }
 
     gov_summary = {row["description"]: row for row in gov_summary if row["indent"] == 0}

--- a/india_compliance/gst_india/doctype/gst_return_log/generate_gstr_1.py
+++ b/india_compliance/gst_india/doctype/gst_return_log/generate_gstr_1.py
@@ -596,7 +596,7 @@ class GenerateGSTR1(SummarizeGSTR1, ReconcileGSTR1, AggregateInvoices):
         # APIs Enabled
         status = self.get_return_status()
 
-        self.set_filing_preference(filters, status)
+        self.set_filing_preference()
 
         if status == "Filed":
             gov_data_field = "filed"
@@ -645,24 +645,15 @@ class GenerateGSTR1(SummarizeGSTR1, ReconcileGSTR1, AggregateInvoices):
         self.summarize_data(data)
         return callback and callback(filters)
 
-    def set_filing_preference(self, filters, status):
+    def set_filing_preference(self):
         """
         Args:
             filters (dict): Filters containing month_or_quarter and filing_preference.
             status (str): The current filing status.
         """
-        should_update = False
 
         if not self.get("filing_preference"):
-            should_update = True
-
-        # filing pref is determined in the first month of the quarter
-        first_month = ["January", "April", "July", "October"]
-        if status != "Filed" and filters.month_or_quarter in first_month:
-            should_update = True
-
-        if should_update:
-            filters.filing_preference = get_and_update_filing_preference(
+            self.filing_preference = get_and_update_filing_preference(
                 self.gstin, self.return_period, force=True
             )
 
@@ -710,7 +701,7 @@ class GenerateGSTR1(SummarizeGSTR1, ReconcileGSTR1, AggregateInvoices):
                 return books_data
 
         from_date, to_date = get_gstr_1_from_and_to_date(
-            filters.month_or_quarter, filters.year, filters.filing_preference
+            filters.month_or_quarter, filters.year, self.filing_preference
         )
 
         _filters = frappe._dict(
@@ -720,7 +711,7 @@ class GenerateGSTR1(SummarizeGSTR1, ReconcileGSTR1, AggregateInvoices):
                 "from_date": from_date,
                 "to_date": to_date,
                 "month": MONTHS.index(filters.month_or_quarter) + 1,
-                "filing_preference": filters.filing_preference,
+                "filing_preference": self.filing_preference,
             }
         )
 

--- a/india_compliance/gst_india/doctype/gst_return_log/gst_return_log.js
+++ b/india_compliance/gst_india/doctype/gst_return_log/gst_return_log.js
@@ -14,7 +14,7 @@ frappe.ui.form.on("GST Return Log", {
                     file_field: field,
                     name: frm.doc.name,
                     doctype: frm.doc.doctype,
-                    file_name: `${field}.gz`
+                    file_name: `${field}.json.gz`
                 };
                 open_url_post(frappe.request.url, args);
             });

--- a/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_beta.js
+++ b/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_beta.js
@@ -222,6 +222,8 @@ frappe.ui.form.on(DOCTYPE, {
         set_options_for_month_or_quarter(frm);
     },
 
+    filing_preference: render_empty_state,
+
     refresh(frm) {
         frm.disable_save();
 
@@ -1066,7 +1068,6 @@ class TabManager {
                         if (!this.summary) return null;
 
                         const total = this.summary.reduce((acc, row) => {
-                            if (row.indent !== 1) return acc;
                             if (
                                 row.consider_in_total_taxable_value &&
                                 ["no_of_records", "total_taxable_value"].includes(

--- a/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_beta.js
+++ b/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_beta.js
@@ -115,6 +115,7 @@ frappe.ui.form.on(DOCTYPE, {
 
         if (is_gstr1_api_enabled()) {
             frm.set_df_property("filing_preference", "read_only", 1);
+            update_filing_preference(frm);
         }
 
         frm.__setup_complete = true;
@@ -3067,4 +3068,30 @@ async function get_net_gst_liability(frm) {
     });
 
     return response?.message;
+}
+
+function update_filing_preference(frm) {
+    frm.set_df_property('filing_preference', 'description',
+        `<button class="btn btn-secondary update-filing-preference">Refresh</button>`
+    );
+
+    frm.fields_dict.filing_preference.$wrapper.on('click', '.update-filing-preference', async function () {
+        const { filing_preference: currentPreference, month_or_quarter, year, company_gstin } = frm.doc;
+
+        const month = india_compliance.MONTH.indexOf(month_or_quarter) + 1;
+        const period = `${String(month).padStart(2, '0')}${year}`;
+
+        const { message: newPreference } = await frm.taxpayer_api_call(
+            'india_compliance.gst_india.utils.gstin_info.get_and_update_filing_preference',
+            { gstin: company_gstin, period, force: true },
+            null,
+            false
+        );
+
+        if (newPreference === currentPreference) return;
+
+        const response = await frm.taxpayer_api_call("generate_gstr1");
+        frm.doc.__gst_data = response.message;
+        frm.trigger("load_gstr1_data");
+    });
 }

--- a/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_beta.js
+++ b/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_beta.js
@@ -115,7 +115,7 @@ frappe.ui.form.on(DOCTYPE, {
 
         if (is_gstr1_api_enabled()) {
             frm.set_df_property("filing_preference", "read_only", 1);
-            update_filing_preference(frm);
+            refresh_filing_preference(frm);
         }
 
         frm.__setup_complete = true;
@@ -206,7 +206,7 @@ frappe.ui.form.on(DOCTYPE, {
 
     company_gstin(frm) {
         render_empty_state(frm);
-        update_fields_based_on_filing_preference(frm);
+        update_filing_preference(frm);
     },
 
     file_nil_gstr1(frm) {
@@ -215,7 +215,7 @@ frappe.ui.form.on(DOCTYPE, {
 
     month_or_quarter(frm) {
         render_empty_state(frm);
-        update_fields_based_on_filing_preference(frm);
+        update_filing_preference(frm);
     },
 
     year(frm) {
@@ -2987,19 +2987,19 @@ function set_options_for_year(frm) {
     frm.set_value("year", current_year.toString());
 }
 
-async function update_fields_based_on_filing_preference(frm) {
-    let { message: preference } = await frappe.call({
+function update_filing_preference(frm) {
+    frappe.call({
         method: "india_compliance.gst_india.doctype.gstr_1_beta.gstr_1_beta.get_filing_preference_from_log",
         args: {
             month_or_quarter: frm.doc.month_or_quarter,
             year: frm.doc.year,
             company_gstin: frm.doc.company_gstin,
         },
+        callback: r => {
+            if (!r.message) return;
+            frm.set_value("filing_preference", r.message);
+        },
     });
-
-    if (preference === frm.doc.filing_preference) return;
-
-    frm.set_value("filing_preference", preference);
 }
 
 function set_options_for_month_or_quarter(frm) {
@@ -3070,28 +3070,35 @@ async function get_net_gst_liability(frm) {
     return response?.message;
 }
 
-function update_filing_preference(frm) {
-    frm.set_df_property('filing_preference', 'description',
-        `<button class="btn btn-secondary update-filing-preference">Refresh</button>`
+function refresh_filing_preference(frm) {
+    const ref_btn = frappe.utils.icon("refresh", "sm", "update-filing-preference");
+    frm.set_df_property("filing_preference", "description", `${ref_btn}`);
+
+    frm.fields_dict.filing_preference.$wrapper.on(
+        "click",
+        ".update-filing-preference",
+        async function () {
+            const {
+                filing_preference: old_preference,
+                month_or_quarter,
+                year,
+                company_gstin,
+            } = frm.doc;
+
+            const month = india_compliance.MONTH.indexOf(month_or_quarter) + 1;
+            const period = `${String(month).padStart(2, "0")}${year}`;
+
+            const { message: new_preference } = await taxpayer_api.call({
+                method: "india_compliance.gst_india.utils.gstin_info.get_and_update_filing_preference",
+                args: { gstin: company_gstin, period, force: true },
+            });
+
+            if (new_preference === old_preference)
+                return frappe.show_alert(__("No change in filing preference"));
+
+            frappe.show_alert(__("Filing preference updated. Regenerating data..."));
+            frm.set_value("filing_preference", new_preference);
+            frm.gstr1_action.generate_gstr1_data();
+        }
     );
-
-    frm.fields_dict.filing_preference.$wrapper.on('click', '.update-filing-preference', async function () {
-        const { filing_preference: currentPreference, month_or_quarter, year, company_gstin } = frm.doc;
-
-        const month = india_compliance.MONTH.indexOf(month_or_quarter) + 1;
-        const period = `${String(month).padStart(2, '0')}${year}`;
-
-        const { message: newPreference } = await frm.taxpayer_api_call(
-            'india_compliance.gst_india.utils.gstin_info.get_and_update_filing_preference',
-            { gstin: company_gstin, period, force: true },
-            null,
-            false
-        );
-
-        if (newPreference === currentPreference) return;
-
-        const response = await frm.taxpayer_api_call("generate_gstr1");
-        frm.doc.__gst_data = response.message;
-        frm.trigger("load_gstr1_data");
-    });
 }

--- a/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_beta.js
+++ b/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_beta.js
@@ -115,7 +115,6 @@ frappe.ui.form.on(DOCTYPE, {
 
         if (is_gstr1_api_enabled()) {
             frm.set_df_property("filing_preference", "read_only", 1);
-            refresh_filing_preference(frm);
         }
 
         frm.__setup_complete = true;
@@ -227,6 +226,9 @@ frappe.ui.form.on(DOCTYPE, {
 
     refresh(frm) {
         frm.disable_save();
+        if (is_gstr1_api_enabled()) {
+            refresh_filing_preference(frm);
+        }
 
         frm.gstr1?.render_form_actions();
 
@@ -3071,34 +3073,30 @@ async function get_net_gst_liability(frm) {
 }
 
 function refresh_filing_preference(frm) {
-    const ref_btn = frappe.utils.icon("refresh", "sm", "update-filing-preference");
-    frm.set_df_property("filing_preference", "description", `${ref_btn}`);
+    const ref_btn_html = frappe.utils.icon("refresh", "sm", "update-filing-preference", "float:right");
+    $('[data-fieldname="filing_preference"] .control-value.like-disabled-input').append(ref_btn_html);
 
-    frm.fields_dict.filing_preference.$wrapper.on(
-        "click",
-        ".update-filing-preference",
-        async function () {
-            const {
-                filing_preference: old_preference,
-                month_or_quarter,
-                year,
-                company_gstin,
-            } = frm.doc;
+    frm.$wrapper.find(".update-filing-preference").click(async function (e) {
+        const {
+            filing_preference: old_preference,
+            month_or_quarter,
+            year,
+            company_gstin,
+        } = frm.doc;
 
-            const month = india_compliance.MONTH.indexOf(month_or_quarter) + 1;
-            const period = `${String(month).padStart(2, "0")}${year}`;
+        const month = india_compliance.MONTH.indexOf(month_or_quarter) + 1;
+        const period = `${String(month).padStart(2, "0")}${year}`;
 
-            const { message: new_preference } = await taxpayer_api.call({
-                method: "india_compliance.gst_india.utils.gstin_info.get_and_update_filing_preference",
-                args: { gstin: company_gstin, period },
-            });
+        const { message: new_preference } = await taxpayer_api.call({
+            method: "india_compliance.gst_india.utils.gstin_info.get_and_update_filing_preference",
+            args: { gstin: company_gstin, period },
+        });
 
-            if (new_preference === old_preference)
-                return frappe.show_alert(__("No change in filing preference"));
+        if (new_preference === old_preference)
+            return frappe.show_alert(__("No change in filing preference"));
 
-            frappe.show_alert(__("Filing preference updated. Regenerating data..."));
-            frm.set_value("filing_preference", new_preference);
-            frm.gstr1_action.generate_gstr1_data();
-        }
-    );
+        frappe.show_alert(__("Filing preference updated. Regenerating data..."));
+        frm.set_value("filing_preference", new_preference);
+        frm.gstr1_action.generate_gstr1_data();
+    });
 }

--- a/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_beta.js
+++ b/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_beta.js
@@ -3090,7 +3090,7 @@ function refresh_filing_preference(frm) {
 
             const { message: new_preference } = await taxpayer_api.call({
                 method: "india_compliance.gst_india.utils.gstin_info.get_and_update_filing_preference",
-                args: { gstin: company_gstin, period, force: true },
+                args: { gstin: company_gstin, period },
             });
 
             if (new_preference === old_preference)

--- a/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_beta.js
+++ b/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_beta.js
@@ -3085,9 +3085,11 @@ function refresh_filing_preference(frm) {
     $pref_wrapper
         .empty()
         .addClass("flex align-center justify-content-between")
-        .append(`<span>${text}</span>`)
+        .append($("<span></span>").text(text))
         .append(
-            `<span title="Refresh Filing Preference from GSTN">${ref_btn_html}</span>`
+            $("<span></span>")
+                .attr("title", "Refresh Filing Preference from GSTN")
+                .html(ref_btn_html)
         );
 
     // bind click event

--- a/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_beta.js
+++ b/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_beta.js
@@ -3073,9 +3073,24 @@ async function get_net_gst_liability(frm) {
 }
 
 function refresh_filing_preference(frm) {
-    const ref_btn_html = frappe.utils.icon("refresh", "sm", "update-filing-preference", "float:right");
-    $('[data-fieldname="filing_preference"] .control-value.like-disabled-input').append(ref_btn_html);
+    // update html/css to show refresh button next to filing preference
+    const $pref_wrapper = $(
+        '[data-fieldname="filing_preference"] .control-value.like-disabled-input'
+    );
+    if (!$pref_wrapper.length) return;
 
+    const text = $pref_wrapper.text().trim();
+    const ref_btn_html = frappe.utils.icon("refresh", "xs", "update-filing-preference");
+
+    $pref_wrapper
+        .empty()
+        .addClass("flex align-center justify-content-between")
+        .append(`<span>${text}</span>`)
+        .append(
+            `<span title="Refresh Filing Preference from GSTN">${ref_btn_html}</span>`
+        );
+
+    // bind click event
     frm.$wrapper.find(".update-filing-preference").click(async function (e) {
         const {
             filing_preference: old_preference,
@@ -3095,8 +3110,7 @@ function refresh_filing_preference(frm) {
         if (new_preference === old_preference)
             return frappe.show_alert(__("No change in filing preference"));
 
-        frappe.show_alert(__("Filing preference updated. Regenerating data..."));
+        frappe.show_alert(__("Filing preference updated. Regenerate data."));
         frm.set_value("filing_preference", new_preference);
-        frm.gstr1_action.generate_gstr1_data();
     });
 }

--- a/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_beta.py
+++ b/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_beta.py
@@ -99,15 +99,8 @@ class GSTR1Beta(Document):
         settings = frappe.get_cached_doc("GST Settings")
 
         if self.filing_preference != gstr1_log.filing_preference:
-
             recompute_books = True
-            # TODO:
-            # when i do this it changes filing_preference in frontend
-            # self.filing_preference = gstr1_log.filing_preference
-
             gstr1_log.db_set("filing_preference", self.filing_preference)
-            # when i do refresh at that time self.filing_preference may be wrong
-            # so we can not set it in filing_preference
 
         if sync_for:
             gstr1_log.remove_json_for(sync_for)

--- a/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_beta.py
+++ b/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_beta.py
@@ -99,10 +99,15 @@ class GSTR1Beta(Document):
         settings = frappe.get_cached_doc("GST Settings")
 
         if self.filing_preference != gstr1_log.filing_preference:
+
             recompute_books = True
-            self.filing_preference = gstr1_log.filing_preference
-            # gstr1_log.db_set("filing_preference", self.filing_preference)
-            # will this be self.filing_preference or gstr1_log.filing_preference
+            # TODO:
+            # when i do this it changes filing_preference in frontend
+            # self.filing_preference = gstr1_log.filing_preference
+
+            gstr1_log.db_set("filing_preference", self.filing_preference)
+            # when i do refresh at that time self.filing_preference may be wrong
+            # so we can not set it in filing_preference
 
         if sync_for:
             gstr1_log.remove_json_for(sync_for)

--- a/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_beta.py
+++ b/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_beta.py
@@ -100,7 +100,9 @@ class GSTR1Beta(Document):
 
         if self.filing_preference != gstr1_log.filing_preference:
             recompute_books = True
-            gstr1_log.db_set("filing_preference", self.filing_preference)
+            self.filing_preference = gstr1_log.filing_preference
+            # gstr1_log.db_set("filing_preference", self.filing_preference)
+            # will this be self.filing_preference or gstr1_log.filing_preference
 
         if sync_for:
             gstr1_log.remove_json_for(sync_for)

--- a/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_beta.py
+++ b/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_beta.py
@@ -93,9 +93,14 @@ class GSTR1Beta(Document):
             gstr1_log.gstin = self.company_gstin
             gstr1_log.return_period = period
             gstr1_log.return_type = "GSTR1"
+            gstr1_log.filing_preference = self.filing_preference
             gstr1_log.insert()
 
         settings = frappe.get_cached_doc("GST Settings")
+
+        if self.filing_preference != gstr1_log.filing_preference:
+            recompute_books = True
+            gstr1_log.db_set("filing_preference", self.filing_preference)
 
         if sync_for:
             gstr1_log.remove_json_for(sync_for)

--- a/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_beta.py
+++ b/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_beta.py
@@ -19,12 +19,10 @@ from india_compliance.gst_india.doctype.gst_return_log.generate_gstr_1 import (
     verify_request_in_progress,
 )
 from india_compliance.gst_india.utils import (
+    MONTHS,
     get_gst_accounts_by_type,
-    get_month_or_quarter_dict,
 )
 from india_compliance.gst_india.utils.gstin_info import get_gstr_1_return_status
-
-MONTH = list(get_month_or_quarter_dict().keys())[4:]
 
 
 class GSTR1Beta(Document):
@@ -410,7 +408,7 @@ def get_gstr_1_from_and_to_date(
     Returns the from and to date for the given month or quarter and year
     This is used to filter the data for the given period in Books
     """
-    start_month = end_month = MONTH.index(month_or_quarter) + 1
+    start_month = end_month = MONTHS.index(month_or_quarter) + 1
 
     # only for quarter ending month
     if filing_preference == "Quarterly" and start_month % 3 == 0:

--- a/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_beta.py
+++ b/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_beta.py
@@ -18,6 +18,9 @@ from india_compliance.gst_india.api_classes.taxpayer_base import (
 from india_compliance.gst_india.doctype.gst_return_log.generate_gstr_1 import (
     verify_request_in_progress,
 )
+from india_compliance.gst_india.doctype.gst_return_log.gst_return_log import (
+    get_gst_return_log,
+)
 from india_compliance.gst_india.utils import (
     MONTHS,
     get_gst_accounts_by_type,
@@ -63,38 +66,27 @@ class GSTR1Beta(Document):
         self, sync_for=None, recompute_books=False, only_books_data=None, message=None
     ):
         period = get_period(self.month_or_quarter, self.year)
+        log_name = f"GSTR1-{period}-{self.company_gstin}"
 
-        # get gstr1 log
-        if log_name := frappe.db.exists(
-            "GST Return Log", f"GSTR1-{period}-{self.company_gstin}"
-        ):
+        gstr1_log = get_gst_return_log(
+            log_name, company=self.company, filing_preference=self.filing_preference
+        )
 
-            gstr1_log = frappe.get_doc("GST Return Log", log_name)
+        message = None
+        if gstr1_log.status == "In Progress":
+            message = (
+                "GSTR-1 is being prepared. Please wait for the process to complete."
+            )
 
-            message = None
-            if gstr1_log.status == "In Progress":
-                message = (
-                    "GSTR-1 is being prepared. Please wait for the process to complete."
-                )
+        elif gstr1_log.status == "Queued":
+            message = (
+                "GSTR-1 download is queued and could take some time. Please wait"
+                " for the process to complete."
+            )
 
-            elif gstr1_log.status == "Queued":
-                message = (
-                    "GSTR-1 download is queued and could take some time. Please wait"
-                    " for the process to complete."
-                )
-
-            if message:
-                frappe.msgprint(_(message), title=_("GSTR-1 Generation In Progress"))
-                return
-
-        else:
-            gstr1_log = frappe.new_doc("GST Return Log")
-            gstr1_log.company = self.company
-            gstr1_log.gstin = self.company_gstin
-            gstr1_log.return_period = period
-            gstr1_log.return_type = "GSTR1"
-            gstr1_log.filing_preference = self.filing_preference
-            gstr1_log.insert()
+        if message:
+            frappe.msgprint(_(message), title=_("GSTR-1 Generation In Progress"))
+            return
 
         settings = frappe.get_cached_doc("GST Settings")
 
@@ -393,15 +385,7 @@ def get_period(month_or_quarter: str, year: str) -> str:
     Returns the period in the format MMYYYY
     as accepted by the GST Portal
     """
-
-    if "-" in month_or_quarter:
-        # Quarterly
-        last_month = month_or_quarter.split("-")[1]
-        month_number = str(getdate(f"{last_month}-{year}").month).zfill(2)
-
-    else:
-        # Monthly
-        month_number = str(datetime.strptime(month_or_quarter, "%B").month).zfill(2)
+    month_number = str(datetime.strptime(month_or_quarter, "%B").month).zfill(2)
 
     return f"{month_number}{year}"
 

--- a/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_export.py
+++ b/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_export.py
@@ -77,7 +77,7 @@ class DataProcessor:
         Apply transformations to row fields
         """
         for field, modifier in self.FIELD_TRANSFORMATIONS.items():
-            if field in row:
+            if row.get(field):
                 row[field] = modifier(row[field])
 
         return row
@@ -2069,6 +2069,8 @@ def get_gstr_1_json(
             GSTR1_SubCategory.NIL_EXEMPT.value,
             GSTR1_SubCategory.HSN.value,
             GSTR1_SubCategory.DOC_ISSUE.value,
+            "already_included_docs_for_quarterly",
+            "excluded_docs_for_quarterly",
         }:
             continue
 

--- a/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_export.py
+++ b/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_export.py
@@ -14,6 +14,7 @@ from india_compliance.gst_india.doctype.gstr_1_beta.gstr_1_beta import get_perio
 from india_compliance.gst_india.utils.exporter import ExcelExporter
 from india_compliance.gst_india.utils.gstr_1 import (
     JSON_CATEGORY_EXCEL_CATEGORY_MAPPING,
+    QUARTERLY_KEYS,
     GovExcelField,
     GovExcelSheetName,
     GovJsonKey,
@@ -2069,8 +2070,7 @@ def get_gstr_1_json(
             GSTR1_SubCategory.NIL_EXEMPT.value,
             GSTR1_SubCategory.HSN.value,
             GSTR1_SubCategory.DOC_ISSUE.value,
-            "already_included_docs_for_quarterly",
-            "excluded_docs_for_quarterly",
+            *QUARTERLY_KEYS,
         }:
             continue
 

--- a/india_compliance/gst_india/utils/__init__.py
+++ b/india_compliance/gst_india/utils/__init__.py
@@ -1023,6 +1023,9 @@ def get_month_or_quarter_dict():
     }
 
 
+MONTHS = list(get_month_or_quarter_dict().keys())[4:]
+
+
 def get_period(month_or_quarter, year=None):
     month_or_quarter_no = get_month_or_quarter_dict().get(month_or_quarter)
 

--- a/india_compliance/gst_india/utils/gstin_info.py
+++ b/india_compliance/gst_india/utils/gstin_info.py
@@ -380,35 +380,15 @@ def get_latest_3b_filed_period(company, company_gstin):
 
 @frappe.whitelist()
 @otp_handler
-def get_and_update_filing_preference(gstin, period, force=False):
-    frappe.has_permission("GST Return Log", "write", throw=True)
-
-    if not force:
-        log_names = get_logs_for_year(gstin, period)
-
-        filing_preference = frappe.db.get_value(
-            "GST Return Log", {"name": ["in", log_names]}, "filing_preference"
-        )
-
-        if filing_preference:
-            return filing_preference
+def get_and_update_filing_preference(gstin, period):
+    frappe.has_permission("GST Return Log", throw=True)
 
     response = fetch_filing_preference(gstin, get_fy(period))
 
     # update GST Return Log
     create_or_update_logs_for_year(gstin, period, response)
 
-    return _get_filing_preference(period, response)
-
-
-def get_filing_preference(gstin, period):
-    response = fetch_filing_preference(gstin, get_fy(period))
-    return _get_filing_preference(period, response)
-
-
-def _get_filing_preference(period, response):
-    quarter = get_financial_quarter(cint(period[:2]))
-    return "Quarterly" if response[quarter - 1].get("preference") == "Q" else "Monthly"
+    return get_filing_preference(period, response)
 
 
 @request_cache
@@ -432,7 +412,7 @@ def create_or_update_logs_for_year(gstin, period, response):
 
     for log_name in log_names:
         period = log_name.split("-")[1]
-        filing_preference = _get_filing_preference(period, response)
+        filing_preference = get_filing_preference(period, response)
 
         if log_name in existing_log:
             if existing_log[log_name] == filing_preference:
@@ -465,6 +445,11 @@ def create_or_update_logs_for_year(gstin, period, response):
     patch_filing_preference(gstin)
 
 
+def get_filing_preference(period, response):
+    quarter = get_financial_quarter(cint(period[:2]))
+    return "Quarterly" if response[quarter - 1].get("preference") == "Q" else "Monthly"
+
+
 ####################################################################################################
 #### GSTIN UTILITIES ###############################################################################
 ####################################################################################################
@@ -495,8 +480,7 @@ def get_logs_for_year(gstin, period):
         year -= 1
 
     for return_type in ["GSTR1", "GSTR3B"]:
-        for month_offset in range(12):
-            current_month = (4 + month_offset - 1) % 12 + 1
+        for current_month in range(1, 13):
             current_year = year if current_month >= 4 else year + 1
             logs.append(f"{return_type}-{current_month:02d}{current_year}-{gstin}")
 

--- a/india_compliance/gst_india/utils/gstin_info.py
+++ b/india_compliance/gst_india/utils/gstin_info.py
@@ -421,8 +421,13 @@ def fetch_filing_preference(gstin, fy):
 
 def create_or_update_logs_for_year(gstin, period, response):
     log_names = get_logs_for_year(gstin, period)
-    existing_log = frappe.get_all(
-        "GST Return Log", filters={"name": ["in", log_names]}, pluck="name"
+    existing_log = frappe._dict(
+        frappe.get_all(
+            "GST Return Log",
+            filters={"name": ["in", log_names]},
+            fields=["name", "filing_preference"],
+            as_list=True,
+        )
     )
 
     for log_name in log_names:
@@ -430,8 +435,14 @@ def create_or_update_logs_for_year(gstin, period, response):
         filing_preference = _get_filing_preference(period, response)
 
         if log_name in existing_log:
+            if existing_log[log_name] == filing_preference:
+                continue
+
+            # books may need a refresh
             frappe.db.set_value(
-                "GST Return Log", log_name, "filing_preference", filing_preference
+                "GST Return Log",
+                log_name,
+                {"filing_preference": filing_preference, "is_latest_data": 0},
             )
             continue
 

--- a/india_compliance/gst_india/utils/gstin_info.py
+++ b/india_compliance/gst_india/utils/gstin_info.py
@@ -14,6 +14,9 @@ from india_compliance.gst_india.api_classes.base import BASE_URL
 from india_compliance.gst_india.api_classes.e_invoice import EInvoiceAPI
 from india_compliance.gst_india.api_classes.e_waybill import EWaybillAPI
 from india_compliance.gst_india.api_classes.public import PublicAPI
+from india_compliance.gst_india.api_classes.taxpayer_base import (
+    otp_handler,
+)
 from india_compliance.gst_india.api_classes.taxpayer_returns import GSTR1API
 from india_compliance.gst_india.utils import parse_datetime, titlecase, validate_gstin
 
@@ -375,7 +378,11 @@ def get_latest_3b_filed_period(company, company_gstin):
 ####################################################################################################
 
 
+@frappe.whitelist()
+@otp_handler
 def get_and_update_filing_preference(gstin, period, force=False):
+    frappe.has_permission("GST Return Log", "write", throw=True)
+
     if not force:
         log_names = get_logs_for_year(gstin, period)
 
@@ -386,23 +393,22 @@ def get_and_update_filing_preference(gstin, period, force=False):
         if filing_preference:
             return filing_preference
 
-    filing_preference = get_filing_preference(gstin, period)
+    response = fetch_filing_preference(gstin, get_fy(period))
 
     # update GST Return Log
-    create_or_update_logs_for_year(gstin, period, filing_preference)
+    create_or_update_logs_for_year(gstin, period, response)
 
-    return filing_preference
+    return _get_filing_preference(period, response)
 
 
 def get_filing_preference(gstin, period):
     response = fetch_filing_preference(gstin, get_fy(period))
+    return _get_filing_preference(period, response)
 
+
+def _get_filing_preference(period, response):
     quarter = get_financial_quarter(cint(period[:2]))
-    filing_preference = (
-        "Quarterly" if response[quarter - 1].get("preference") == "Q" else "Monthly"
-    )
-
-    return filing_preference
+    return "Quarterly" if response[quarter - 1].get("preference") == "Q" else "Monthly"
 
 
 @request_cache
@@ -413,13 +419,16 @@ def fetch_filing_preference(gstin, fy):
     return response
 
 
-def create_or_update_logs_for_year(gstin, period, filing_preference):
+def create_or_update_logs_for_year(gstin, period, response):
     log_names = get_logs_for_year(gstin, period)
     existing_log = frappe.get_all(
         "GST Return Log", filters={"name": ["in", log_names]}, pluck="name"
     )
 
     for log_name in log_names:
+        period = log_name.split("-")[1]
+        filing_preference = _get_filing_preference(period, response)
+
         if log_name in existing_log:
             frappe.db.set_value(
                 "GST Return Log", log_name, "filing_preference", filing_preference
@@ -467,16 +476,18 @@ def get_current_fy():
 
 
 def get_logs_for_year(gstin, period):
-    # TODO: Update this to get logs for the entire FY
-    quarter = get_financial_quarter(cint(period[:2]))
-    start_month = ((quarter - 1) * 3 + 4) % 12
-    year = period[2:]
-
+    year = cint(period[2:])
+    month = cint(period[:2])
     logs = []
 
+    if month <= 3:
+        year -= 1
+
     for return_type in ["GSTR1", "GSTR3B"]:
-        for month in range(start_month, start_month + 3):
-            logs.append(f"{return_type}-{month:02d}{year}-{gstin}")
+        for month_offset in range(12):
+            current_month = (4 + month_offset - 1) % 12 + 1
+            current_year = year if current_month >= 4 else year + 1
+            logs.append(f"{return_type}-{current_month:02d}{current_year}-{gstin}")
 
     return logs
 

--- a/india_compliance/gst_india/utils/gstin_info.py
+++ b/india_compliance/gst_india/utils/gstin_info.py
@@ -377,7 +377,7 @@ def get_latest_3b_filed_period(company, company_gstin):
 
 def get_and_update_filing_preference(gstin, period, force=False):
     if not force:
-        log_names = get_logs_for_quarter(gstin, period)
+        log_names = get_logs_for_year(gstin, period)
 
         filing_preference = frappe.db.get_value(
             "GST Return Log", {"name": ["in", log_names]}, "filing_preference"
@@ -389,7 +389,7 @@ def get_and_update_filing_preference(gstin, period, force=False):
     filing_preference = get_filing_preference(gstin, period)
 
     # update GST Return Log
-    create_or_update_logs_for_quarter(gstin, period, filing_preference)
+    create_or_update_logs_for_year(gstin, period, filing_preference)
 
     return filing_preference
 
@@ -413,8 +413,8 @@ def fetch_filing_preference(gstin, fy):
     return response
 
 
-def create_or_update_logs_for_quarter(gstin, period, filing_preference):
-    log_names = get_logs_for_quarter(gstin, period)
+def create_or_update_logs_for_year(gstin, period, filing_preference):
+    log_names = get_logs_for_year(gstin, period)
     existing_log = frappe.get_all(
         "GST Return Log", filters={"name": ["in", log_names]}, pluck="name"
     )
@@ -466,7 +466,8 @@ def get_current_fy():
     return get_fy(period)
 
 
-def get_logs_for_quarter(gstin, period):
+def get_logs_for_year(gstin, period):
+    # TODO: Update this to get logs for the entire FY
     quarter = get_financial_quarter(cint(period[:2]))
     start_month = ((quarter - 1) * 3 + 4) % 12
     year = period[2:]

--- a/india_compliance/gst_india/utils/gstr_1/__init__.py
+++ b/india_compliance/gst_india/utils/gstr_1/__init__.py
@@ -60,6 +60,12 @@ class SUPECOM(Enum):
     US_52 = "Liable to collect tax u/s 52(TCS)"
 
 
+QUARTERLY_KEYS = (
+    "already_included_docs_for_quarterly",
+    "excluded_docs_for_quarterly",
+)
+
+
 CATEGORY_SUB_CATEGORY_MAPPING = {
     GSTR1_Category.B2B: (
         GSTR1_SubCategory.B2B_REGULAR,

--- a/india_compliance/gst_india/utils/gstr_1/gstr_1_json_map.py
+++ b/india_compliance/gst_india/utils/gstr_1/gstr_1_json_map.py
@@ -2502,7 +2502,7 @@ class GSTR1BooksData(BooksDataMapper):
             self.process_excluded_docs_for_quarterly(data, m1_m2_subcategories)
 
     def process_included_docs_for_quarterly(self, data, m1_m2_subcategories):
-        included_docs = self.get_already_filed_docs(self.from_date)
+        included_docs = self.get_already_filed_docs(m1_m2_subcategories)
 
         for category in data.copy():
             if category not in m1_m2_subcategories:
@@ -2547,8 +2547,40 @@ class GSTR1BooksData(BooksDataMapper):
 
         return data
 
-    def get_already_filed_docs(self, from_date):
-        # get already filed docs
-        # TODO: generate GSTR-1 if missing
+    def get_already_filed_docs(self, m1_m2_subcategories):
+        current_month = self.filters.month
+        company_gstin = self.filters.company_gstin
+        year = self.filters.year
 
-        return []
+        log_names = [
+            f"GSTR1-{(current_month-1):02d}{year}-{company_gstin}",
+            f"GSTR1-{(current_month-2):02d}{year}-{company_gstin}",
+        ]
+
+        filed_invoices = set()
+
+        for log_name in log_names:
+            doc = frappe.db.exists("GST Return Log", log_name)
+            if not doc:
+                gstr1_log = frappe.new_doc("GST Return Log")
+                gstr1_log.company = self.filters.company
+                gstr1_log.gstin = self.filters.company_gstin
+                gstr1_log.return_period = log_name.split("-")[1]
+                gstr1_log.return_type = "GSTR1"
+                gstr1_log.filing_preference = self.filters.filing_preference
+                gstr1_log.insert()
+
+                gstr1_log.generate_gstr1_data(self.filters)
+
+            else:
+                gstr1_log = frappe.get_doc("GST Return Log", log_name)
+
+            filed_data = gstr1_log.get_json_for("filed")
+
+            for category, invoices in filed_data.items():
+                if category not in m1_m2_subcategories:
+                    continue
+
+                filed_invoices.update(invoices.keys())
+
+        return filed_invoices

--- a/india_compliance/gst_india/utils/gstr_1/gstr_1_json_map.py
+++ b/india_compliance/gst_india/utils/gstr_1/gstr_1_json_map.py
@@ -8,7 +8,7 @@ from india_compliance.gst_india.report.gstr_1.gstr_1 import (
     GSTR1DocumentIssuedSummary,
     GSTR11A11BData,
 )
-from india_compliance.gst_india.utils import get_gst_accounts_by_type
+from india_compliance.gst_india.utils import MONTHS, get_gst_accounts_by_type
 from india_compliance.gst_india.utils.__init__ import get_party_for_gstin
 from india_compliance.gst_india.utils.gstr_1 import (
     CATEGORY_SUB_CATEGORY_MAPPING,
@@ -2375,6 +2375,7 @@ class BooksDataMapper:
 class GSTR1BooksData(BooksDataMapper):
     def __init__(self, filters):
         self.filters = filters
+        self.current_month = MONTHS.index(filters.month_or_quarter) + 1
 
     def prepare_mapped_data(self):
         prepared_data = {}
@@ -2485,7 +2486,7 @@ class GSTR1BooksData(BooksDataMapper):
         if self.filters.filing_preference != "Quarterly":
             return
 
-        is_m3 = self.filters.month % 3 == 0
+        is_m3 = self.current_month % 3 == 0
         m1_m2_subcategories = (
             GSTR1_SubCategory.B2B_REGULAR.value,
             GSTR1_SubCategory.B2B_REVERSE_CHARGE.value,
@@ -2547,32 +2548,29 @@ class GSTR1BooksData(BooksDataMapper):
         return data
 
     def get_already_filed_docs(self, m1_m2_subcategories):
-        current_month = self.filters.month
+        from india_compliance.gst_india.doctype.gst_return_log.gst_return_log import (
+            get_gst_return_log,
+        )
+
         company_gstin = self.filters.company_gstin
         year = self.filters.year
 
         log_names = [
-            f"GSTR1-{(current_month-1):02d}{year}-{company_gstin}",
-            f"GSTR1-{(current_month-2):02d}{year}-{company_gstin}",
+            f"GSTR1-{(self.current_month-1):02d}{year}-{company_gstin}",
+            f"GSTR1-{(self.current_month-2):02d}{year}-{company_gstin}",
         ]
 
         filed_invoices = set()
 
         for log_name in log_names:
-            doc = frappe.db.exists("GST Return Log", log_name)
-            if not doc:
-                gstr1_log = frappe.new_doc("GST Return Log")
-                gstr1_log.company = self.filters.company
-                gstr1_log.gstin = self.filters.company_gstin
-                gstr1_log.return_period = log_name.split("-")[1]
-                gstr1_log.return_type = "GSTR1"
-                gstr1_log.filing_preference = self.filters.filing_preference
-                gstr1_log.insert()
+            gstr1_log = get_gst_return_log(
+                log_name,
+                company=self.filters.company,
+                filing_preference=self.filters.filing_preference,
+            )
 
+            if not gstr1_log.filed:
                 gstr1_log.generate_gstr1_data(self.filters)
-
-            else:
-                gstr1_log = frappe.get_doc("GST Return Log", log_name)
 
             filed_data = gstr1_log.get_json_for("filed")
 

--- a/india_compliance/gst_india/utils/gstr_1/gstr_1_json_map.py
+++ b/india_compliance/gst_india/utils/gstr_1/gstr_1_json_map.py
@@ -2417,6 +2417,8 @@ class GSTR1BooksData(BooksDataMapper):
 
             self.round_values(list(data.values()))
 
+        self.process_for_quarterly(prepared_data)
+
         return prepared_data
 
     def prepare_document_issued_data(self):
@@ -2478,3 +2480,75 @@ class GSTR1BooksData(BooksDataMapper):
             )
 
         return advances_data
+
+    def process_for_quarterly(self, data):
+        if self.filters.filing_preference != "Quarterly":
+            return
+
+        is_m3 = self.filters.month % 3 == 0
+        m1_m2_subcategories = (
+            GSTR1_SubCategory.B2B_REGULAR.value,
+            GSTR1_SubCategory.B2B_REVERSE_CHARGE.value,
+            GSTR1_SubCategory.SEZWP.value,
+            GSTR1_SubCategory.SEZWOP.value,
+            GSTR1_SubCategory.DE.value,
+            GSTR1_SubCategory.CDNR.value,
+            GSTR1_SubCategory.SUPECOM_9_5.value,
+        )
+
+        if is_m3:
+            self.process_included_docs_for_quarterly(data, m1_m2_subcategories)
+        else:
+            self.process_excluded_docs_for_quarterly(data, m1_m2_subcategories)
+
+    def process_included_docs_for_quarterly(self, data, m1_m2_subcategories):
+        included_docs = self.get_already_filed_docs(self.from_date)
+
+        for category in data.copy():
+            if category not in m1_m2_subcategories:
+                continue
+
+            included = data.setdefault("already_included_docs_for_quarterly", [])
+
+            for key, row in data[category].items():
+                if key in included_docs:
+                    continue
+
+                row["sub_category"] = category
+                included.append(row)
+                del data[category][key]
+
+    def process_excluded_docs_for_quarterly(self, data, m1_m2_subcategories):
+        for category in data.copy():
+            if category in m1_m2_subcategories:
+                continue
+
+            if category in (
+                GSTR1_SubCategory.HSN.value,
+                GSTR1_SubCategory.DOC_ISSUE.value,
+            ):
+                del data[category]
+                continue
+
+            excluded = data.setdefault("excluded_docs_for_quarterly", [])
+
+            for row in data[category].values():
+                if isinstance(row, dict):
+                    row["sub_category"] = category
+                    excluded.append(row)
+
+                elif isinstance(row, list):
+                    for item in row:
+                        item["sub_category"] = category
+
+                    excluded.extend(row)
+
+            del data[category]
+
+        return data
+
+    def get_already_filed_docs(self, from_date):
+        # get already filed docs
+        # TODO: generate GSTR-1 if missing
+
+        return []

--- a/india_compliance/gst_india/utils/gstr_1/gstr_1_json_map.py
+++ b/india_compliance/gst_india/utils/gstr_1/gstr_1_json_map.py
@@ -2504,13 +2504,13 @@ class GSTR1BooksData(BooksDataMapper):
     def process_included_docs_for_quarterly(self, data, m1_m2_subcategories):
         included_docs = self.get_already_filed_docs(m1_m2_subcategories)
 
-        for category in data.copy():
+        for category in data:
             if category not in m1_m2_subcategories:
                 continue
 
             included = data.setdefault("already_included_docs_for_quarterly", [])
 
-            for key, row in data[category].items():
+            for key, row in data[category].copy().items():
                 if key in included_docs:
                     continue
 

--- a/india_compliance/gst_india/utils/gstr_1/gstr_1_json_map.py
+++ b/india_compliance/gst_india/utils/gstr_1/gstr_1_json_map.py
@@ -2493,7 +2493,6 @@ class GSTR1BooksData(BooksDataMapper):
             GSTR1_SubCategory.SEZWOP.value,
             GSTR1_SubCategory.DE.value,
             GSTR1_SubCategory.CDNR.value,
-            GSTR1_SubCategory.SUPECOM_9_5.value,
         )
 
         if is_m3:

--- a/india_compliance/patches/v15/update_return_logs_with_filing_preference.py
+++ b/india_compliance/patches/v15/update_return_logs_with_filing_preference.py
@@ -1,6 +1,10 @@
 import frappe
 
-from india_compliance.gst_india.utils.gstin_info import get_filing_preference
+from india_compliance.gst_india.utils.gstin_info import (
+    fetch_filing_preference,
+    get_filing_preference,
+    get_fy,
+)
 
 
 def patch_filing_preference(gstin):
@@ -20,7 +24,8 @@ def patch_filing_preference(gstin):
 
     gst_return_log = {}
     for log in logs:
-        preference = get_filing_preference(log.gstin, log.return_period)
+        response = fetch_filing_preference(gstin, get_fy(log.return_period))
+        preference = get_filing_preference(log.return_period, response)
         gst_return_log[log.name] = {"filing_preference": preference}
 
     frappe.db.bulk_update("GST Return Log", gst_return_log, update_modified=False)

--- a/india_compliance/public/js/gst_api_handler.js
+++ b/india_compliance/public/js/gst_api_handler.js
@@ -92,14 +92,16 @@ Object.assign(india_compliance, {
 });
 
 class IndiaComplianceForm extends frappe.ui.form.Form {
-    taxpayer_api_call(method, args, callback) {
+    taxpayer_api_call(method, args, callback, doc_method = true) {
         // similar to frappe.ui.form.Form.prototype.call
         const opts = {
             method: method,
-            doc: this.doc,
             args: args,
             callback: callback,
         };
+
+        if(doc_method)
+            opts.doc = this.doc
 
         opts.original_callback = opts.callback;
         opts.callback = r => {

--- a/india_compliance/public/js/gst_api_handler.js
+++ b/india_compliance/public/js/gst_api_handler.js
@@ -92,16 +92,14 @@ Object.assign(india_compliance, {
 });
 
 class IndiaComplianceForm extends frappe.ui.form.Form {
-    taxpayer_api_call(method, args, callback, doc_method = true) {
+    taxpayer_api_call(method, args, callback) {
         // similar to frappe.ui.form.Form.prototype.call
         const opts = {
             method: method,
+            doc: this.doc,
             args: args,
             callback: callback,
         };
-
-        if(doc_method)
-            opts.doc = this.doc
 
         opts.original_callback = opts.callback;
         opts.callback = r => {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/65f8adc8-f898-4461-b1a7-f80a9b2c72e8)

## Implementation

- Each quarter is divided into 3 months.
- Limited information is required to be filed in M1 and M2. Here a row is added to show total invoices excluded from M1 and M2.
- For M3, additional row is added to show invoices that were already filed in M1 and M2.
- Quarterly is auto-set based on the month in which the return is filed. Books info is computed accordingly.
- User can manually refresh the filing preference if it's set incorrectly. This will refresh the preference from the GST Portal.