### PR TITLE
fix: show `Filing Preference` once during view GSTR-1

### DIFF
--- a/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_beta.js
+++ b/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_beta.js
@@ -3079,7 +3079,7 @@ function refresh_filing_preference(frm) {
     );
     if (!$pref_wrapper.length) return;
 
-    const text = $pref_wrapper.text().trim();
+    const text = $pref_wrapper[0]?.textContent.trim();
     const ref_btn_html = frappe.utils.icon("refresh", "xs", "update-filing-preference");
 
     $pref_wrapper


### PR DESCRIPTION
text() retrieves text from all child elements within a selected element, while textContent extracts text only from the specific element itself, ignoring child elements.