### PR TITLE
refactor: move `is_gstr1_api_enabled` function to gst settings

### DIFF
--- a/india_compliance/gst_india/doctype/gst_return_log/generate_gstr_1.py
+++ b/india_compliance/gst_india/doctype/gst_return_log/generate_gstr_1.py
@@ -586,7 +586,9 @@ class GenerateGSTR1(SummarizeGSTR1, ReconcileGSTR1, AggregateInvoices):
         data = {}
 
         # APIs Disabled
-        if not self.is_gstr1_api_enabled(warn_for_missing_credentials=True):
+        if not frappe.get_cached_doc("GST Settings").is_gstr1_api_enabled(
+            self.gstin, warn_for_missing_credentials=True
+        ):
             return self.generate_only_books_data(data, filters, callback)
 
         # APIs Enabled

--- a/india_compliance/gst_india/doctype/gst_return_log/generate_gstr_1.py
+++ b/india_compliance/gst_india/doctype/gst_return_log/generate_gstr_1.py
@@ -586,7 +586,8 @@ class GenerateGSTR1(SummarizeGSTR1, ReconcileGSTR1, AggregateInvoices):
         data = {}
 
         # APIs Disabled
-        if not frappe.get_cached_doc("GST Settings").is_gstr1_api_enabled(
+        settings = frappe.get_cached_doc("GST Settings")
+        if not settings.is_gstr1_api_enabled(
             self.gstin, warn_for_missing_credentials=True
         ):
             return self.generate_only_books_data(data, filters, callback)
@@ -601,11 +602,7 @@ class GenerateGSTR1(SummarizeGSTR1, ReconcileGSTR1, AggregateInvoices):
         else:
             gov_data_field = "unfiled"
 
-        if (
-            status != "Filed"
-            and frappe.get_cached_value("GST Settings", None, "compare_unfiled_data")
-            != 1
-        ):
+        if status != "Filed" and settings.compare_unfiled_data != 1:
             return self.generate_only_books_data(data, filters, callback)
 
         # Get Data

--- a/india_compliance/gst_india/doctype/gst_return_log/gst_return_log.py
+++ b/india_compliance/gst_india/doctype/gst_return_log/gst_return_log.py
@@ -5,7 +5,6 @@ import gzip
 from datetime import datetime
 
 import frappe
-from frappe import _
 from frappe.model.document import Document
 from frappe.utils import (
     get_datetime,
@@ -19,10 +18,7 @@ from india_compliance.gst_india.doctype.gst_return_log.generate_gstr_1 import (
     FileGSTR1,
     GenerateGSTR1,
 )
-from india_compliance.gst_india.utils import (
-    get_party_for_gstin,
-    is_production_api_enabled,
-)
+from india_compliance.gst_india.utils import get_party_for_gstin
 
 DOCTYPE = "GST Return Log"
 
@@ -123,37 +119,8 @@ class GSTReturnLog(GenerateGSTR1, FileGSTR1, Document):
         if file_field == "filed":
             self.remove_json_for("unfiled")
 
-    # GSTR 1 UTILITY
-    def is_gstr1_api_enabled(self, settings=None, warn_for_missing_credentials=False):
-        if not settings:
-            settings = frappe.get_cached_doc("GST Settings")
-
-        if not is_production_api_enabled(settings):
-            return False
-
-        if not settings.enable_gstr_1_api:
-            return False
-
-        if not settings.has_valid_credentials(self.gstin, "Returns"):
-            if warn_for_missing_credentials:
-                frappe.publish_realtime(
-                    "show_missing_gst_credentials_message",
-                    dict(
-                        message=_(
-                            "Credentials are missing for GSTIN {0} for service"
-                            " Returns in GST Settings"
-                        ).format(self.gstin),
-                        title=_("Missing Credentials"),
-                    ),
-                    user=frappe.session.user,
-                )
-
-            return False
-
-        return True
-
     def is_sek_needed(self, settings=None):
-        if not self.is_gstr1_api_enabled(settings):
+        if not settings.is_gstr1_api_enabled(self.gstin):
             return False
 
         if not self.unfiled or self.filing_status != "Filed":
@@ -192,7 +159,7 @@ class GSTReturnLog(GenerateGSTR1, FileGSTR1, Document):
 
         fields = ["books", "books_summary"]
 
-        if self.is_gstr1_api_enabled(settings):
+        if settings.is_gstr1_api_enabled(self.gstin):
             if self.filing_status == "Filed":
                 fields.extend(
                     ["reconcile", "reconcile_summary", "filed", "filed_summary"]

--- a/india_compliance/gst_india/doctype/gst_settings/gst_settings.py
+++ b/india_compliance/gst_india/doctype/gst_settings/gst_settings.py
@@ -373,7 +373,7 @@ class GSTSettings(Document):
     # GSTR 1 UTILITY
     def is_gstr1_api_enabled(self, gstin, warn_for_missing_credentials=False):
         if not is_production_api_enabled(self):
-            pass
+            return False
 
         if not self.enable_gstr_1_api:
             return False

--- a/india_compliance/gst_india/doctype/gst_settings/gst_settings.py
+++ b/india_compliance/gst_india/doctype/gst_settings/gst_settings.py
@@ -22,7 +22,11 @@ from india_compliance.gst_india.page.india_compliance_account import (
     _disable_api_promo,
     post_login,
 )
-from india_compliance.gst_india.utils import can_enable_api, is_api_enabled
+from india_compliance.gst_india.utils import (
+    can_enable_api,
+    is_api_enabled,
+    is_production_api_enabled,
+)
 from india_compliance.gst_india.utils.custom_fields import toggle_custom_fields
 from india_compliance.gst_india.utils.gstin_info import get_gstin_info
 
@@ -361,6 +365,32 @@ class GSTSettings(Document):
 
             if throw:
                 frappe.throw(message)
+
+            return False
+
+        return True
+
+    # GSTR 1 UTILITY
+    def is_gstr1_api_enabled(self, gstin, warn_for_missing_credentials=False):
+        if not is_production_api_enabled(self):
+            pass
+
+        if not self.enable_gstr_1_api:
+            return False
+
+        if not self.has_valid_credentials(gstin, "Returns"):
+            if warn_for_missing_credentials:
+                frappe.publish_realtime(
+                    "show_missing_gst_credentials_message",
+                    dict(
+                        message=_(
+                            "Credentials are missing for GSTIN {0} for service"
+                            " Returns in GST Settings"
+                        ).format(gstin),
+                        title=_("Missing Credentials"),
+                    ),
+                    user=frappe.session.user,
+                )
 
             return False
 


### PR DESCRIPTION
Moved the `is_gstr1_api_enabled` functionality from `GST Return Log` to `GST Settings`, as it is not related to `GST Return Log`