### PR TITLE
fix: ignore item wise tax validation when dont_recompute_tax is enabled

### DIFF
--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -147,6 +147,9 @@ def validate_item_wise_tax_detail(doc):
         if not row.gst_tax_type:
             continue
 
+        if row.dont_recompute_tax:
+            continue
+
         if row.charge_type != "Actual":
             continue
 

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -147,7 +147,7 @@ def validate_item_wise_tax_detail(doc):
         if not row.gst_tax_type:
             continue
 
-        if row.dont_recompute_tax:
+        if row.get("dont_recompute_tax"):
             continue
 
         if row.charge_type != "Actual":


### PR DESCRIPTION
**Issue:**
Unable to sync orders from e-commerce sites.
ref: [33079](https://support.frappe.io/helpdesk/tickets/33079)

**Solution:**
As the tax details fetched from the e-commerce sites won't be recalculated, the validation can be ignored if `dont_recompute_tax` is enabled.

![image](https://github.com/user-attachments/assets/b02dff06-a861-4a24-b6e5-f75123c22bf8)

Backport needed for v15 & v14