### PR TITLE
fix: reduce margin-top for information section

### DIFF
--- a/india_compliance/gst_india/print_format/e_waybill/e_waybill.css
+++ b/india_compliance/gst_india/print_format/e_waybill/e_waybill.css
@@ -20,6 +20,10 @@
     color: black;
 }
 
+.info-section > .table{
+    margin-top: 5px !important;
+}
+
 table, th, td {
     border: 1px solid #d1d8dd;
     border-collapse: collapse;

--- a/india_compliance/gst_india/print_format/e_waybill/e_waybill.html
+++ b/india_compliance/gst_india/print_format/e_waybill/e_waybill.html
@@ -101,7 +101,7 @@
             </table>
         </section>
 
-        <section>
+        <section class="section info-section">
             <div>
                 <strong>Part - A</strong>
             </div>
@@ -204,7 +204,7 @@
             </table>
         </section>
 
-        <section>
+        <section class="section info-section">
             {% if data.VehiclListDetails|length > 0 %}
             <div>
                 <strong>Part - B</strong>


### PR DESCRIPTION
For some users, the barcode in the e-Waybill PDF was overflowing onto a new page, affecting readability and document formatting. To resolve this, the layout has been adjusted to ensure the barcode remains on the same page, improving overall document structure and presentation.

Before:
![before-e-waybill](https://github.com/user-attachments/assets/7003bcd2-a40f-4fd6-93b2-2e1001eea59b)

After:
![after-e-waybill](https://github.com/user-attachments/assets/b84bab99-c4ef-408d-bd98-0e0598c271e7)