### PR TITLE
fix: leap year check logic

### DIFF
--- a/india_compliance/income_tax_india/overrides/asset_depreciation_schedule.py
+++ b/india_compliance/income_tax_india/overrides/asset_depreciation_schedule.py
@@ -89,7 +89,7 @@ def get_wdv_or_dd_depr_amount(
                 flt(fb_row.rate_of_depreciation) / 100
             )
             # if leap year, then consider 366 days
-            if cint(schedule_date.year) % 4 == 0 and fb_row.daily_prorata_based:
+            if is_fiscal_year(cint(schedule_date.year)) and fb_row.daily_prorata_based:
                 depreciation_amount = depreciation_amount * 366 / 365
     elif fb_row.frequency_of_depreciation == 1:
         if fb_row.daily_prorata_based:
@@ -126,6 +126,8 @@ def get_wdv_or_dd_depr_amount(
 
     return depreciation_amount, None
 
+def is_fiscal_year(year):
+    return (year % 4 == 0 and year % 100 != 0) or (year % 400 == 0)
 
 def cancel_depreciation_entries(asset_doc, date):
     # Once the asset is sold during the current year, depreciation booked during the year of sale has to be cancelled as per Income Tax Act

--- a/india_compliance/income_tax_india/overrides/asset_depreciation_schedule.py
+++ b/india_compliance/income_tax_india/overrides/asset_depreciation_schedule.py
@@ -29,6 +29,7 @@ def get_wdv_or_dd_depr_amount(
     asset_depr_schedule,
     prev_per_day_depr=0,
 ):
+
     # As per IT act, if the asset is purchased in the 2nd half of fiscal year, then rate is divided by 2 for the first year
 
     if not fb_row.finance_book or not frappe.db.get_value(
@@ -126,8 +127,10 @@ def get_wdv_or_dd_depr_amount(
 
     return depreciation_amount, None
 
+
 def is_fiscal_year(year):
     return (year % 4 == 0 and year % 100 != 0) or (year % 400 == 0)
+
 
 def cancel_depreciation_entries(asset_doc, date):
     # Once the asset is sold during the current year, depreciation booked during the year of sale has to be cancelled as per Income Tax Act


### PR DESCRIPTION
This PR fixes an incorrect leap year check in the depreciation calculation logic. Previously, the code only checked for divisibility by 4, which led to incorrect results for century years that are not divisible by 400.