### PR TITLE
fix: do not auto apply rcm if place of supply is not set

### DIFF
--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -1433,6 +1433,7 @@ def set_reverse_charge_as_per_gst_settings(doc):
         or not doc.gst_category == "Unregistered"
         or (doc.grand_total and doc.grand_total <= gst_settings.rcm_threshold)
         or doc.get("is_opening") == "Yes"
+        or not doc.get("place_of_supply")
     ):
         return
 


### PR DESCRIPTION
### Traceback

```
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 116, in application
    response = frappe.api.handle(request)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/api/__init__.py", line 49, in handle
    data = endpoint(**arguments)
           ^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/api/v1.py", line 36, in handle_rpc_call
    return frappe.handler.handle()
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/handler.py", line 51, in handle
    data = execute_cmd(cmd)
           ^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/handler.py", line 84, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/__init__.py", line 1520, in call
    return fn(*args, **newargs)
           ^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/utils/typing_validations.py", line 32, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/desk/form/save.py", line 43, in savedocs
    doc.save()
  File "apps/frappe/frappe/model/document.py", line 123, in wrapper
    return func(self, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 483, in save
    return self._save(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 123, in wrapper
    return func(self, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 506, in _save
    return self.insert()
           ^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 123, in wrapper
    return func(self, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 412, in insert
    self.run_before_save_methods()
  File "apps/frappe/frappe/model/document.py", line 1274, in run_before_save_methods
    self.run_method("before_validate")
  File "apps/frappe/frappe/model/document.py", line 1128, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 1516, in composer
    return composed(self, method, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 1498, in runner
    add_to_return_value(self, f(self, method, *args, **kwargs))
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/india_compliance/india_compliance/gst_india/overrides/transaction.py", line 1539, in before_validate_transaction
    set_reverse_charge_as_per_gst_settings(doc)
  File "apps/india_compliance/india_compliance/gst_india/overrides/transaction.py", line 1446, in set_reverse_charge_as_per_gst_settings
    set_reverse_charge(doc)
  File "apps/india_compliance/india_compliance/gst_india/overrides/transaction.py", line 1451, in set_reverse_charge
    is_inter_state = is_inter_state_supply(doc)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/india_compliance/india_compliance/gst_india/overrides/transaction.py", line 654, in is_inter_state_supply
    doc.place_of_supply[:2] != get_source_state_code(doc)
    ~~~~~~~~~~~~~~~~~~~^^^^
TypeError: 'NoneType' object is not subscriptable
```

Frappe Support Issue: https://support.frappe.io/app/hd-ticket/35344