### PR TITLE
feat: update ship_from in buying_address key to dispatch_address in e-waybill constants

### DIFF
--- a/india_compliance/gst_india/constants/e_waybill.py
+++ b/india_compliance/gst_india/constants/e_waybill.py
@@ -11,7 +11,7 @@ selling_address = {
 buying_address = {
     "bill_from": "supplier_address",
     "bill_to": "billing_address",
-    "ship_from": "supplier_address",
+    "ship_from": "dispatch_address",
     "ship_to": "shipping_address",
 }
 

--- a/india_compliance/patches/check_version_compatibility.py
+++ b/india_compliance/patches/check_version_compatibility.py
@@ -18,7 +18,7 @@ VERSIONS_TO_COMPARE = [
     {
         "app_name": "ERPNext",
         "current_version": version.parse(erpnext.__version__),
-        "required_versions": {"version-14": "14.70.7", "version-15": "15.45.5"},
+        "required_versions": {"version-14": "14.70.7", "version-15": "15.60.0"},
     },
 ]
 


### PR DESCRIPTION
depends on: https://github.com/frappe/erpnext/pull/46993
closes: #2614

no-docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the "ship_from" address mapping in GST India e-waybill compliance to use the dispatch address instead of the supplier address.
- **Chores**
  - Updated ERPNext version requirements to ensure compatibility with the latest supported versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->