### PR TITLE
fix: validate same party gstin based on document field in subcontracting transaction

### DIFF
--- a/india_compliance/gst_india/overrides/subcontracting_transaction.py
+++ b/india_compliance/gst_india/overrides/subcontracting_transaction.py
@@ -247,24 +247,43 @@ def validate_doc_references(doc, method=None):
         frappe.msgprint(error_msg, alert=True, indicator="yellow")
 
 
+def get_gstin_field_map(doc):
+    # Subcontracting Receipt
+    gstin_field_map = frappe._dict(
+        {
+            "company_gstin_field": "company_gstin",
+            "party_gstin_field": "supplier_gstin",
+        }
+    )
+
+    if doc.doctype == "Stock Entry":
+        if not doc.is_return:
+            gstin_field_map.company_gstin_field = "bill_from_gstin"
+            gstin_field_map.party_gstin_field = "bill_to_gstin"
+        else:
+            gstin_field_map.company_gstin_field = "bill_to_gstin"
+            gstin_field_map.party_gstin_field = "bill_from_gstin"
+
+    return gstin_field_map
+
+
 def validate_transaction(doc, method=None):
     validate_items(doc)
+
+    gstin_field_map = get_gstin_field_map(doc)
+
+    company_gstin_field = gstin_field_map.company_gstin_field
+    party_gstin_field = gstin_field_map.party_gstin_field
 
     if doc.doctype == "Stock Entry":
         if not doc.is_return:
             company_address_field = "bill_from_address"
-            company_gstin_field = "bill_from_gstin"
-            party_gstin_field = "bill_to_gstin"
             gst_category_field = "bill_to_gst_category"
         else:
             company_address_field = "bill_to_address"
-            company_gstin_field = "bill_to_gstin"
-            party_gstin_field = "bill_from_gstin"
             gst_category_field = "bill_from_gst_category"
     else:
         # Subcontracting Receipt and Subcontracting Order
-        company_gstin_field = "company_gstin"
-        party_gstin_field = "supplier_gstin"
         company_address_field = "billing_address"
         gst_category_field = "gst_category"
 
@@ -343,8 +362,10 @@ class SubcontractingGSTAccounts(GSTAccounts):
         if is_outward_stock_entry(self.doc):
             return
 
-        company_gstin = self.doc.get("company_gstin") or self.doc.get("bill_from_gstin")
-        party_gstin = self.doc.get("supplier_gstin") or self.doc.get("bill_to_gstin")
+        gst_field_map = get_gstin_field_map(self.doc)
+
+        company_gstin = self.doc.get(gst_field_map.company_gstin_field)
+        party_gstin = self.doc.get(gst_field_map.party_gstin_field)
 
         if not party_gstin or company_gstin != party_gstin:
             return

--- a/india_compliance/gst_india/overrides/subcontracting_transaction.py
+++ b/india_compliance/gst_india/overrides/subcontracting_transaction.py
@@ -247,45 +247,49 @@ def validate_doc_references(doc, method=None):
         frappe.msgprint(error_msg, alert=True, indicator="yellow")
 
 
-def get_gstin_field_map(doc):
-    # Subcontracting Receipt
-    gstin_field_map = frappe._dict(
+def get_doctype_field_map(doc):
+    # Subcontracting Receipt and Subcontracting Order
+    doctype_field_map = frappe._dict(
         {
             "company_gstin_field": "company_gstin",
             "party_gstin_field": "supplier_gstin",
+            "company_address_field": "billing_address",
+            "gst_category_field": "gst_category",
         }
     )
 
     if doc.doctype == "Stock Entry":
         if not doc.is_return:
-            gstin_field_map.company_gstin_field = "bill_from_gstin"
-            gstin_field_map.party_gstin_field = "bill_to_gstin"
+            doctype_field_map.update(
+                {
+                    "company_gstin_field": "bill_from_gstin",
+                    "party_gstin_field": "bill_to_gstin",
+                    "company_address_field": "bill_from_address",
+                    "gst_category_field": "bill_to_gst_category",
+                }
+            )
         else:
-            gstin_field_map.company_gstin_field = "bill_to_gstin"
-            gstin_field_map.party_gstin_field = "bill_from_gstin"
+            doctype_field_map.update(
+                {
+                    "company_gstin_field": "bill_to_gstin",
+                    "party_gstin_field": "bill_from_gstin",
+                    "company_address_field": "bill_to_address",
+                    "gst_category_field": "bill_from_gst_category",
+                }
+            )
 
-    return gstin_field_map
+    return doctype_field_map
 
 
 def validate_transaction(doc, method=None):
     validate_items(doc)
 
-    gstin_field_map = get_gstin_field_map(doc)
+    doctype_field_map = get_doctype_field_map(doc)
 
-    company_gstin_field = gstin_field_map.company_gstin_field
-    party_gstin_field = gstin_field_map.party_gstin_field
-
-    if doc.doctype == "Stock Entry":
-        if not doc.is_return:
-            company_address_field = "bill_from_address"
-            gst_category_field = "bill_to_gst_category"
-        else:
-            company_address_field = "bill_to_address"
-            gst_category_field = "bill_from_gst_category"
-    else:
-        # Subcontracting Receipt and Subcontracting Order
-        company_address_field = "billing_address"
-        gst_category_field = "gst_category"
+    company_gstin_field = doctype_field_map.company_gstin_field
+    party_gstin_field = doctype_field_map.party_gstin_field
+    company_address_field = doctype_field_map.company_address_field
+    gst_category_field = doctype_field_map.gst_category_field
 
     if doc.place_of_supply:
         validate_place_of_supply(doc)
@@ -362,10 +366,10 @@ class SubcontractingGSTAccounts(GSTAccounts):
         if is_outward_stock_entry(self.doc):
             return
 
-        gst_field_map = get_gstin_field_map(self.doc)
+        doctype_field_map = get_doctype_field_map(self.doc)
 
-        company_gstin = self.doc.get(gst_field_map.company_gstin_field)
-        party_gstin = self.doc.get(gst_field_map.party_gstin_field)
+        company_gstin = self.doc.get(doctype_field_map.company_gstin_field)
+        party_gstin = self.doc.get(doctype_field_map.party_gstin_field)
 
         if not party_gstin or company_gstin != party_gstin:
             return


### PR DESCRIPTION
An incorrect validation occurred in the stock entry because the client created a custom field for the company's GSTIN, which was unexpected.

Instead of using th "Or" condition, the validation now checks based on the document's field map.

Frappe Support Issue: https://support.frappe.io/app/hd-ticket/35271