### PR TITLE
fix: correct data format for error response for hsn data upload

### DIFF
--- a/india_compliance/gst_india/utils/gstr_1/gstr_1_json_map.py
+++ b/india_compliance/gst_india/utils/gstr_1/gstr_1_json_map.py
@@ -1181,7 +1181,7 @@ class HSNSUM(GSTR1DataMapper):
     def convert_to_internal_data_format(self, input_data):
         output = {}
 
-        # get hsn summary has dict
+        # error JSON is diff from normal JSON
         if isinstance(input_data, dict):
             input_data = [input_data]
 

--- a/india_compliance/gst_india/utils/gstr_1/gstr_1_json_map.py
+++ b/india_compliance/gst_india/utils/gstr_1/gstr_1_json_map.py
@@ -1181,23 +1181,22 @@ class HSNSUM(GSTR1DataMapper):
     def convert_to_internal_data_format(self, input_data):
         output = {}
 
-        default_data = {
-            GSTR1_DataField.ERROR_CD.value: input_data.get(GovDataField.ERROR_CD.value),
-            GSTR1_DataField.ERROR_MSG.value: input_data.get(
-                GovDataField.ERROR_MSG.value
-            ),
-        }
+        for row in input_data:
+            default_data = {
+                GSTR1_DataField.ERROR_CD.value: row.get(GovDataField.ERROR_CD.value),
+                GSTR1_DataField.ERROR_MSG.value: row.get(GovDataField.ERROR_MSG.value),
+            }
 
-        for invoice in input_data[GovDataField.HSN_DATA.value]:
-            output[
-                " - ".join(
-                    (
-                        invoice.get(GovDataField.HSN_CODE.value, ""),
-                        self.map_uom(invoice.get(GovDataField.UOM.value, "")),
-                        str(flt(invoice.get(GovDataField.TAX_RATE.value))),
+            for invoice in row[GovDataField.HSN_DATA.value]:
+                output[
+                    " - ".join(
+                        (
+                            invoice.get(GovDataField.HSN_CODE.value, ""),
+                            self.map_uom(invoice.get(GovDataField.UOM.value, "")),
+                            str(flt(invoice.get(GovDataField.TAX_RATE.value))),
+                        )
                     )
-                )
-            ] = self.format_data(invoice, default_data)
+                ] = self.format_data(invoice, default_data)
 
         return {self.SUBCATEGORY: output}
 

--- a/india_compliance/gst_india/utils/gstr_1/gstr_1_json_map.py
+++ b/india_compliance/gst_india/utils/gstr_1/gstr_1_json_map.py
@@ -1181,6 +1181,10 @@ class HSNSUM(GSTR1DataMapper):
     def convert_to_internal_data_format(self, input_data):
         output = {}
 
+        # get hsn summary has dict
+        if isinstance(input_data, dict):
+            input_data = [input_data]
+
         for row in input_data:
             default_data = {
                 GSTR1_DataField.ERROR_CD.value: row.get(GovDataField.ERROR_CD.value),

--- a/india_compliance/gst_india/utils/gstr_1/test_gstr_1_json_map.py
+++ b/india_compliance/gst_india/utils/gstr_1/test_gstr_1_json_map.py
@@ -1361,3 +1361,84 @@ class TestSUPECOM(IntegrationTestCase):
             process_mapped_data(self.mapped_data)
         )
         self.assertDictEqual(self.json_data, output)
+
+
+##### ERROR JSON TEST CASES #####
+
+
+class TestHSNSUMError(IntegrationTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.json_data = [
+            {
+                GovDataField.HSN_DATA.value: [
+                    {
+                        GovDataField.INDEX.value: 1,
+                        GovDataField.HSN_CODE.value: "1010",
+                        GovDataField.DESCRIPTION.value: "Goods Description",
+                        GovDataField.UOM.value: "KGS",
+                        GovDataField.QUANTITY.value: 2.05,
+                        GovDataField.TAXABLE_VALUE.value: 10.23,
+                        GovDataField.IGST.value: 14.52,
+                        GovDataField.CESS.value: 500,
+                        GovDataField.TAX_RATE.value: 0.1,
+                    },
+                ],
+                GovDataField.ERROR_CD.value: "RET191350",
+                GovDataField.ERROR_MSG.value: "Length of entered HSN code is not valid as per AATO",
+            },
+            {
+                GovDataField.HSN_DATA.value: [
+                    {
+                        GovDataField.INDEX.value: 2,
+                        GovDataField.HSN_CODE.value: "1011",
+                        GovDataField.DESCRIPTION.value: "Goods Description",
+                        GovDataField.UOM.value: "NOS",
+                        GovDataField.QUANTITY.value: 2.05,
+                        GovDataField.TAXABLE_VALUE.value: 10.23,
+                        GovDataField.IGST.value: 14.52,
+                        GovDataField.CESS.value: 500,
+                        GovDataField.TAX_RATE.value: 5.0,
+                    }
+                ],
+                GovDataField.ERROR_CD.value: "RET191350",
+                GovDataField.ERROR_MSG.value: "Length of entered HSN code is not valid as per AATO",
+            },
+        ]
+
+        cls.mapped_data = {
+            GSTR1_SubCategory.HSN.value: {
+                "1010 - KGS-KILOGRAMS - 0.1": {
+                    GSTR1_DataField.HSN_CODE.value: "1010",
+                    GSTR1_DataField.DESCRIPTION.value: "Goods Description",
+                    GSTR1_DataField.UOM.value: "KGS-KILOGRAMS",
+                    GSTR1_DataField.QUANTITY.value: 2.05,
+                    GSTR1_DataField.TAXABLE_VALUE.value: 10.23,
+                    GSTR1_DataField.IGST.value: 14.52,
+                    GSTR1_DataField.CESS.value: 500,
+                    GSTR1_DataField.TAX_RATE.value: 0.1,
+                    GSTR1_DataField.DOC_VALUE.value: 524.75,
+                    GSTR1_DataField.ERROR_CD.value: "RET191350",
+                    GSTR1_DataField.ERROR_MSG.value: "Length of entered HSN code is not valid as per AATO",
+                },
+                "1011 - NOS-NUMBERS - 5.0": {
+                    GSTR1_DataField.HSN_CODE.value: "1011",
+                    GSTR1_DataField.DESCRIPTION.value: "Goods Description",
+                    GSTR1_DataField.UOM.value: "NOS-NUMBERS",
+                    GSTR1_DataField.QUANTITY.value: 2.05,
+                    GSTR1_DataField.TAXABLE_VALUE.value: 10.23,
+                    GSTR1_DataField.IGST.value: 14.52,
+                    GSTR1_DataField.CESS.value: 500,
+                    GSTR1_DataField.TAX_RATE.value: 5,
+                    GSTR1_DataField.DOC_VALUE.value: 524.75,
+                    GSTR1_DataField.ERROR_CD.value: "RET191350",
+                    GSTR1_DataField.ERROR_MSG.value: "Length of entered HSN code is not valid as per AATO",
+                },
+            }
+        }
+
+    def test_convert_to_internal_data_format(self):
+        output = HSNSUM().convert_to_internal_data_format(self.json_data)
+        self.assertDictEqual(self.mapped_data, output)


### PR DESCRIPTION
### Traceback

```
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 115, in application
    response = frappe.api.handle(request)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/api/__init__.py", line 49, in handle
    data = endpoint(**arguments)
           ^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/api/v1.py", line 36, in handle_rpc_call
    return frappe.handler.handle()
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/handler.py", line 51, in handle
    data = execute_cmd(cmd)
           ^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/handler.py", line 84, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/__init__.py", line 1736, in call
    return fn(*args, **newargs)
           ^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/utils/typing_validations.py", line 31, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "apps/india_compliance/india_compliance/gst_india/api_classes/taxpayer_base.py", line 43, in wrapper
    raise e
  File "apps/india_compliance/india_compliance/gst_india/api_classes/taxpayer_base.py", line 34, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "apps/india_compliance/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_beta.py", line 222, in check_action_status
    data = getattr(gstr_1_log, method_name)()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/india_compliance/india_compliance/gst_india/doctype/gst_return_log/generate_gstr_1.py", line 902, in process_upload_gstr1
    response["error_report"] = convert_to_internal_data_format(
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/india_compliance/india_compliance/gst_india/utils/gstr_1/gstr_1_json_map.py", line 1833, in convert_to_internal_data_format
    mapper_class().convert_to_internal_data_format(gov_data.get(category))
  File "apps/india_compliance/india_compliance/gst_india/utils/gstr_1/gstr_1_json_map.py", line 1185, in convert_to_internal_data_format
    GSTR1_DataField.ERROR_CD.value: input_data.get(GovDataField.ERROR_CD.value),
                                    ^^^^^^^^^^^^^^
AttributeError: 'list' object has no attribute 'get'
```