### PR TITLE
fix: support same item with different tax rates

### DIFF
--- a/india_compliance/gst_india/overrides/test_transaction.py
+++ b/india_compliance/gst_india/overrides/test_transaction.py
@@ -200,15 +200,37 @@ class TestTransaction(IntegrationTestCase):
 
     def test_transaction_for_items_with_duplicate_taxes(self):
         # Should not allow same item in invoice with multiple taxes
-        doc = create_transaction(**self.transaction_details, do_not_save=True)
+        doc = create_transaction(
+            **self.transaction_details, do_not_save=True, is_in_state=True
+        )
 
         append_item(doc, frappe._dict(item_tax_template="GST 28% - _TIRC"))
+        doc.taxes[0].dont_recompute_tax = 1
 
         self.assertRaisesRegex(
             frappe.exceptions.ValidationError,
             re.compile(r"^(Cannot use different Item Tax Templates in different.*)$"),
             doc.insert,
         )
+
+    def test_transaction_for_items_with_different_tax_templates(self):
+        doc = create_transaction(
+            **self.transaction_details, do_not_save=True, is_in_state=True
+        )
+
+        append_item(doc, frappe._dict(item_tax_template="GST 12% - _TIRC"))
+        doc.insert()
+
+        # Verify that taxes and amounts are set correctly in both items
+        self.assertEqual(doc.items[0].cgst_rate, 9)
+        self.assertEqual(doc.items[0].sgst_rate, 9)
+        self.assertEqual(doc.items[0].cgst_amount, 9)
+        self.assertEqual(doc.items[0].sgst_amount, 9)
+
+        self.assertEqual(doc.items[1].cgst_rate, 6)
+        self.assertEqual(doc.items[1].sgst_rate, 6)
+        self.assertEqual(doc.items[1].cgst_amount, 6)
+        self.assertEqual(doc.items[1].sgst_amount, 6)
 
     def test_place_of_supply_is_set(self):
         doc = create_transaction(**self.transaction_details)

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -584,6 +584,9 @@ def validate_items(doc):
     if not doc.get("items"):
         return
 
+    if not any(row.get("dont_recompute_tax") for row in doc.taxes):
+        return
+
     item_tax_templates = frappe._dict()
     items_with_duplicate_taxes = []
 
@@ -1162,10 +1165,10 @@ class ItemGSTDetails:
             if not doc.get("items") or not doc.get("taxes"):
                 continue
 
-            self.set_item_wise_tax_details()
+            self.set_item_code_wise_tax_details()
 
             for item in doc.get("items"):
-                response[item.name] = self.get_item_tax_detail(item)
+                response[item.name] = self.get_tax_detail_by_item_code(item)
 
         return response
 
@@ -1179,8 +1182,14 @@ class ItemGSTDetails:
 
         self.get_item_defaults()
         self.set_tax_amount_precisions(doc.doctype)
-        self.set_item_wise_tax_details()
-        self.update_item_tax_details()
+
+        # To Deprecate
+        if self.dont_recompute_tax_is_set():
+            self.set_item_code_wise_tax_details()
+            self.update_tax_details_by_item_code()
+
+        else:
+            self.set_item_name_wise_tax_details()
 
     def get_item_defaults(self):
         item_defaults = frappe._dict(count=0)
@@ -1191,7 +1200,71 @@ class ItemGSTDetails:
 
         self.item_defaults = item_defaults
 
-    def set_item_wise_tax_details(self):
+    def set_item_name_wise_tax_details(self):
+        """
+        Update Item Tax Details
+
+        Possible Exceptions Handled:
+        - There could be more than one row for same account
+        - Item count added to handle rounding errors
+        """
+
+        tax_differences = frappe._dict(
+            {
+                tax_row.gst_tax_type: tax_row.get(self.tax_amount_field(), 0)
+                for tax_row in self.doc.taxes
+                if self.is_gst_tax_row(tax_row)
+            }
+        )
+        last_item_with_tax = None
+        last_item_defaults = None
+
+        for item in self.doc.get("items"):
+            item_defaults = self.item_defaults.copy()
+            tax_amount = 0
+
+            for tax_row in self.doc.taxes:
+                if not self.is_gst_tax_row(tax_row):
+                    continue
+
+                tax = tax_row.gst_tax_type
+                tax_rate_field = f"{tax}_rate"
+                tax_amount_field = f"{tax}_amount"
+
+                old = frappe.parse_json(tax_row.get(self.tax_details_field(), "{}"))
+
+                if self.get_item_key(item) not in old:
+                    # Do not compute if Item is not present in Item table
+                    # There can be difference in Item Table and Item Wise Tax Details
+                    continue
+
+                tax_rate = self.get_item_tax_rate(item, tax_row)
+                tax_amount = self.get_item_tax_amount(item, tax_rate, tax)
+
+                # cases when charge type == "Actual"
+                if tax_amount and not tax_rate:
+                    continue
+
+                tax_differences[tax] -= tax_amount
+                item_defaults[tax_rate_field] = tax_rate
+                item_defaults[tax_amount_field] += tax_amount
+
+            item.update(item_defaults)
+
+            # update tax difference only for taxable items
+            if tax_amount:
+                last_item_with_tax = item
+                last_item_defaults = item_defaults
+
+        # Handle rounding errors
+        if tax_differences and last_item_with_tax:
+            for tax, tax_amount in tax_differences.items():
+                last_item_defaults[f"{tax}_amount"] += flt(tax_amount, 5)
+
+            for fieldname, value in last_item_defaults.items():
+                last_item_with_tax.set(fieldname, value)
+
+    def set_item_code_wise_tax_details(self):
         """
         Item Tax Details complied
         Example:
@@ -1215,25 +1288,22 @@ class ItemGSTDetails:
         tax_details = frappe._dict()
 
         for row in self.doc.get("items"):
-            key = row.item_code or row.item_name
+            key = self.get_item_key(row)
 
             if key not in tax_details:
                 tax_details[key] = self.item_defaults.copy()
+
             tax_details[key]["count"] += 1
 
         for row in self.doc.taxes:
-            if (
-                not row.base_tax_amount_after_discount_amount
-                or row.gst_tax_type not in GST_TAX_TYPES
-                or not row.item_wise_tax_detail
-            ):
+            if not self.is_gst_tax_row(row):
                 continue
 
             tax = row.gst_tax_type
             tax_rate_field = f"{tax}_rate"
             tax_amount_field = f"{tax}_amount"
 
-            old = json.loads(row.item_wise_tax_detail)
+            old = json.loads(row.get(self.tax_details_field(), "{}"))
 
             tax_difference = row.base_tax_amount_after_discount_amount
             last_item_with_tax = None
@@ -1271,14 +1341,14 @@ class ItemGSTDetails:
 
         self.item_tax_details = tax_details
 
-    def update_item_tax_details(self):
+    def update_tax_details_by_item_code(self):
         for item in self.doc.get("items"):
-            item.update(self.get_item_tax_detail(item))
+            item.update(self.get_tax_detail_by_item_code(item))
 
     def get_item_key(self, item):
         return item.item_code or item.item_name
 
-    def get_item_tax_detail(self, item):
+    def get_tax_detail_by_item_code(self, item):
         """
         - get item_tax_detail as it is if
             - only one row exists for same item
@@ -1307,14 +1377,9 @@ class ItemGSTDetails:
             if (tax_rate := item_tax_detail[f"{tax}_rate"]) == 0:
                 continue
 
+            tax_amount = self.get_item_tax_amount(item, tax_rate, tax)
+
             tax_amount_field = f"{tax}_amount"
-            precision = self.precision.get(tax_amount_field)
-
-            multiplier = (
-                item.qty if tax == "cess_non_advol" else item.taxable_value / 100
-            )
-            tax_amount = flt(tax_rate * multiplier, precision)
-
             item_tax_detail[tax_amount_field] -= tax_amount
 
             response.update({tax_amount_field: tax_amount})
@@ -1336,6 +1401,50 @@ class ItemGSTDetails:
                 continue
 
             self.precision[fieldname] = field.precision or default_precision
+
+    def dont_recompute_tax_is_set(self):
+        for row in self.doc.taxes:
+            if not self.is_gst_tax_row(row):
+                continue
+
+            if row.get("dont_recompute_tax"):
+                return True
+
+    def is_gst_tax_row(self, row):
+        return (
+            row.gst_tax_type
+            and row.gst_tax_type in GST_TAX_TYPES
+            and row.get(self.tax_details_field())
+        )
+
+    def get_item_tax_rate(self, item, tax_row):
+        if not getattr(self, "item_tax_rates", None):
+            self.item_tax_rates = frappe._dict()
+
+        if item.name not in self.item_tax_rates:
+            tax_rates = frappe.parse_json(item.item_tax_rate)
+            self.item_tax_rates[item.name] = tax_rates
+
+        item_tax_rates = self.item_tax_rates[item.name]
+
+        if tax_row.account_head in item_tax_rates:
+            return item_tax_rates[tax_row.account_head]
+
+        return tax_row.rate
+
+    def get_item_tax_amount(self, item, tax_rate, tax):
+        precision = self.precision.get(f"{tax}_amount")
+        multiplier = item.qty if tax == "cess_non_advol" else item.taxable_value / 100
+
+        return flt(tax_rate * multiplier, precision)
+
+    @staticmethod
+    def tax_amount_field():
+        return "base_tax_amount_after_discount_amount"
+
+    @staticmethod
+    def tax_details_field():
+        return "item_wise_tax_detail"
 
 
 class ItemGSTTreatment:

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -1231,6 +1231,7 @@ class ItemGSTDetails:
                 tax_rate_field = f"{tax}_rate"
                 tax_amount_field = f"{tax}_amount"
 
+                old = self.get_tax_details(tax_row)
                 old = frappe.parse_json(tax_row.get(self.tax_details_field(), "{}"))
 
                 if self.get_item_key(item) not in old:
@@ -1410,6 +1411,8 @@ class ItemGSTDetails:
             if row.get("dont_recompute_tax"):
                 return True
 
+        return False
+
     def is_gst_tax_row(self, row):
         return (
             row.gst_tax_type
@@ -1418,14 +1421,7 @@ class ItemGSTDetails:
         )
 
     def get_item_tax_rate(self, item, tax_row):
-        if not getattr(self, "item_tax_rates", None):
-            self.item_tax_rates = frappe._dict()
-
-        if item.name not in self.item_tax_rates:
-            tax_rates = frappe.parse_json(item.item_tax_rate)
-            self.item_tax_rates[item.name] = tax_rates
-
-        item_tax_rates = self.item_tax_rates[item.name]
+        item_tax_rates = frappe.parse_json(item.item_tax_rate)
 
         if tax_row.account_head in item_tax_rates:
             return item_tax_rates[tax_row.account_head]
@@ -1437,6 +1433,14 @@ class ItemGSTDetails:
         multiplier = item.qty if tax == "cess_non_advol" else item.taxable_value / 100
 
         return flt(tax_rate * multiplier, precision)
+
+    def get_tax_details(self, tax_row):
+        if not getattr(tax_row, "__tax_details", None):
+            tax_row.__tax_details = frappe.parse_json(
+                tax_row.get(self.tax_details_field()) or "{}"
+            )
+
+        return tax_row.__tax_details
 
     @staticmethod
     def tax_amount_field():

--- a/india_compliance/gst_india/report/hsn_wise_summary_of_outward_supplies/test_hsn_wise_summary_of_outward_supplies.py
+++ b/india_compliance/gst_india/report/hsn_wise_summary_of_outward_supplies/test_hsn_wise_summary_of_outward_supplies.py
@@ -43,6 +43,6 @@ class TestHSNWiseSummaryReport(IntegrationTestCase):
         self.assertTrue(filtered_rows)
 
         hsn_row = filtered_rows[0]
-        self.assertEquals(hsn_row["quantity"], 2.0)
-        self.assertEquals(hsn_row["total_taxable_value"], 200)
-        self.assertEquals(hsn_row["document_value"], 236)  # 2 * 1.18 * 100
+        self.assertEqual(hsn_row["quantity"], 2.0)
+        self.assertEqual(hsn_row["total_taxable_value"], 200)
+        self.assertEqual(hsn_row["document_value"], 236)  # 2 * 1.18 * 100

--- a/india_compliance/gst_india/utils/taxes_controller.py
+++ b/india_compliance/gst_india/utils/taxes_controller.py
@@ -34,14 +34,7 @@ class CustomItemGSTDetails(ItemGSTDetails):
         """
         Get item tax rate from item tax template
         """
-        if not getattr(self, "item_tax_rates", None):
-            self.item_tax_rates = frappe._dict()
-
-        if tax_row.name not in self.item_tax_rates:
-            tax_rates = frappe.parse_json(tax_row.item_wise_tax_rates)
-            self.item_tax_rates[tax_row.name] = tax_rates
-
-        item_tax_rates = self.item_tax_rates[tax_row.name]
+        item_tax_rates = self.get_tax_details(tax_row)
         return item_tax_rates.get(item.name)
 
 

--- a/india_compliance/gst_india/utils/taxes_controller.py
+++ b/india_compliance/gst_india/utils/taxes_controller.py
@@ -20,22 +20,19 @@ class CustomItemGSTDetails(ItemGSTDetails):
     Support use of Item wise tax rates in Taxes and Charges table
     """
 
-    def set_item_wise_tax_details(self):
+    # TO Deprecate
+    def set_item_code_wise_tax_details(self):
         tax_details = frappe._dict()
         item_map = {}
 
         for row in self.doc.get("items"):
-            key = row.name
+            key = self.get_item_key(row)
             item_map[key] = row
             tax_details[key] = self.item_defaults.copy()
             tax_details[key]["count"] += 1
 
         for row in self.doc.taxes:
-            if (
-                not row.tax_amount
-                or row.gst_tax_type not in GST_TAX_TYPES
-                or not row.item_wise_tax_rates
-            ):
+            if not self.is_gst_tax_row(row):
                 continue
 
             tax = row.gst_tax_type
@@ -53,18 +50,14 @@ class CustomItemGSTDetails(ItemGSTDetails):
 
                 item_taxes = tax_details[row_name]
                 tax_rate = item_wise_tax_rates.get(row_name)
-                precision = self.precision.get(tax_amount_field)
-                item = item_map.get(row_name)
-
-                multiplier = (
-                    item.qty if tax == "cess_non_advol" else item.taxable_value / 100
-                )
 
                 # cases when charge type == "Actual"
                 if not tax_rate:
                     continue
 
-                tax_amount = flt(tax_rate * multiplier, precision)
+                item = item_map.get(row_name)
+                tax_amount = self.get_item_tax_amount(item, tax_rate, tax)
+
                 item_taxes[tax_rate_field] = tax_rate
                 item_taxes[tax_amount_field] += tax_amount
 
@@ -72,6 +65,28 @@ class CustomItemGSTDetails(ItemGSTDetails):
 
     def get_item_key(self, item):
         return item.name
+
+    @staticmethod
+    def tax_amount_field():
+        return "tax_amount"
+
+    @staticmethod
+    def tax_details_field():
+        return "item_wise_tax_rates"
+
+    def get_item_tax_rate(self, item, tax_row):
+        """
+        Get item tax rate from item tax template
+        """
+        if not getattr(self, "item_tax_rates", None):
+            self.item_tax_rates = frappe._dict()
+
+        if tax_row.name not in self.item_tax_rates:
+            tax_rates = frappe.parse_json(tax_row.item_wise_tax_rates)
+            self.item_tax_rates[tax_row.name] = tax_rates
+
+        item_tax_rates = self.item_tax_rates[tax_row.name]
+        return item_tax_rates.get(item.name)
 
 
 def update_gst_details(doc, method=None):

--- a/india_compliance/gst_india/utils/taxes_controller.py
+++ b/india_compliance/gst_india/utils/taxes_controller.py
@@ -7,7 +7,6 @@ from erpnext.controllers.taxes_and_totals import (
     get_round_off_applicable_accounts as fetch_round_off_accounts,
 )
 
-from india_compliance.gst_india.constants import GST_TAX_TYPES
 from india_compliance.gst_india.overrides.transaction import (
     ItemGSTDetails,
     ItemGSTTreatment,
@@ -19,49 +18,6 @@ class CustomItemGSTDetails(ItemGSTDetails):
     """
     Support use of Item wise tax rates in Taxes and Charges table
     """
-
-    # TO Deprecate
-    def set_item_code_wise_tax_details(self):
-        tax_details = frappe._dict()
-        item_map = {}
-
-        for row in self.doc.get("items"):
-            key = self.get_item_key(row)
-            item_map[key] = row
-            tax_details[key] = self.item_defaults.copy()
-            tax_details[key]["count"] += 1
-
-        for row in self.doc.taxes:
-            if not self.is_gst_tax_row(row):
-                continue
-
-            tax = row.gst_tax_type
-            tax_rate_field = f"{tax}_rate"
-            tax_amount_field = f"{tax}_amount"
-
-            item_wise_tax_rates = json.loads(row.item_wise_tax_rates)
-
-            # update item taxes
-            for row_name in item_wise_tax_rates:
-                if row_name not in tax_details:
-                    # Do not compute if Item is not present in Item table
-                    # There can be difference in Item Table and Item Wise Tax Details
-                    continue
-
-                item_taxes = tax_details[row_name]
-                tax_rate = item_wise_tax_rates.get(row_name)
-
-                # cases when charge type == "Actual"
-                if not tax_rate:
-                    continue
-
-                item = item_map.get(row_name)
-                tax_amount = self.get_item_tax_amount(item, tax_rate, tax)
-
-                item_taxes[tax_rate_field] = tax_rate
-                item_taxes[tax_amount_field] += tax_amount
-
-        self.item_tax_details = tax_details
 
     def get_item_key(self, item):
         return item.name


### PR DESCRIPTION
## Support same item codes with different tax rates

- Not supported when flag `dont_recompute_taxes` is used. It will still use the old functionality
- Common utility for India Compliance Taxes.

![image](https://github.com/user-attachments/assets/dda13dc1-eb25-43c5-a8e6-c7b91a61f77f)

- [x] Fix GSTR-1 Legacy Report

Closes: https://github.com/resilient-tech/india-compliance/issues/2941