### PR TITLE
fix: validate hsn code for Overseas purchase invoice

### DIFF
--- a/india_compliance/gst_india/overrides/purchase_invoice.py
+++ b/india_compliance/gst_india/overrides/purchase_invoice.py
@@ -8,9 +8,7 @@ from india_compliance.gst_india.overrides.sales_invoice import (
     update_dashboard_with_gst_logs,
 )
 from india_compliance.gst_india.overrides.transaction import (
-    validate_hsn_codes as _validate_hsn_codes,
-)
-from india_compliance.gst_india.overrides.transaction import (
+    _validate_hsn_codes,
     validate_transaction,
 )
 from india_compliance.gst_india.utils import is_api_enabled, validate_invoice_number
@@ -264,6 +262,7 @@ def validate_hsn_codes(doc):
 
     _validate_hsn_codes(
         doc,
+        valid_hsn_length=[4, 6, 8],
         throw=True,
-        message="GST HSN Code is mandatory for Overseas Purchase Invoice.<br>",
+        message=_("GST HSN Code is mandatory for Overseas Purchase Invoice.<br>"),
     )

--- a/india_compliance/gst_india/overrides/test_purchase_invoice.py
+++ b/india_compliance/gst_india/overrides/test_purchase_invoice.py
@@ -1,3 +1,5 @@
+import re
+
 import frappe
 from frappe.tests import IntegrationTestCase, change_settings
 from erpnext.accounts.doctype.account.test_account import create_account
@@ -86,3 +88,22 @@ class TestPurchaseInvoice(IntegrationTestCase):
 
         # Reset autoname (as it's cached)
         pinv.meta.autoname = "naming_series:"
+
+    @change_settings("GST Settings", {"enable_overseas_transactions": 1})
+    @change_settings("GST Settings", {"validate_hsn_code": 0})
+    def test_validate_hsn_code_for_overseas(self):
+        frappe.db.set_value("Item", "_Test Service Item", "gst_hsn_code", "")
+        pinv = create_purchase_invoice(
+            supplier="_Test Foreign Supplier",
+            do_not_submit=1,
+            do_not_save=1,
+            item_code="_Test Service Item",
+        )
+
+        self.assertRaisesRegex(
+            frappe.exceptions.ValidationError,
+            re.compile(r"^(GST HSN Code is mandatory for Overseas Purchase Invoice.*)"),
+            pinv.save,
+        )
+
+        frappe.db.set_value("Item", "_Test Service Item", "gst_hsn_code", "999900")


### PR DESCRIPTION
Traceback:

```
Traceback (most recent call last): 
  File "apps/frappe/frappe/app.py", line 115, in application 
    response = frappe.api.handle(request) 
               ^^^^^^^^^^^^^^^^^^^^^^^^^^ 
  File "apps/frappe/frappe/api/__init__.py", line 49, in handle 
    data = endpoint(**arguments) 
           ^^^^^^^^^^^^^^^^^^^^^ 
  File "apps/frappe/frappe/api/v1.py", line 36, in handle_rpc_call 
    return frappe.handler.handle() 
           ^^^^^^^^^^^^^^^^^^^^^^^ 
  File "apps/frappe/frappe/handler.py", line 51, in handle 
    data = execute_cmd(cmd) 
           ^^^^^^^^^^^^^^^^ 
  File "apps/frappe/frappe/handler.py", line 84, in execute_cmd 
    return frappe.call(method, **frappe.form_dict) 
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
  File "apps/frappe/frappe/__init__.py", line 1736, in call 
    return fn(*args, **newargs) 
           ^^^^^^^^^^^^^^^^^^^^ 
  File "apps/frappe/frappe/utils/typing_validations.py", line 31, in wrapper 
    return func(*args, **kwargs) 
           ^^^^^^^^^^^^^^^^^^^^^ 
  File "apps/frappe/frappe/desk/form/save.py", line 39, in savedocs 
    doc.save() 
  File "apps/frappe/frappe/model/document.py", line 378, in save 
    return self._save(*args, **kwargs) 
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
  File "apps/frappe/frappe/model/document.py", line 400, in _save 
    return self.insert() 
           ^^^^^^^^^^^^^ 
  File "apps/frappe/frappe/model/document.py", line 309, in insert 
    self.run_before_save_methods() 
  File "apps/frappe/frappe/model/document.py", line 1136, in run_before_save_methods 
    self.run_method("validate") 
  File "apps/frappe/frappe/model/document.py", line 1007, in run_method 
    out = Document.hook(fn)(self, *args, **kwargs) 
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
  File "apps/frappe/frappe/model/document.py", line 1367, in composer 
    return composed(self, method, *args, **kwargs) 
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
  File "apps/frappe/frappe/model/document.py", line 1351, in runner 
    add_to_return_value(self, f(self, method, *args, **kwargs)) 
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
  File "apps/india_compliance/india_compliance/gst_india/overrides/purchase_invoice.py", line 
55, in validate 
    set_itc_classification(doc) 
  File "apps/india_compliance/india_compliance/gst_india/overrides/purchase_invoice.py", line 
103, in set_itc_classification 
    if not item.gst_hsn_code.startswith("99"): 
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
AttributeError: 'NoneType' object has no attribute 'startswith' 
```