### PR TITLE
fix: date comparison in cancel_e_waybill_e_invoice function

### DIFF
--- a/india_compliance/gst_india/overrides/sales_invoice.py
+++ b/india_compliance/gst_india/overrides/sales_invoice.py
@@ -1,7 +1,7 @@
 import frappe
 from frappe import _, bold
 from frappe.desk.form.load import run_onload
-from frappe.utils import add_days, days_diff, flt, fmt_money
+from frappe.utils import add_days, flt, fmt_money, get_datetime
 
 from india_compliance.gst_india.overrides.payment_entry import get_taxes_summary
 from india_compliance.gst_india.overrides.transaction import (
@@ -257,7 +257,7 @@ def cancel_e_waybill_e_invoice(doc, method=None):
             generated_on = doc.get_onload().get("e_waybill_info", {}).get("created_on")
             reason = gst_settings.reason_for_e_waybill_cancellation
 
-        if not generated_on or days_diff(add_days(generated_on, 1), generated_on) > 1:
+        if not generated_on or (add_days(generated_on, 1) < get_datetime()):
             return
 
         values = frappe._dict(

--- a/india_compliance/gst_india/utils/test_e_invoice.py
+++ b/india_compliance/gst_india/utils/test_e_invoice.py
@@ -42,6 +42,8 @@ class TestEInvoice(IntegrationTestCase):
                 "fetch_e_waybill_data": 0,
                 "apply_e_invoice_only_for_selected_companies": 0,
                 "enable_retry_einv_ewb_generation": 1,
+                "auto_cancel_e_invoice": 0,
+                "restrict_cancel_if_e_invoice_final": 0,
             },
         )
         cls.e_invoice_test_data = frappe._dict(
@@ -557,6 +559,37 @@ class TestEInvoice(IntegrationTestCase):
             cancelled_doc,
         )
         self.assertDocumentEqual({"ewaybill": ""}, cancelled_doc)
+
+    @responses.activate
+    def test_auto_cancel_e_invoice(self):
+        """Test for auto cancel e-Invoice on cancellation of Sales Invoice"""
+        frappe.db.set_single_value("GST Settings", "auto_cancel_e_invoice", 1)
+        test_data = self.e_invoice_test_data.get("service_item")
+        si = create_sales_invoice(
+            **test_data.get("kwargs"),
+            is_in_state=True,
+        )
+        test_data.get("response_data").get("result").update(
+            {"AckDt": str(add_to_date(days=-2))}
+        )
+        # Mock response for generating irnFser
+        self._mock_e_invoice_response(data=test_data)
+
+        generate_e_invoice(si.name)
+
+        si_doc = load_doc("Sales Invoice", si.name, "cancel")
+
+        # Assert e-Invoice is not cancellable
+        self.assertRaisesRegex(
+            frappe.exceptions.ValidationError,
+            re.compile(r"^(e-Invoice can only be cancelled.*)$"),
+            validate_if_e_invoice_can_be_cancelled,
+            si_doc,
+        )
+
+        # document sholud be cancelled without any error if e-Invoice is not cancellable
+        si_doc.cancel()
+        frappe.db.set_single_value("GST Settings", "auto_cancel_e_invoice", 0)
 
     @responses.activate
     def test_mark_e_invoice_as_cancelled(self):


### PR DESCRIPTION
Issue: The date comparison condition was incorrect.

Frappe Support Issue: https://support.frappe.io/app/hd-ticket/36377

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the accuracy of the cancellation window for e-Invoice and e-Waybill by updating the logic for determining expiry.
- **Tests**
	- Added a new test to verify that e-Invoice cannot be cancelled after the allowed window, ensuring correct behavior when automatic cancellation is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->