### PR TITLE
fix: otp handling in e-invoice for taxpayer API

### DIFF
--- a/india_compliance/gst_india/client_scripts/e_invoice_actions.js
+++ b/india_compliance/gst_india/client_scripts/e_invoice_actions.js
@@ -49,12 +49,11 @@ frappe.ui.form.on("Sales Invoice", {
                     frappe.call({
                         method: "india_compliance.gst_india.utils.e_invoice.generate_e_invoice",
                         args: { docname: frm.doc.name, force: true },
-                        callback: async (r) => {
-                            if (r.message?.error_type == "otp_requested") {
-                                await india_compliance.authenticate_otp(frm.doc.company_gstin);
-                                await frappe.call({
+                        callback: async r => {
+                            if (r.message?.error_code == "2283") {
+                                await taxpayer_api.call({
                                     method: "india_compliance.gst_india.utils.e_invoice.handle_duplicate_irn_error",
-                                    args: r.message
+                                    args: r.message,
                                 });
                             }
                             frm.refresh();

--- a/india_compliance/gst_india/utils/e_invoice.py
+++ b/india_compliance/gst_india/utils/e_invoice.py
@@ -16,6 +16,7 @@ from frappe.utils import (
 
 from india_compliance.exceptions import GSPServerError
 from india_compliance.gst_india.api_classes.e_invoice import EInvoiceAPI
+from india_compliance.gst_india.api_classes.taxpayer_base import otp_handler
 from india_compliance.gst_india.api_classes.taxpayer_e_invoice import (
     EInvoiceAPI as TaxpayerEInvoiceAPI,
 )
@@ -193,12 +194,14 @@ def generate_e_invoice(docname, throw=True, force=False):
 
 
 @frappe.whitelist()
+@otp_handler
 def handle_duplicate_irn_error(
     irn_data,
     current_gstin,
     current_invoice_amount,
     doc=None,
     docname=None,
+    taxpayer_api=False,
 ):
     """
     Handle Duplicate IRN errors by fetching the IRN details and comparing with the current invoice.
@@ -214,8 +217,15 @@ def handle_duplicate_irn_error(
         current_invoice_amount = flt(current_invoice_amount)
 
     doc = doc or load_doc("Sales Invoice", docname, "submit")
-    api = EInvoiceAPI(doc)
-    response = api.get_e_invoice_by_irn(irn_data.Irn)
+
+    if taxpayer_api:
+        api = TaxpayerEInvoiceAPI(doc)
+        response = api.get_irn_details(irn_data.Irn)
+        response = frappe._dict(response.data or response.error)
+
+    else:
+        api = EInvoiceAPI(doc)
+        response = api.get_e_invoice_by_irn(irn_data.Irn)
 
     # Handle error 2283:
     # IRN details cannot be provided as it is generated more than 2 days ago
@@ -223,21 +233,17 @@ def handle_duplicate_irn_error(
         response.error_code == "2283"
         and api.settings.fetch_e_invoice_details_from_gst_portal
     ):
-        response = TaxpayerEInvoiceAPI(doc).get_irn_details(irn_data.Irn)
+        response.update(
+            {
+                "irn_data": irn_data,
+                "current_gstin": current_gstin,
+                "current_invoice_amount": current_invoice_amount,
+                "docname": doc.name,
+                "taxpayer_api": True,
+            }
+        )
 
-        if response.error_type == "otp_requested":
-            response.update(
-                {
-                    "irn_data": irn_data,
-                    "current_gstin": current_gstin,
-                    "current_invoice_amount": current_invoice_amount,
-                    "docname": doc.name,
-                }
-            )
-
-            return response
-
-        response = frappe._dict(response.data or response.error)
+        return response
 
     if signed_data := response.SignedInvoice:
         verify_e_invoice_details(current_gstin, current_invoice_amount, signed_data)


### PR DESCRIPTION
Use otp_handler and the taxpayer_api call for handling

Frappe Support Issue: https://support.frappe.io/app/hd-ticket/36024

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of duplicate IRN errors on Sales Invoice by updating the logic for error code 2283, ensuring more reliable error resolution and response messaging.
- **New Features**
  - Enhanced support for alternate API methods when resolving IRN-related errors, providing better handling for cases where IRN details are unavailable after two days.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->