### PR TITLE
fix: Validate GST HSN Code for JSON Upload/Download

### DIFF
--- a/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_export.py
+++ b/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_export.py
@@ -2077,7 +2077,11 @@ def get_gstr_1_json(
                 if row.get(GSTR1_DataField.HSN_CODE.value):
                     continue
 
-                frappe.throw(_("GST HSN Code is Mandatory."))
+                frappe.throw(
+                    _(
+                        "GST HSN Code is missing in one or more invoices. Please ensure all invoices include the HSN Code, as it is Mandatory for filing GSTR-1."
+                    )
+                )
 
             continue
 

--- a/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_export.py
+++ b/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_export.py
@@ -47,7 +47,6 @@ CATEGORIES_WITH_ITEMS = {
 
 
 class DataProcessor:
-
     # transform input data to required format
     FIELD_TRANSFORMATIONS = {}
 
@@ -2068,10 +2067,18 @@ def get_gstr_1_json(
     for subcategory, subcategory_data in data.items():
         if subcategory in {
             GSTR1_SubCategory.NIL_EXEMPT.value,
-            GSTR1_SubCategory.HSN.value,
             GSTR1_SubCategory.DOC_ISSUE.value,
             *QUARTERLY_KEYS,
         }:
+            continue
+
+        if subcategory == GSTR1_SubCategory.HSN.value:
+            for row in subcategory_data.values():
+                if row.get(GSTR1_DataField.HSN_CODE.value):
+                    continue
+
+                frappe.throw(_("GST HSN Code is Mandatory."))
+
             continue
 
         discard_invoices = []

--- a/india_compliance/gst_india/report/hsn_wise_summary_of_outward_supplies/hsn_wise_summary_of_outward_supplies.py
+++ b/india_compliance/gst_india/report/hsn_wise_summary_of_outward_supplies/hsn_wise_summary_of_outward_supplies.py
@@ -210,7 +210,11 @@ def get_hsn_wise_json_data(report_data):
             continue
 
         if not hsn.get("hsn_code"):
-            frappe.throw(_("GST HSN Code is Mandatory."))
+            frappe.throw(
+                _(
+                    "GST HSN Code is missing in one or more invoices. Please ensure all invoices include the HSN Code, as it is Mandatory for filing GSTR-1."
+                )
+            )
 
         row = {
             "num": count,

--- a/india_compliance/gst_india/report/hsn_wise_summary_of_outward_supplies/hsn_wise_summary_of_outward_supplies.py
+++ b/india_compliance/gst_india/report/hsn_wise_summary_of_outward_supplies/hsn_wise_summary_of_outward_supplies.py
@@ -208,6 +208,10 @@ def get_hsn_wise_json_data(report_data):
     for hsn in report_data:
         if hsn.get("hsn_code") == "Total":
             continue
+
+        if not hsn.get("hsn_code"):
+            frappe.throw(_("GST HSN Code is Mandatory."))
+
         row = {
             "num": count,
             "hsn_sc": hsn.get("hsn_code"),

--- a/india_compliance/gst_india/report/hsn_wise_summary_of_outward_supplies/test_hsn_wise_summary_of_outward_supplies.py
+++ b/india_compliance/gst_india/report/hsn_wise_summary_of_outward_supplies/test_hsn_wise_summary_of_outward_supplies.py
@@ -1,12 +1,16 @@
 # Copyright (c) 2021, Frappe Technologies Pvt. Ltd. and contributors
 # For license information, please see license.txt
 
+import re
 
 import frappe
-from frappe.tests import IntegrationTestCase
+from frappe.tests import IntegrationTestCase, change_settings
 
 from india_compliance.gst_india.report.hsn_wise_summary_of_outward_supplies.hsn_wise_summary_of_outward_supplies import (
     execute as run_report,
+)
+from india_compliance.gst_india.report.hsn_wise_summary_of_outward_supplies.hsn_wise_summary_of_outward_supplies import (
+    get_hsn_wise_json_data,
 )
 from india_compliance.gst_india.utils.tests import append_item, create_sales_invoice
 
@@ -17,12 +21,16 @@ class TestHSNWiseSummaryReport(IntegrationTestCase):
         frappe.db.rollback()
 
     def test_hsn_summary_for_invoice_with_duplicate_items(self):
-        si_one = create_sales_invoice(do_not_save=1, is_in_state=True)
+        si_one = create_sales_invoice(
+            do_not_save=1, is_in_state=True, gst_hsn_code="61149090"
+        )
         append_item(si_one, frappe._dict(gst_hsn_code="61149090", uom="Box"))
         append_item(si_one, frappe._dict(gst_hsn_code="61149090", uom="Litre"))
         si_one.submit()
 
-        si_two = create_sales_invoice(do_not_save=1, is_in_state=True)
+        si_two = create_sales_invoice(
+            do_not_save=1, is_in_state=True, gst_hsn_code="61149090"
+        )
         append_item(si_two, frappe._dict(gst_hsn_code="61149090", uom="Box"))
         append_item(si_two, frappe._dict(gst_hsn_code="61149090", uom="Litre"))
 
@@ -46,3 +54,28 @@ class TestHSNWiseSummaryReport(IntegrationTestCase):
         self.assertEqual(hsn_row["quantity"], 2.0)
         self.assertEqual(hsn_row["total_taxable_value"], 200)
         self.assertEqual(hsn_row["document_value"], 236)  # 2 * 1.18 * 100
+
+    @change_settings("GST Settings", {"validate_hsn_code": 0})
+    def test_json_upload_for_missing_hsn_code(self):
+        frappe.db.set_value(
+            "Item", "_Test Trading Goods 1", "gst_hsn_code", ""
+        )  # Avoid fetching of hsn code from item
+        si = create_sales_invoice()
+
+        columns, data = run_report(
+            frappe._dict(
+                {
+                    "company": "_Test Indian Registered Company",
+                    "company_gstin": si.company_gstin,
+                    "from_date": si.posting_date,
+                    "to_date": si.posting_date,
+                }
+            )
+        )
+
+        self.assertRaisesRegex(
+            frappe.exceptions.ValidationError,
+            re.compile(r"^(GST HSN Code is Mandatory.*)"),
+            get_hsn_wise_json_data,
+            report_data=data,
+        )

--- a/india_compliance/gst_india/report/hsn_wise_summary_of_outward_supplies/test_hsn_wise_summary_of_outward_supplies.py
+++ b/india_compliance/gst_india/report/hsn_wise_summary_of_outward_supplies/test_hsn_wise_summary_of_outward_supplies.py
@@ -75,7 +75,7 @@ class TestHSNWiseSummaryReport(IntegrationTestCase):
 
         self.assertRaisesRegex(
             frappe.exceptions.ValidationError,
-            re.compile(r"^(GST HSN Code is Mandatory.*)"),
+            re.compile(r"^(GST HSN Code is missing in one or more invoices*)"),
             get_hsn_wise_json_data,
             report_data=data,
         )


### PR DESCRIPTION
closes: https://github.com/resilient-tech/india-compliance/issues/3289

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Added mandatory validation to ensure HSN codes are present in GST reports and exports. An error is now raised if any HSN entry is missing the required code.
- **Tests**
	- Introduced a new test case to verify that missing HSN codes trigger the appropriate validation error in reports. Existing tests were updated for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->