### PR TITLE
fix: include only Taxable and Zero-Rated supplies for taxable value in Purchase reco tool

### DIFF
--- a/india_compliance/gst_india/constants/__init__.py
+++ b/india_compliance/gst_india/constants/__init__.py
@@ -60,6 +60,9 @@ EXPORT_TYPES = (
     "WP",  # With Payment of Tax [1]
 )
 
+TAXABLE_GST_TREATMENTS = ("Taxable", "Zero-Rated")
+
+
 STATE_NUMBERS = {
     "Andaman and Nicobar Islands": "35",
     "Andhra Pradesh": "37",

--- a/india_compliance/gst_india/data/test_purchase_reconciliation_tool.json
+++ b/india_compliance/gst_india/data/test_purchase_reconciliation_tool.json
@@ -222,6 +222,60 @@
                     "cost_center": ""
                 }
             }
+        ],
+        "TEST_TAXABLE_VALUE_DIFFERENCE_WITH_NIL_RATED": [
+            {
+                "PURCHASE_INVOICE": {
+                    "bill_no": "BILL-23-00050",
+                    "items" : [
+                        {
+                            "item_code": "_Test Nil Rated Item",
+                            "rate": 1000,
+                            "qty": 10,
+                            "gst_trreatment": "Nil-Rated"
+                        },
+                        {
+                            "item_code": "_Test Trading Goods 1",
+                            "rate": 1000,
+                            "qty": 10,
+                            "gst_trreatment": "Taxable"
+                        }
+                    ]
+                },
+                "INWARD_SUPPLY": {
+                    "bill_no": "BILL-23-00050",
+                    "items": [
+                        {
+                            "taxable_value": 10000,
+                            "rate": 18,
+                            "sgst": 900,
+                            "cgst": 900
+                        }
+                    ],
+                    "document_value": 21800
+                },
+                "RECONCILED_DATA": {
+                    "action": "No Action",
+                    "bill_date": "2023-12-11",
+                    "bill_no": "BILL-23-00050",
+                    "classification": "B2B",
+                    "differences": "",
+                    "inward_supply_company_gstin": "24AAQCA8719H1ZC",
+                    "inward_supply_name": "",
+                    "is_reverse_charge": 0,
+                    "is_supplier_return_filed": 0,
+                    "match_status": "Exact Match",
+                    "purchase_company_gstin": "24AAQCA8719H1ZC",
+                    "purchase_doctype": "Purchase Invoice",
+                    "purchase_invoice_name": "",
+                    "supplier_gstin": "24AABCR6898M1ZN",
+                    "supplier_name": "_Test Registered Supplier",
+                    "tax_difference": 0.0,
+                    "taxable_value_difference": 0.0,
+                    "project": "",
+                    "cost_center": ""
+                }
+            }
         ]
     }
 }

--- a/india_compliance/gst_india/data/test_purchase_reconciliation_tool.json
+++ b/india_compliance/gst_india/data/test_purchase_reconciliation_tool.json
@@ -332,13 +332,13 @@
                             "item_code": "_Test Nil Rated Item",
                             "rate": 1000,
                             "qty": 10,
-                            "gst_trreatment": "Nil-Rated"
+                            "gst_treatment": "Nil-Rated"
                         },
                         {
                             "item_code": "_Test Trading Goods 1",
                             "rate": 1000,
                             "qty": 10,
-                            "gst_trreatment": "Taxable"
+                            "gst_treatment": "Taxable"
                         }
                     ]
                 },

--- a/india_compliance/gst_india/doctype/gst_settings/gst_settings.py
+++ b/india_compliance/gst_india/doctype/gst_settings/gst_settings.py
@@ -7,7 +7,11 @@ from frappe.model.document import Document
 from frappe.query_builder.functions import IfNull
 from frappe.utils import add_to_date, getdate
 
-from india_compliance.gst_india.constants import GST_ACCOUNT_FIELDS, GST_PARTY_TYPES
+from india_compliance.gst_india.constants import (
+    GST_ACCOUNT_FIELDS,
+    GST_PARTY_TYPES,
+    TAXABLE_GST_TREATMENTS,
+)
 from india_compliance.gst_india.constants.custom_fields import (
     E_INVOICE_FIELDS,
     E_WAYBILL_FIELDS,
@@ -517,7 +521,7 @@ def update_pending_status(e_invoice_applicability_date, company=None):
             != IfNull(sales_invoice.company_gstin, "")
         )
         .where(IfNull(sales_invoice.irn, "") == "")
-        .where(sales_invoice_item.gst_treatment.isin(("Taxable", "Zero-Rated")))
+        .where(sales_invoice_item.gst_treatment.isin(TAXABLE_GST_TREATMENTS))
         .where(
             (IfNull(sales_invoice.place_of_supply, "") == "96-Other Countries")
             | (IfNull(sales_invoice.billing_address_gstin, "") != "")

--- a/india_compliance/gst_india/doctype/purchase_reconciliation_tool/__init__.py
+++ b/india_compliance/gst_india/doctype/purchase_reconciliation_tool/__init__.py
@@ -15,7 +15,7 @@ from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import (
     get_accounting_dimensions,
 )
 
-from india_compliance.gst_india.constants import GST_TAX_TYPES
+from india_compliance.gst_india.constants import GST_TAX_TYPES, TAXABLE_GST_TREATMENTS
 from india_compliance.gst_india.utils import get_gstin_list, get_party_for_gstin
 from india_compliance.gst_india.utils.gstr_2 import IMPORT_CATEGORY, ReturnType
 
@@ -422,6 +422,7 @@ class PurchaseInvoice:
             .where(IfNull(self.PI.reconciliation_status, "") != "Not Applicable")
             .where(self.PI.is_opening == "No")
             .where(self.PI_ITEM.parenttype == "Purchase Invoice")
+            .where(self.PI_ITEM.gst_treatment.isin(TAXABLE_GST_TREATMENTS))
             .groupby(self.PI.name)
             .select(
                 *fields,
@@ -572,6 +573,7 @@ class BillOfEntry:
             .where(self.BOE.docstatus == 1)
             .where(IfNull(self.BOE.reconciliation_status, "") != "Not Applicable")
             .where(self.BOE_ITEM.parenttype == "Bill of Entry")
+            .where(self.BOE_ITEM.gst_treatment.isin(TAXABLE_GST_TREATMENTS))
             .groupby(self.BOE.name)
             .select(*fields, ConstantColumn("Bill of Entry").as_("doctype"))
         )

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -16,6 +16,7 @@ from india_compliance.gst_india.constants import (
     STATE_NUMBERS,
     SUBCONTRACTING_DOCTYPES,
     TAX_TYPES,
+    TAXABLE_GST_TREATMENTS,
 )
 from india_compliance.gst_india.constants.custom_fields import E_WAYBILL_INV_FIELDS
 from india_compliance.gst_india.doctype.gst_settings.gst_settings import (
@@ -1756,10 +1757,10 @@ def validate_item_tax_template(doc):
 
         total_taxes = abs(item.igst_amount + item.cgst_amount + item.sgst_amount)
 
-        if total_taxes and item.gst_treatment in ("Nil-Rated", "Exempted", "Non-GST"):
+        if total_taxes and item.gst_treatment not in TAXABLE_GST_TREATMENTS:
             non_taxable_items_with_tax.append(item.idx)
 
-        if not total_taxes and item.gst_treatment in ("Taxable", "Zero-Rated"):
+        if not total_taxes and item.gst_treatment in TAXABLE_GST_TREATMENTS:
             taxable_items_with_no_tax.append(item.idx)
 
     # Case: Zero Tax template with taxes or missing GST Accounts

--- a/india_compliance/gst_india/utils/e_invoice.py
+++ b/india_compliance/gst_india/utils/e_invoice.py
@@ -24,6 +24,7 @@ from india_compliance.gst_india.constants import (
     EXPORT_TYPES,
     GST_CATEGORIES,
     PORT_CODES,
+    TAXABLE_GST_TREATMENTS,
 )
 from india_compliance.gst_india.constants.e_invoice import (
     CANCEL_REASON_CODES,
@@ -520,7 +521,7 @@ def validate_taxable_item(doc, throw=True):
 
     """
     # Check if there is at least one taxable item in the document
-    if any(item.gst_treatment in ("Taxable", "Zero-Rated") for item in doc.items):
+    if any(item.gst_treatment in TAXABLE_GST_TREATMENTS for item in doc.items):
         return True
 
     if not throw:
@@ -606,7 +607,7 @@ class EInvoiceData(GSTTransactionData):
         self.item_list = []
 
         for item_details in self.get_all_item_details():
-            if item_details.get("gst_treatment") not in ("Taxable", "Zero-Rated"):
+            if item_details.get("gst_treatment") not in TAXABLE_GST_TREATMENTS:
                 continue
 
             self.item_list.append(self.get_item_data(item_details))

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -23,6 +23,7 @@ from india_compliance.gst_india.constants import (
     GST_TAX_TYPES,
     SALES_DOCTYPES,
     STATE_NUMBERS,
+    TAXABLE_GST_TREATMENTS,
 )
 from india_compliance.gst_india.constants.e_waybill import (
     ADDRESS_FIELDS,
@@ -1540,8 +1541,7 @@ class EWaybillData(GSTTransactionData):
             doc.doctype in ("Sales Invoice", "Purchase Invoice")
             and not doc.is_return
             and all(
-                item.gst_treatment in ("Nil-Rated", "Exempted", "Non-GST")
-                for item in doc.items
+                item.gst_treatment not in TAXABLE_GST_TREATMENTS for item in doc.items
             )
         ):
             self.transaction_details.update(document_type="BIL")

--- a/india_compliance/gst_india/utils/transaction_data.py
+++ b/india_compliance/gst_india/utils/transaction_data.py
@@ -9,6 +9,7 @@ from india_compliance.gst_india.constants import (
     GST_REFUND_TAX_TYPES,
     GST_TAX_RATES,
     GST_TAX_TYPES,
+    TAXABLE_GST_TREATMENTS,
 )
 from india_compliance.gst_india.constants.e_waybill import (
     TRANSPORT_MODES,
@@ -78,7 +79,7 @@ class GSTTransactionData:
         for row in self.doc.items:
             total += row.taxable_value
 
-            if row.gst_treatment in ("Taxable", "Zero-Rated"):
+            if row.gst_treatment in TAXABLE_GST_TREATMENTS:
                 total_taxable_value += row.taxable_value
 
             if self.is_purchase_rcm:


### PR DESCRIPTION
Frappe Support Issue: https://support.frappe.io/app/hd-ticket/36480

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a standardized set of taxable GST treatments for improved consistency across GST-related operations.
- **Bug Fixes**
  - Enhanced GST validation and reconciliation logic to use a unified definition of taxable GST treatments, reducing discrepancies in tax handling.
- **Tests**
  - Added a new test case to verify reconciliation scenarios involving nil-rated and taxable GST treatments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->