### PR TITLE
fix: Skip transporter info if e-way bill is already generated

### DIFF
--- a/india_compliance/gst_india/utils/e_invoice.py
+++ b/india_compliance/gst_india/utils/e_invoice.py
@@ -762,6 +762,8 @@ class EInvoiceData(GSTTransactionData):
             self.transaction_details.grand_total < self.settings.e_waybill_threshold
             # e-waybill auto-generation is disabled by user
             or not self.settings.generate_e_waybill_with_e_invoice
+            # e-waybill is already generated
+            or self.doc.ewaybill
         ):
             return
 


### PR DESCRIPTION
Support ticket: [Support Ticket  - 36400](https://support.frappe.io/helpdesk/tickets/36400)

If transporter details are provided, an e-way bill is generated.
So, added a check if the ewaybill is already generated, then don't pass the transporter details.

<img width="793" alt="Screenshot 2025-04-19 at 5 22 18 PM" src="https://github.com/user-attachments/assets/d34d403e-8ec7-44c2-9066-690395374832" />
