### PR TITLE
fix: insert account with ignoring mandatory fields

### DIFF
--- a/india_compliance/gst_india/overrides/company.py
+++ b/india_compliance/gst_india/overrides/company.py
@@ -241,7 +241,7 @@ def create_default_company_account(
     )
     account.flags.ignore_permissions = True
     account.flags.ignore_root_company_validation = True
-    account.insert(ignore_if_duplicate=True)
+    account.insert(ignore_if_duplicate=True, ignore_mandatory=True)
 
     if default_fieldname and not frappe.db.get_value(
         "Company", company, default_fieldname


### PR DESCRIPTION
Sometimes users have added some custom mandatory fields in the Account Doctype, which causes error on installation or migrate.

Frappe Support Issue: https://support.frappe.io/app/hd-ticket/36849

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the process for creating default company accounts to prevent errors related to missing mandatory fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->