### PR TITLE
fix: correct pending_boe_qty on cancellation of BOE

### DIFF
--- a/india_compliance/gst_india/doctype/bill_of_entry/bill_of_entry.py
+++ b/india_compliance/gst_india/doctype/bill_of_entry/bill_of_entry.py
@@ -7,7 +7,7 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 from frappe.model.mapper import get_mapped_doc
-from frappe.query_builder.functions import Sum
+from frappe.query_builder.functions import IfNull, Sum
 from frappe.utils import today
 import erpnext
 from erpnext.accounts.general_ledger import make_gl_entries, make_reverse_gl_entries
@@ -446,11 +446,11 @@ class BillofEntry(Document):
 
         (
             frappe.qb.update(pi_item)
-            .join(submitted_boe_qty)
+            .left_join(submitted_boe_qty)
             .on(pi_item.name == submitted_boe_qty.pi_detail)
             .set(
                 pi_item.pending_boe_qty,
-                pi_item.qty - submitted_boe_qty.qty,
+                pi_item.qty - IfNull(submitted_boe_qty.qty, 0),
             )
             .where(pi_item.name.isin(pi_item_names))
             .run()

--- a/india_compliance/gst_india/doctype/bill_of_entry/test_bill_of_entry.py
+++ b/india_compliance/gst_india/doctype/bill_of_entry/test_bill_of_entry.py
@@ -242,3 +242,66 @@ class TestBillofEntry(IntegrationTestCase):
         )
 
         boe.save()
+
+    def test_pending_boe_qty(self):
+        pi = create_purchase_invoice(supplier="_Test Foreign Supplier", update_stock=1)
+
+        self.assertDocumentEqual(
+            {
+                "pending_boe_qty": 1,
+            },
+            pi.items[0],
+        )
+
+        # Create BOE
+        boe = make_bill_of_entry(pi.name)
+        boe.bill_of_entry_no = "123"
+        boe.bill_of_entry_date = today()
+        boe.save()
+        boe.submit()
+
+        pi.reload()
+        self.assertDocumentEqual(
+            {
+                "pending_boe_qty": 0,
+            },
+            pi.items[0],
+        )
+
+        boe.cancel()
+        pi.reload()
+
+        self.assertDocumentEqual(
+            {
+                "pending_boe_qty": 1,
+            },
+            pi.items[0],
+        )
+
+        # with partial boe
+        pi = create_purchase_invoice(
+            supplier="_Test Foreign Supplier", update_stock=1, qty=2
+        )
+        boe = make_bill_of_entry(pi.name)
+        boe.bill_of_entry_no = "123"
+        boe.bill_of_entry_date = today()
+        boe.items[0].qty = 1
+        boe.save()
+        boe.submit()
+
+        pi.reload()
+        self.assertDocumentEqual(
+            {
+                "pending_boe_qty": 1,
+            },
+            pi.items[0],
+        )
+
+        boe.cancel()
+        pi.reload()
+        self.assertDocumentEqual(
+            {
+                "pending_boe_qty": 2,
+            },
+            pi.items[0],
+        )

--- a/india_compliance/patches.txt
+++ b/india_compliance/patches.txt
@@ -73,5 +73,5 @@ india_compliance.patches.v15.migrate_boe_taxes_to_ic_taxes
 india_compliance.patches.v15.set_download_document_for_2a_2b
 india_compliance.patches.v15.multiple_pi_in_boe
 india_compliance.patches.v15.update_supplier_filing_status
-india_compliance.patches.v14.set_pending_boe_qty
+india_compliance.patches.v14.set_pending_boe_qty #1
 india_compliance.patches.v15.remove_itc_amount_custom_fields

--- a/india_compliance/patches/v14/set_pending_boe_qty.py
+++ b/india_compliance/patches/v14/set_pending_boe_qty.py
@@ -1,20 +1,30 @@
 import frappe
-from frappe.query_builder import Case
+from frappe.query_builder.functions import IfNull, Sum
 
 
 def execute():
+    pi = frappe.qb.DocType("Purchase Invoice")
     pi_item = frappe.qb.DocType("Purchase Invoice Item")
     boe_item = frappe.qb.DocType("Bill of Entry Item")
 
+    submitted_boe_qty = (
+        frappe.qb.from_(boe_item)
+        .select(boe_item.pi_detail, Sum(boe_item.qty).as_("qty"))
+        .where(boe_item.docstatus == 1)
+        .groupby(boe_item.pi_detail)
+    )
+
     (
         frappe.qb.update(pi_item)
-        .left_join(boe_item)
-        .on(boe_item.pi_detail == pi_item.name)
+        .join(pi)
+        .on(pi_item.parent == pi.name)
+        .left_join(submitted_boe_qty)
+        .on(pi_item.name == submitted_boe_qty.pi_detail)
         .set(
             pi_item.pending_boe_qty,
-            Case()
-            .when(((boe_item.name.isnotnull()) & (boe_item.docstatus == 1)), 0)
-            .else_(pi_item.qty),
+            pi_item.qty - IfNull(submitted_boe_qty.qty, 0),
         )
+        .where(pi.docstatus == 1)
+        .where(pi.gst_category == "Overseas")
         .run()
     )


### PR DESCRIPTION
Issue: On cancellation of the Bill of Entry,pending_boe_qty in the Purchase Invoice was not updating because of inner join.
There were no submitted documents, so no data was returned in sub subquery.


Closes: #3322

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the calculation of pending Bill of Entry (BOE) quantities on purchase invoice items, ensuring accurate updates even when no submitted BOE exists.
- **Tests**
	- Added tests to verify correct updates to pending BOE quantities after creation, submission, and cancellation of BOE documents, including partial quantity scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->