### PR TITLE
fix: prefer tradename for GST Registrations of HUF

### DIFF
--- a/india_compliance/gst_india/utils/gstin_info.py
+++ b/india_compliance/gst_india/utils/gstin_info.py
@@ -78,7 +78,9 @@ def _get_gstin_info(gstin, *, doc=None, throw_error=True):
             return frappe._dict()
 
     business_name = (
-        response.tradeNam if response.ctb == "Proprietorship" else response.lgnm
+        response.tradeNam
+        if response.ctb in ["Proprietorship", "Hindu Undivided Family"]
+        else response.lgnm
     )
 
     gstin_info = frappe._dict(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved business name selection logic for GSTIN information to better handle "Proprietorship" and "Hindu Undivided Family" business types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->