### PR TITLE
fix: proper filtering of `PI` for `Bill Of Entry`

### DIFF
--- a/india_compliance/gst_india/doctype/bill_of_entry/bill_of_entry.js
+++ b/india_compliance/gst_india/doctype/bill_of_entry/bill_of_entry.js
@@ -97,10 +97,18 @@ frappe.ui.form.on("Bill of Entry", {
             get_query() {
                 return {
                     query: "india_compliance.gst_india.doctype.bill_of_entry.bill_of_entry.fetch_pending_boe_invoices",
-                }
+                };
             },
             add_filters_group: 1,
             action: function (selections, args) {
+                if (selections.length === 0) {
+                    frappe.msgprint(
+                        __("Please select at least one Purchase Invoice"),
+                        __("No Selection")
+                    );
+                    return;
+                }
+
                 frm.call("get_items_from_purchase_invoice", {
                     purchase_invoices: selections,
                 }).then(d.dialog.hide());

--- a/india_compliance/gst_india/doctype/bill_of_entry/bill_of_entry.py
+++ b/india_compliance/gst_india/doctype/bill_of_entry/bill_of_entry.py
@@ -807,7 +807,7 @@ def fetch_pending_boe_invoices(doctype, txt, searchfield, start, page_len, filte
     if filters.name and filters.name[1] is None:
         filters.name = ["!=", ""]
 
-    data = frappe.get_all(
+    return frappe.get_all(
         "Purchase Invoice",
         filters={
             **filters,
@@ -820,5 +820,3 @@ def fetch_pending_boe_invoices(doctype, txt, searchfield, start, page_len, filte
         limit_page_length=page_len,
         distinct=True,
     )
-
-    return data

--- a/india_compliance/gst_india/doctype/bill_of_entry/bill_of_entry.py
+++ b/india_compliance/gst_india/doctype/bill_of_entry/bill_of_entry.py
@@ -308,8 +308,7 @@ class BillofEntry(Document):
 
     def get_gl_entries(self):
         # company_currency is required by get_gl_dict
-        # nosemgrep
-        self.company_currency = erpnext.get_company_currency(self.company)
+        self.company_currency = erpnext.get_company_currency(self.company)  # nosemgrep
 
         gl_entries = []
         remarks = "No Remarks"

--- a/india_compliance/gst_india/doctype/bill_of_entry/bill_of_entry.py
+++ b/india_compliance/gst_india/doctype/bill_of_entry/bill_of_entry.py
@@ -393,6 +393,10 @@ class BillofEntry(Document):
 
     @frappe.whitelist()
     def get_items_from_purchase_invoice(self, purchase_invoices):
+        if not purchase_invoices:
+            frappe.msgprint(_("No Purchase Invoices selected"))
+            return
+
         frappe.has_permission("Bill Of Entry", "write")
         frappe.has_permission("Purchase Invoice", "read")
 

--- a/india_compliance/gst_india/doctype/bill_of_entry/bill_of_entry.py
+++ b/india_compliance/gst_india/doctype/bill_of_entry/bill_of_entry.py
@@ -791,23 +791,30 @@ def get_pi_items(purchase_invoices):
 
 
 @frappe.whitelist()
-def fetch_pending_boe_invoices(*args, **kwargs):
+def fetch_pending_boe_invoices(doctype, txt, searchfield, start, page_len, filters):
     frappe.has_permission("Purchase Invoice", "read")
 
-    filters = next((arg for arg in args if isinstance(arg, dict)), {})
-    return frappe.get_all(
+    filters = frappe._dict(filters)
+
+    if txt and not filters.get("name"):
+        filters.name = ["like", f"%{txt}%"]
+
+    # TODO: fix required in frappe
+    if filters.name and filters.name[1] is None:
+        filters.name = ["!=", ""]
+
+    data = frappe.get_all(
         "Purchase Invoice",
         filters={
+            **filters,
             "docstatus": 1,
-            "company": filters.get("company"),
-            "company_gstin": filters.get("company_gstin"),
             "gst_category": "Overseas",
             "pending_boe_qty": [">", 0],
         },
-        fields=[
-            "name",
-            "company",
-            "company_gstin",
-        ],
+        fields=["name", "company", "company_gstin"],
+        limit_start=start,
+        limit_page_length=page_len,
         distinct=True,
     )
+
+    return data


### PR DESCRIPTION
# [Frappe Support - 38359](https://support.frappe.io/helpdesk/tickets/38359)

### Issue

1.  Filtering of **Purchase Invoice** was not working for getting Items in **Bill Of Entry**
2. If there is no selection of `PI` throws an error

<details>
<summary><h3>See Traceback for 2<sup>nd</sup> Issue</h3></summary>

```bash
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 116, in application
    response = frappe.api.handle(request)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/api/__init__.py", line 49, in handle
    data = endpoint(**arguments)
           ^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/api/v1.py", line 36, in handle_rpc_call
    return frappe.handler.handle()
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/handler.py", line 51, in handle
    data = execute_cmd(cmd)
           ^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/handler.py", line 84, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/__init__.py", line 1461, in call
    return fn(*args, **newargs)
           ^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/handler.py", line 300, in run_doc_method
    response = doc.run_method(method, **args)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 1127, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 1511, in composer
    return composed(self, method, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 1489, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
                              ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 1124, in fn
    return method_object(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/utils/typing_validations.py", line 32, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "apps/india_compliance/india_compliance/gst_india/doctype/bill_of_entry/bill_of_entry.py", line 402, in get_items_from_purchase_invoice
    item_to_add = get_pi_items(purchase_invoices)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/india_compliance/india_compliance/gst_india/doctype/bill_of_entry/bill_of_entry.py", line 789, in get_pi_items
    .run(as_dict=True)
     ^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/query_builder/utils.py", line 85, in execute_query
    result = frappe.db.sql(query, params, *args, **kwargs)  # nosemgrep
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/database/database.py", line 260, in sql
    self.execute_query(query, values)
  File "apps/frappe/frappe/database/database.py", line 355, in execute_query
    return self._cursor.execute(query, values)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "env/lib/python3.11/site-packages/pymysql/cursors.py", line 153, in execute
    result = self._query(query)
             ^^^^^^^^^^^^^^^^^^
  File "env/lib/python3.11/site-packages/pymysql/cursors.py", line 322, in _query
    conn.query(q)
  File "env/lib/python3.11/site-packages/pymysql/connections.py", line 563, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "env/lib/python3.11/site-packages/pymysql/connections.py", line 825, in _read_query_result
    result.read()
  File "env/lib/python3.11/site-packages/pymysql/connections.py", line 1199, in read
    first_packet = self.connection._read_packet()
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "env/lib/python3.11/site-packages/pymysql/connections.py", line 775, in _read_packet
    packet.raise_for_error()
  File "env/lib/python3.11/site-packages/pymysql/protocol.py", line 219, in raise_for_error
    err.raise_mysql_exception(self._data)
  File "env/lib/python3.11/site-packages/pymysql/err.py", line 150, in raise_mysql_exception
    raise errorclass(errno, errval)
pymysql.err.ProgrammingError: (1064, "You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near ') AND `pending_boe_qty`>0' at line 1")
```

</details> 


> [!IMPORTANT]
>  Backport to V-15

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Added a prompt to ensure users select at least one purchase invoice before fetching items in the Bill of Entry form.
	- Improved handling when no purchase invoices are selected, preventing unnecessary server calls.

- **Enhancements**
	- Enhanced search and filtering for pending purchase invoices with better input validation and pagination support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->