### PR TITLE
fix: set company_gstin value unconditionally in purchase reco

### DIFF
--- a/india_compliance/gst_india/doctype/bill_of_entry/bill_of_entry.json
+++ b/india_compliance/gst_india/doctype/bill_of_entry/bill_of_entry.json
@@ -267,7 +267,7 @@
    "depends_on": "eval: doc.docstatus == 1",
    "fieldname": "reconciliation_status",
    "fieldtype": "Select",
-   "label": "Reconciliation Status",
+   "label": "2A/2B Reconciliation Status",
    "no_copy": 1,
    "options": "\nNot Applicable\nReconciled\nUnreconciled\nIgnored",
    "print_hide": 1,

--- a/india_compliance/gst_india/doctype/gst_return_log/gst_return_log.py
+++ b/india_compliance/gst_india/doctype/gst_return_log/gst_return_log.py
@@ -261,14 +261,11 @@ def process_gstr_1_returns_info(company, gstin, e_filed_list):
 
 def process_gstr_3b_returns_info(company, gstin, e_filed_list):
     for info in e_filed_list:
-        if info["status"] != "Filed":
+        if info["rtntype"] != "GSTR3B" or info["status"] != "Filed":
             continue
 
         log_name = f"GSTR3B-{info['ret_prd']}-{gstin}"
-        if frappe.db.exists(
-            "GST Return Log",
-            log_name,
-        ):
+        if frappe.db.exists("GST Return Log", log_name):
             gstr3b_log = frappe.get_doc("GST Return Log", log_name)
         else:
             gstr3b_log = frappe.new_doc("GST Return Log")

--- a/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.js
+++ b/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.js
@@ -1408,7 +1408,25 @@ function apply_action(frm, action, selected_rows) {
                     "You can only apply <strong>Ignore</strong> action on rows where data is Missing in 2A/2B or Missing in PI. These rows will be ignored."
                 )
             );
+    } else if (action == "Pending") {
+        let warn = false;
+        affected_rows = affected_rows.filter(row => {
+            if (row.match_status == "Missing in 2A/2B") {
+                warn = true;
+                return false;
+            }
+            return true;
+        });
+
+        if (warn)
+            frappe.msgprint(
+                __(
+                    "You cannot apply <strong>Pending</strong> action on rows where data is Missing in 2A/2B. These rows will be ignored."
+                )
+            );
     }
+
+    if (!affected_rows.length) return;
 
     // update affected rows to backend and frontend
     frm._call("apply_action", { data: affected_rows, action });

--- a/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.js
+++ b/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.js
@@ -96,7 +96,7 @@ frappe.ui.form.on(DOCTYPE, {
         if (!frm.doc.company) return;
         const options = await india_compliance.set_gstin_options(frm, true);
 
-        if (!frm.doc.company_gstin) frm.set_value("company_gstin", options[0]);
+        frm.set_value("company_gstin", options[0]);
     },
 
     async company_gstin(frm) {

--- a/india_compliance/public/js/reconciliation_components/actions.js
+++ b/india_compliance/public/js/reconciliation_components/actions.js
@@ -111,11 +111,15 @@ Object.assign(reconciliation, {
                 }
             }
 
+            const is_return = row.classification.includes("CDNR") ? 1 : 0;
+            const multiplier = is_return ? -1 : 1;
+
             const values = {
                 company: company,
                 bill_no: doc.bill_no,
                 bill_date: doc.bill_date,
                 is_reverse_charge: ["Yes", 1].includes(doc.is_reverse_charge) ? 1 : 0,
+                is_return: is_return,
             };
 
             _set_value({
@@ -129,15 +133,15 @@ Object.assign(reconciliation, {
             frm._inward_supply = {
                 ...values,
                 name: row.inward_supply_name,
-                company_gstin: company_gstin,
+                company_gstin: doc.company_gstin,
                 inward_supply: row.inward_supply,
                 supplier_gstin: row.supplier_gstin,
                 place_of_supply: doc.place_of_supply,
-                cgst: doc.cgst,
-                sgst: doc.sgst,
-                igst: doc.igst,
-                cess: doc.cess,
-                taxable_value: doc.taxable_value,
+                cgst: doc.cgst * multiplier,
+                sgst: doc.sgst * multiplier,
+                igst: doc.igst * multiplier,
+                cess: doc.cess * multiplier,
+                taxable_value: doc.taxable_value * multiplier,
                 source_doc,
             };
         };


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved handling of purchase invoice returns by automatically marking return documents and adjusting tax and value amounts accordingly.
- **Bug Fixes**
  - Ensured the "company_gstin" field is always set when selecting a company.
  - Enhanced validation for the "Pending" action to prevent applying it to rows missing in 2A/2B, with a warning message shown when such rows are ignored.
- **Enhancements**
  - Updated the label for reconciliation status to "2A/2B Reconciliation Status" for clearer context.
  - Refined processing of GSTR3B returns to only include entries with the correct return type and filed status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->