### PR TITLE
fix: Handle validation error when saving tax withholding category in company.py

### DIFF
--- a/india_compliance/income_tax_india/overrides/company.py
+++ b/india_compliance/income_tax_india/overrides/company.py
@@ -89,7 +89,16 @@ def update_existing_tax_withholding_category(category_doc, category_name, compan
     # accounts table is mandatory
     doc.flags.ignore_mandatory = True
 
-    doc.save()
+    try:
+        doc.save()
+
+    except frappe.ValidationError:
+        frappe.log_error(
+            title="Error Updating Tax Withholding Category",
+            message=frappe.get_traceback(),
+            reference_doctype="Tax Withholding Category",
+            reference_name=category_name,
+        )
 
 
 def get_tds_category_details(accounts):


### PR DESCRIPTION
To avoid failures in patch,

Many site have errors in tax withholding categories causing patch to fail.

- Used group account.
- Overlapping periods

![Uploading image.png…]()

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced error handling during tax withholding category updates to ensure smoother saving and better logging of issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->