### PR TITLE
fix: use data.purchase_doctype  and remove unnecessary function call.

### DIFF
--- a/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.js
+++ b/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.js
@@ -813,7 +813,7 @@ class DetailViewDialog extends reconciliation.detail_view_dialog {
                 this.frm,
                 this.data.purchase_invoice_name,
                 this.data.inward_supply_name,
-                this.dialog.get_value("doctype"),
+                this.data.purchase_doctype,
                 true
             );
         } else if (action == "Create") {

--- a/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.py
+++ b/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.py
@@ -256,8 +256,6 @@ class PurchaseReconciliationTool(Document):
             purchase_invoice_name, inward_supply_name, link_doctype
         )
 
-        set_reconciliation_status(link_doctype, (purchase_invoice_name,), "Match Found")
-
         return self.ReconciledData.get(purchases, inward_supplies)
 
     @frappe.whitelist()


### PR DESCRIPTION
Closes: https://github.com/resilient-tech/india-compliance/issues/3400
GST Inward Supply being passed as linked doctype when a purchase invoice is matched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved accuracy when linking documents in the purchase reconciliation tool detail view.
	- Resolved an issue where the reconciliation status of linked purchase invoices was incorrectly updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->