### PR TITLE
feat: add rounding difference row in gstr-1 beta

### DIFF
--- a/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_beta.js
+++ b/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_beta.js
@@ -1758,7 +1758,11 @@ class BooksTab extends GSTR1_TabManager {
     refresh_data(data, summary_data, status) {
         super.refresh_data(data, summary_data, status);
 
-        if (!data?.rounding_difference) return;
+        // rounding_difference is array
+        if (!data?.rounding_difference || data.rounding_difference.length === 0) {
+            this.rounding_difference = null;
+            return;
+        }
 
         this.rounding_difference = data.rounding_difference[0];
         this.render_rounding_difference();

--- a/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_beta.js
+++ b/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_beta.js
@@ -1700,6 +1700,16 @@ class GSTR1_TabManager extends TabManager {
 }
 
 class BooksTab extends GSTR1_TabManager {
+    constructor(instance, wrapper, summary_view_callback, detailed_view_callback) {
+        super(instance, wrapper, summary_view_callback, detailed_view_callback);
+        const datatable = this.datatable.datatable;
+        const renderFooter = datatable.bodyRenderer.renderFooter;
+        datatable.bodyRenderer.renderFooter = () => {
+            renderFooter.call(datatable.bodyRenderer);
+            this.render_rounding_difference();
+        };
+    }
+
     CATEGORY_COLUMNS = {
         // [GSTR1_Categories.NIL_EXEMPT]: this.get_document_columns,
 
@@ -1743,6 +1753,79 @@ class BooksTab extends GSTR1_TabManager {
     filter_data(data, filters) {
         data = super.filter_data(data, filters);
         return data.filter(row => row.upload_status !== "Missing in Books");
+    }
+
+    refresh_data(data, summary_data, status) {
+        super.refresh_data(data, summary_data, status);
+
+        if (!data?.rounding_difference) return;
+
+        this.rounding_difference = data.rounding_difference[0];
+        this.render_rounding_difference();
+    }
+
+    refresh_view(view, category, filters) {
+        super.refresh_view(view, category, filters);
+        if (view === "Summary") {
+            this.render_rounding_difference();
+        }
+    }
+
+    // isTotalRow: 1 is redundant
+    // classname was showing undefined within it if isTotalRow was not given
+    render_rounding_difference() {
+        if (
+            !this.rounding_difference ||
+            Object.values(this.rounding_difference).every(v => !v)
+        )
+            return;
+
+        const rounding_difference = this.get_rounding_difference();
+
+        const datatable = this.datatable.datatable;
+
+        let html = datatable.rowmanager.getRowHTML(rounding_difference, {
+            rowIndex: "roundingDifference",
+            isTotalRow: 1,
+        });
+
+        datatable.footer.insertAdjacentHTML("beforeend", html);
+
+        $(`[data-row-index='roundingDifference']`).css({
+            "font-weight": "bold",
+        });
+    }
+
+    get_rounding_difference() {
+        const datatable = this.datatable.datatable;
+        const columns = datatable.getColumns();
+        const rounding_difference_row_template = columns.map(col => {
+            let content = null;
+            if (["_rowIndex", "_checkbox", "no_of_records"].includes(col.id)) {
+                content = "";
+            }
+            return {
+                content,
+                isTotalRow: 1,
+                colIndex: col.colIndex,
+                column: col,
+            };
+        });
+
+        const rounding_difference = rounding_difference_row_template.map(cell => {
+            if (cell.content === "") return cell;
+
+            if (cell.column.id === "description") {
+                cell.content = "Rounding Difference";
+            } else if (cell.column._fieldtype == "Float") {
+                const fieldname = cell.column.id;
+                cell.content = this.rounding_difference[fieldname] || 0.0;
+            }
+
+            return cell;
+        });
+
+        return rounding_difference;
     }
 
     // ACTIONS

--- a/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_beta.js
+++ b/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_beta.js
@@ -812,6 +812,81 @@ class GSTR1 {
         this.create_journal_entry_dialog(je_details);
     }
 
+    async show_round_off_jv_dialog() {
+        if (!frappe.perm.has_perm("Journal Entry")) return;
+
+        const { month_or_quarter, year, company, filing_preference } = this.frm.doc;
+        const { message: data } = await frappe.call({
+            method: "india_compliance.gst_india.doctype.gstr_1_beta.gstr_1_beta.get_accounts",
+            args: { month_or_quarter, year, company, filing_preference },
+        });
+
+        if (!data) return;
+
+        this.create_rounding_journal_entry(data.account, data.posting_date);
+    }
+
+    TAX_TO_ACCOUNT_MAP = {
+        total_igst_amount: "igst_account",
+        total_cgst_amount: "cgst_account",
+        total_sgst_amount: "sgst_account",
+        total_cess_amount: ["cess_account", "cess_non_advol_account"],
+    };
+
+    create_rounding_journal_entry(account, posting_date) {
+        let rounding_difference = this.data.books?.rounding_difference[0];
+        if (!rounding_difference) return;
+
+        const je_details = {
+            posting_date: posting_date,
+            data: [],
+        };
+
+        const get_account_name = account_field => {
+            if (!Array.isArray(account_field)) return account[account_field];
+            for (const acc of account_field) {
+                if (account[acc]) {
+                    return account[acc];
+                }
+            }
+            return null;
+        };
+
+        let total = 0;
+
+        for (const [tax_field, account_field] of Object.entries(
+            this.TAX_TO_ACCOUNT_MAP
+        )) {
+            let value = rounding_difference[tax_field];
+
+            if (!value) continue;
+
+            let account_name = get_account_name(account_field);
+
+            if (!account_name) continue;
+
+            total += value;
+
+            je_details.data.push({
+                account: account_name,
+                debit_in_account_currency: value > 0 ? value : 0,
+                credit_in_account_currency: value < 0 ? Math.abs(value) : 0,
+            });
+        }
+
+        if (je_details.data.length === 0) return;
+
+        if (total !== 0) {
+            je_details.data.push({
+                account: account.round_off_account,
+                debit_in_account_currency: total < 0 ? Math.abs(total) : 0,
+                credit_in_account_currency: total > 0 ? total : 0,
+            });
+        }
+
+        this.create_journal_entry_dialog(je_details);
+    }
+
     create_journal_entry_dialog(je_details) {
         const dialog = new frappe.ui.Dialog({
             title: "Suggested Journal Entry",
@@ -2728,6 +2803,7 @@ class FileGSTR1Dialog {
                     this.frm.doc.__gst_data = r.message;
                     this.frm.trigger("load_gstr1_data");
                     this.frm.gstr1.show_suggested_jv_dialog();
+                    this.frm.gstr1.show_round_off_jv_dialog();
                 });
         }
     }

--- a/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_beta.js
+++ b/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_beta.js
@@ -1011,6 +1011,7 @@ class TabManager {
         this.data = data;
         this.summary = summary_data;
         this.status = status;
+        this.rounding_difference = this.data?.rounding_difference[0];
         this.remove_tab_custom_buttons();
         this.setup_actions();
         this.datatable.refresh(this.summary, null, this.get_no_data_message());
@@ -1176,9 +1177,15 @@ class TabManager {
                     },
                 },
             },
+            ...this.get_additional_datatable_config(),
         });
 
         this.setup_datatable_listeners(treeView);
+    }
+
+    get_additional_datatable_config() {
+        // Override this method in subclasses to provide additional configuration
+        return {};
     }
 
     setup_datatable_listeners(isSummaryView) {
@@ -1776,16 +1783,6 @@ class GSTR1_TabManager extends TabManager {
 }
 
 class BooksTab extends GSTR1_TabManager {
-    constructor(instance, wrapper, summary_view_callback, detailed_view_callback) {
-        super(instance, wrapper, summary_view_callback, detailed_view_callback);
-        const datatable = this.datatable.datatable;
-        const renderFooter = datatable.bodyRenderer.renderFooter;
-        datatable.bodyRenderer.renderFooter = () => {
-            renderFooter.call(datatable.bodyRenderer);
-            this.render_rounding_difference();
-        };
-    }
-
     CATEGORY_COLUMNS = {
         // [GSTR1_Categories.NIL_EXEMPT]: this.get_document_columns,
 
@@ -1819,6 +1816,26 @@ class BooksTab extends GSTR1_TabManager {
 
     DEFAULT_TITLE = "Summary of Books";
 
+    get_additional_datatable_config() {
+        return {
+            additional_total_rows: [
+                {
+                    label: "Rounding Difference",
+                    row_id: "rounding_difference",
+                    label_column: "description",
+                    exclude_columns: ["_rowIndex", "_checkbox", "no_of_records"],
+                    data: () => this.rounding_difference,
+                    show: () => {
+                        if (!this.rounding_difference) return false;
+
+                        return Object.values(this.rounding_difference).some(v => v);
+                    },
+                    css_styles: { "font-weight": "bold" },
+                },
+            ],
+        };
+    }
+
     setup_actions() {
         this.add_tab_custom_button("Download Excel", () =>
             this.download_books_as_excel()
@@ -1830,88 +1847,6 @@ class BooksTab extends GSTR1_TabManager {
         data = super.filter_data(data, filters);
         return data.filter(row => row.upload_status !== "Missing in Books");
     }
-
-    refresh_data(data, summary_data, status) {
-        super.refresh_data(data, summary_data, status);
-
-        // rounding_difference is array
-        if (!data?.rounding_difference || data.rounding_difference.length === 0) {
-            this.rounding_difference = null;
-            return;
-        }
-
-        this.rounding_difference = data.rounding_difference[0];
-        this.render_rounding_difference();
-    }
-
-    refresh_view(view, category, filters) {
-        super.refresh_view(view, category, filters);
-        if (view === "Summary") {
-            this.render_rounding_difference();
-        }
-    }
-
-    // isTotalRow: 1 is redundant
-    // classname was showing undefined within it if isTotalRow was not given
-    render_rounding_difference() {
-        if (
-            !this.rounding_difference ||
-            Object.values(this.rounding_difference).every(v => !v)
-        )
-            return;
-
-        try {
-            const rounding_difference = this.get_rounding_difference();
-
-            const datatable = this.datatable.datatable;
-
-            let html = datatable.rowmanager.getRowHTML(rounding_difference, {
-                rowIndex: "roundingDifference",
-                isTotalRow: 1,
-            });
-
-            datatable.footer.insertAdjacentHTML("beforeend", html);
-
-            $(`[data-row-index='roundingDifference']`).css({
-                "font-weight": "bold",
-            });
-        } catch (error) {
-            console.error("Error rendering rounding difference:", error);
-        }
-    }
-
-    get_rounding_difference() {
-        const datatable = this.datatable.datatable;
-        const columns = datatable.getColumns();
-        const rounding_difference_row_template = columns.map(col => {
-            let content = null;
-            if (["_rowIndex", "_checkbox", "no_of_records"].includes(col.id)) {
-                content = "";
-            }
-            return {
-                content,
-                isTotalRow: 1,
-                colIndex: col.colIndex,
-                column: col,
-            };
-        });
-
-        const rounding_difference = rounding_difference_row_template.map(cell => {
-            if (cell.content === "") return cell;
-
-            if (cell.column.id === "description") {
-                cell.content = "Rounding Difference";
-            } else if (cell.column._fieldtype == "Float") {
-                const fieldname = cell.column.id;
-                cell.content = this.rounding_difference[fieldname] || 0.0;
-            }
-
-            return cell;
-        });
-
-        return rounding_difference;
-    }
-
     // ACTIONS
 
     download_books_as_excel() {

--- a/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_beta.js
+++ b/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_beta.js
@@ -799,6 +799,11 @@ class GSTR1 {
     }
 
     async show_suggested_jv_dialog() {
+        await this.show_rounding_diff_journal_entry();
+        await this.show_rcm_journal_entry();
+    }
+
+    async show_rcm_journal_entry() {
         if (!frappe.perm.has_perm("Journal Entry")) return;
 
         const { month_or_quarter, year, company, filing_preference } = this.frm.doc;
@@ -809,21 +814,15 @@ class GSTR1 {
 
         if (!je_details) return;
 
-        this.create_journal_entry_dialog(je_details);
-    }
+        return new Promise(resolve => {
+            const dialog = this.create_journal_entry_dialog(je_details);
 
-    async show_round_off_jv_dialog() {
-        if (!frappe.perm.has_perm("Journal Entry")) return;
+            dialog.onhide = () => {
+                resolve();
+            };
 
-        const { month_or_quarter, year, company, filing_preference } = this.frm.doc;
-        const { message: data } = await frappe.call({
-            method: "india_compliance.gst_india.doctype.gstr_1_beta.gstr_1_beta.get_accounts",
-            args: { month_or_quarter, year, company, filing_preference },
+            dialog.show();
         });
-
-        if (!data) return;
-
-        this.create_rounding_journal_entry(data.account, data.posting_date);
     }
 
     TAX_TO_ACCOUNT_MAP = {
@@ -833,10 +832,39 @@ class GSTR1 {
         total_cess_amount: ["cess_account", "cess_non_advol_account"],
     };
 
-    create_rounding_journal_entry(account, posting_date) {
+    async show_rounding_diff_journal_entry() {
+        if (!frappe.perm.has_perm("Journal Entry")) return;
+
         let rounding_difference = this.data.books?.rounding_difference[0];
         if (!rounding_difference || Object.values(rounding_difference).every(v => !v))
             return;
+
+        const { month_or_quarter, year, company, filing_preference } = this.frm.doc;
+        const { message: data } = await frappe.call({
+            method: "india_compliance.gst_india.doctype.gstr_1_beta.gstr_1_beta.get_gst_and_round_off_accounts",
+            args: { month_or_quarter, year, company, filing_preference },
+        });
+
+        if (!data) return;
+
+        return new Promise(resolve => {
+            const dialog = this.create_rounding_diff_journal_entry(
+                data.account,
+                data.posting_date
+            );
+
+            if (!dialog) return resolve();
+
+            dialog.onhide = () => {
+                resolve();
+            };
+
+            dialog.show();
+        });
+    }
+
+    create_rounding_diff_journal_entry(account, posting_date) {
+        let rounding_difference = this.data.books?.rounding_difference[0];
 
         const je_details = {
             posting_date: posting_date,
@@ -885,7 +913,7 @@ class GSTR1 {
             });
         }
 
-        this.create_journal_entry_dialog(je_details);
+        return this.create_journal_entry_dialog(je_details);
     }
 
     create_journal_entry_dialog(je_details) {
@@ -941,7 +969,7 @@ class GSTR1 {
             },
         });
 
-        dialog.show();
+        return dialog;
     }
 
     generate_tax_table(data) {

--- a/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_beta.js
+++ b/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_beta.js
@@ -835,7 +835,8 @@ class GSTR1 {
 
     create_rounding_journal_entry(account, posting_date) {
         let rounding_difference = this.data.books?.rounding_difference[0];
-        if (!rounding_difference) return;
+        if (!rounding_difference || Object.values(rounding_difference).every(v => !v))
+            return;
 
         const je_details = {
             posting_date: posting_date,

--- a/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_beta.js
+++ b/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_beta.js
@@ -815,7 +815,8 @@ class GSTR1 {
         if (!je_details) return;
 
         return new Promise(resolve => {
-            const dialog = this.create_journal_entry_dialog(je_details);
+            const remarks = `Reduced Output GST Liability to the extent of Sales Reverse Charge as per GSTR-1 for ${this.frm.doc.month_or_quarter} - ${this.frm.doc.year}`;
+            const dialog = this.create_journal_entry_dialog(je_details, remarks);
 
             dialog.onhide = () => {
                 resolve();
@@ -913,10 +914,11 @@ class GSTR1 {
             });
         }
 
-        return this.create_journal_entry_dialog(je_details);
+        const remarks = `Rounding Difference in Output GST Liability for ${this.frm.doc.month_or_quarter} - ${this.frm.doc.year}`;
+        return this.create_journal_entry_dialog(je_details, remarks);
     }
 
-    create_journal_entry_dialog(je_details) {
+    create_journal_entry_dialog(je_details, remarks) {
         const dialog = new frappe.ui.Dialog({
             title: "Suggested Journal Entry",
             fields: [
@@ -937,7 +939,7 @@ class GSTR1 {
                     fieldtype: "Text",
                     label: "Remarks",
                     read_only: 1,
-                    default: `Reduced Output GST Liability to the extent of Sales Reverse Charge as per GSTR-1 for ${this.frm.doc.month_or_quarter} - ${this.frm.doc.year}`,
+                    default: remarks,
                 },
                 {
                     fieldname: "auto_submit",
@@ -2767,7 +2769,6 @@ class FileGSTR1Dialog {
                     this.frm.doc.__gst_data = r.message;
                     this.frm.trigger("load_gstr1_data");
                     this.frm.gstr1.show_suggested_jv_dialog();
-                    this.frm.gstr1.show_round_off_jv_dialog();
                 });
         }
     }

--- a/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_beta.js
+++ b/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_beta.js
@@ -1784,20 +1784,24 @@ class BooksTab extends GSTR1_TabManager {
         )
             return;
 
-        const rounding_difference = this.get_rounding_difference();
+        try {
+            const rounding_difference = this.get_rounding_difference();
 
-        const datatable = this.datatable.datatable;
+            const datatable = this.datatable.datatable;
 
-        let html = datatable.rowmanager.getRowHTML(rounding_difference, {
-            rowIndex: "roundingDifference",
-            isTotalRow: 1,
-        });
+            let html = datatable.rowmanager.getRowHTML(rounding_difference, {
+                rowIndex: "roundingDifference",
+                isTotalRow: 1,
+            });
 
-        datatable.footer.insertAdjacentHTML("beforeend", html);
+            datatable.footer.insertAdjacentHTML("beforeend", html);
 
-        $(`[data-row-index='roundingDifference']`).css({
-            "font-weight": "bold",
-        });
+            $(`[data-row-index='roundingDifference']`).css({
+                "font-weight": "bold",
+            });
+        } catch (error) {
+            console.error("Error rendering rounding difference:", error);
+        }
     }
 
     get_rounding_difference() {

--- a/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_beta.py
+++ b/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_beta.py
@@ -304,25 +304,27 @@ def get_journal_entries(month_or_quarter, year, company, filing_preference):
 
 
 @frappe.whitelist()
-def get_accounts(month_or_quarter, year, company, filing_preference):
+def get_gst_and_round_off_accounts(month_or_quarter, year, company, filing_preference):
+    """
+    Get GST output accounts and round off account for journal entry creation.
+
+    Returns:
+        dict: Contains account details and posting date, or None if accounts not found
+    """
     if not frappe.has_permission("Journal Entry", "create"):
         return
 
     _, to_date = get_gstr_1_from_and_to_date(month_or_quarter, year, filing_preference)
 
-    # For Output Account
-    gst_settings = frappe.get_cached_doc("GST Settings")
+    # Get Output GST accounts using existing utility
+    try:
+        gst_accounts = get_gst_accounts_by_type(company, "Output")
 
-    output_gst_account = [
-        account
-        for account in gst_settings.gst_accounts
-        if account.account_type == "Output"
-    ]
-
-    if not output_gst_account:
+    except Exception:
         return
 
-    output_gst_account = output_gst_account[0]
+    if not gst_accounts:
+        return
 
     # For Round Off Account
     round_off_account = frappe.get_all(
@@ -340,11 +342,11 @@ def get_accounts(month_or_quarter, year, company, filing_preference):
     round_off_account = round_off_account[0]
 
     account = {
-        "igst_account": output_gst_account.igst_account,
-        "cgst_account": output_gst_account.cgst_account,
-        "sgst_account": output_gst_account.sgst_account,
-        "cess_account": output_gst_account.cess_account,
-        "cess_non_advol_account": output_gst_account.cess_non_advol_account,
+        "igst_account": gst_accounts.get("igst_account"),
+        "cgst_account": gst_accounts.get("cgst_account"),
+        "sgst_account": gst_accounts.get("sgst_account"),
+        "cess_account": gst_accounts.get("cess_account"),
+        "cess_non_advol_account": gst_accounts.get("cess_non_advol_account"),
         "round_off_account": round_off_account,
     }
 

--- a/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_beta.py
+++ b/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_beta.py
@@ -304,6 +304,57 @@ def get_journal_entries(month_or_quarter, year, company, filing_preference):
 
 
 @frappe.whitelist()
+def get_accounts(month_or_quarter, year, company, filing_preference):
+    if not frappe.has_permission("Journal Entry", "create"):
+        return
+
+    _, to_date = get_gstr_1_from_and_to_date(month_or_quarter, year, filing_preference)
+
+    # For Output Account
+    gst_settings = frappe.get_cached_doc("GST Settings")
+
+    output_gst_account = [
+        account
+        for account in gst_settings.gst_accounts
+        if account.account_type == "Output"
+    ]
+
+    if not output_gst_account:
+        return
+
+    output_gst_account = output_gst_account[0]
+
+    # For Round Off Account
+    round_off_account = frappe.get_all(
+        "Account",
+        filters={
+            "company": company,
+            "account_type": "Round Off",
+        },
+        pluck="name",
+    )
+
+    if not round_off_account:
+        return
+
+    round_off_account = round_off_account[0]
+
+    account = {
+        "igst_account": output_gst_account.igst_account,
+        "cgst_account": output_gst_account.cgst_account,
+        "sgst_account": output_gst_account.sgst_account,
+        "cess_account": output_gst_account.cess_account,
+        "cess_non_advol_account": output_gst_account.cess_non_advol_account,
+        "round_off_account": round_off_account,
+    }
+
+    return {
+        "account": account,
+        "posting_date": to_date,
+    }
+
+
+@frappe.whitelist()
 def make_journal_entry(
     company, company_gstin, month_or_quarter, year, accounts, values
 ):

--- a/india_compliance/gst_india/utils/gstr_1/gstr_1_json_map.py
+++ b/india_compliance/gst_india/utils/gstr_1/gstr_1_json_map.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from itertools import chain
 
 import frappe
-from frappe.utils import flt
+from frappe.utils import cint, flt
 
 from india_compliance.gst_india.constants import UOM_MAP
 from india_compliance.gst_india.report.gstr_1.gstr_1 import (
@@ -2374,8 +2374,10 @@ class BooksDataMapper:
         Round off the rounding difference values to 2 decimal places.
         This method is used to round off the rounding difference values.
         """
+        precision = cint(frappe.db.get_default("currency_precision")) or None
+
         for key, value in self.rounding_difference.items():
-            self.rounding_difference[key] = flt(value, self.PRECISION)
+            self.rounding_difference[key] = flt(value, precision)
 
         # saved as object -> it's normalized
         prepared_data["rounding_difference"] = {

--- a/india_compliance/gst_india/utils/gstr_1/test_gstr_1_books_data.py
+++ b/india_compliance/gst_india/utils/gstr_1/test_gstr_1_books_data.py
@@ -167,10 +167,10 @@ class TestGSTR1BooksData(IntegrationTestCase):
         self.assertDictEq(
             {
                 "rounding_difference": {
-                    "total_taxable_value": -0.02,
+                    "total_taxable_value": -0.022,
                     "total_igst_amount": 0.0,
-                    "total_cgst_amount": 0.02,
-                    "total_sgst_amount": 0.02,
+                    "total_cgst_amount": 0.022,
+                    "total_sgst_amount": 0.022,
                     "total_cess_amount": 0.0,
                 }
             },
@@ -218,10 +218,10 @@ class TestGSTR1BooksData(IntegrationTestCase):
         self.assertDictEq(
             {
                 "rounding_difference": {
-                    "total_taxable_value": -0.02,
+                    "total_taxable_value": -0.022,
                     "total_igst_amount": 0.0,
-                    "total_cgst_amount": 0.02,
-                    "total_sgst_amount": 0.02,
+                    "total_cgst_amount": 0.022,
+                    "total_sgst_amount": 0.022,
                     "total_cess_amount": 0.0,
                 }
             },

--- a/india_compliance/gst_india/utils/gstr_1/test_gstr_1_books_data.py
+++ b/india_compliance/gst_india/utils/gstr_1/test_gstr_1_books_data.py
@@ -275,7 +275,7 @@ class TestGSTR1BooksData(IntegrationTestCase):
         self.assertDictEq(
             {
                 "rounding_difference": {
-                    "total_taxable_value": -0.02,
+                    "total_taxable_value": -0.022,
                 }
             },
             data["rounding_difference"],

--- a/india_compliance/public/js/components/data_table_manager.js
+++ b/india_compliance/public/js/components/data_table_manager.js
@@ -4,6 +4,7 @@ india_compliance.DataTableManager = class DataTableManager {
     constructor(options) {
         Object.assign(this, options);
         this.data = this.data || [];
+        this.additional_total_rows = this.additional_total_rows || null;
         this.make();
     }
 
@@ -11,6 +12,7 @@ india_compliance.DataTableManager = class DataTableManager {
         this.format_data(this.data);
         this.make_no_data();
         this.render_datatable();
+        this.setup_additional_total_row();
 
         this.columns_dict = {};
         for (const column of this.datatable.getColumns()) {
@@ -28,6 +30,7 @@ india_compliance.DataTableManager = class DataTableManager {
         if (noDataMessage) this.datatable.options.noDataMessage = noDataMessage;
 
         this.datatable.refresh(data, columns);
+        this.refresh_additional_total_rows();
     }
 
     get_column(fieldname) {
@@ -143,5 +146,135 @@ india_compliance.DataTableManager = class DataTableManager {
         };
         this.datatable = new frappe.DataTable(this.$wrapper.get(0), datatable_options);
         this.$datatable = $(`.${this.datatable.style.scopeClass}`);
+    }
+
+    setup_additional_total_row() {
+        if (!this.additional_total_rows) return;
+
+        const datatable = this.datatable;
+        const originalRenderFooter = datatable.bodyRenderer.renderFooter;
+
+        datatable.bodyRenderer.renderFooter = () => {
+            originalRenderFooter.call(datatable.bodyRenderer);
+            this.render_additional_total_rows();
+        };
+    }
+
+    refresh_additional_total_rows() {
+        if (!this.additional_total_rows) return;
+
+        this.remove_additional_total_rows(); // I think this is not needed
+        this.render_additional_total_rows();
+    }
+
+    refresh_additional_total_row(row_id) {
+        if (!this.additional_total_rows) return;
+
+        const row = this.additional_total_rows.find(r => r.row_id === row_id);
+
+        if (!row) return;
+
+        this.remove_additional_total_row(row_id);
+        this.render_additional_total_row(row);
+    }
+
+    render_additional_total_rows() {
+        if (!this.additional_total_rows) return;
+
+        for (const row of this.additional_total_rows) {
+            this.render_additional_total_row(row);
+        }
+    }
+
+    render_additional_total_row(row) {
+        if (row.show && !row.show()) return;
+
+        const datatable = this.datatable;
+
+        const total_row_data = this.get_additional_total_row_data(row);
+        if (!total_row_data) return;
+
+        const html = datatable.rowmanager.getRowHTML(total_row_data, {
+            rowIndex: row.row_id,
+            isTotalRow: 1,
+        });
+
+        datatable.footer.insertAdjacentHTML("beforeend", html);
+
+        const $row = $(`[data-row-index='${row.row_id}']`);
+
+        $row.css(row.css_styles || { "font-weight": "bold" });
+    }
+
+    remove_additional_total_rows() {
+        if (!this.additional_total_rows) return;
+
+        for (const row of this.additional_total_rows) {
+            this.remove_additional_total_row(row.row_id);
+        }
+    }
+
+    remove_additional_total_row(row_id) {
+        if (!row_id) return;
+
+        $(`[data-row-index='${row_id}']`).remove();
+    }
+
+    get_additional_total_row_data(row) {
+        let data = this.get_row_data(row);
+        if (!data) return null;
+
+        const row_template = this.get_row_template(row);
+
+        const total_row_data = row_template.map(cell => {
+            if (cell.content === "") return cell;
+
+            const fieldname = cell.column.id;
+
+            if (row.label_column === fieldname) {
+                cell.content = row.label;
+            } else if (
+                cell.column._fieldtype === "Float" ||
+                cell.column.fieldtype === "Float"
+            ) {
+                cell.content = data[fieldname] || 0.0;
+            } else if (data.hasOwnProperty(fieldname)) {
+                cell.content = data[fieldname];
+            }
+
+            return cell;
+        });
+
+        return total_row_data;
+    }
+
+    get_row_data(row) {
+        if (typeof row.data === "function") {
+            return row.data();
+        }
+
+        return row.data;
+    }
+
+    get_row_template(row) {
+        const datatable = this.datatable;
+        const columns = datatable.getColumns();
+
+        const row_template = columns.map(col => {
+            let content = null;
+
+            if (row?.exclude_columns.includes(col.id)) {
+                content = "";
+            }
+
+            return {
+                content,
+                isTotalRow: 1,
+                colIndex: col.colIndex,
+                column: col,
+            };
+        });
+
+        return row_template;
     }
 };

--- a/india_compliance/public/js/components/data_table_manager.js
+++ b/india_compliance/public/js/components/data_table_manager.js
@@ -163,7 +163,7 @@ india_compliance.DataTableManager = class DataTableManager {
     refresh_additional_total_rows() {
         if (!this.additional_total_rows) return;
 
-        this.remove_additional_total_rows(); // I think this is not needed
+        this.remove_additional_total_rows();
         this.render_additional_total_rows();
     }
 

--- a/india_compliance/public/js/components/data_table_manager.js
+++ b/india_compliance/public/js/components/data_table_manager.js
@@ -167,17 +167,6 @@ india_compliance.DataTableManager = class DataTableManager {
         this.render_additional_total_rows();
     }
 
-    refresh_additional_total_row(row_id) {
-        if (!this.additional_total_rows) return;
-
-        const row = this.additional_total_rows.find(r => r.row_id === row_id);
-
-        if (!row) return;
-
-        this.remove_additional_total_row(row_id);
-        this.render_additional_total_row(row);
-    }
-
     render_additional_total_rows() {
         if (!this.additional_total_rows) return;
 
@@ -210,14 +199,9 @@ india_compliance.DataTableManager = class DataTableManager {
         if (!this.additional_total_rows) return;
 
         for (const row of this.additional_total_rows) {
-            this.remove_additional_total_row(row.row_id);
+            if (!row.row_id) continue;
+            $(`[data-row-index='${row.row_id}']`).remove();
         }
-    }
-
-    remove_additional_total_row(row_id) {
-        if (!row_id) return;
-
-        $(`[data-row-index='${row_id}']`).remove();
     }
 
     get_additional_total_row_data(row) {

--- a/india_compliance/public/js/components/data_table_manager.js
+++ b/india_compliance/public/js/components/data_table_manager.js
@@ -238,7 +238,7 @@ india_compliance.DataTableManager = class DataTableManager {
                 cell.column.fieldtype === "Float"
             ) {
                 cell.content = data[fieldname] || 0.0;
-            } else if (data.hasOwnProperty(fieldname)) {
+            } else if (Object.hasOwn(data, fieldname)) {
                 cell.content = data[fieldname];
             }
 

--- a/india_compliance/public/js/components/data_table_manager.js
+++ b/india_compliance/public/js/components/data_table_manager.js
@@ -238,7 +238,7 @@ india_compliance.DataTableManager = class DataTableManager {
                 cell.column.fieldtype === "Float"
             ) {
                 cell.content = data[fieldname] || 0.0;
-            } else if (Object.hasOwn(data, fieldname)) {
+            } else if (Object.prototype.hasOwnProperty.call(data, fieldname)) {
                 cell.content = data[fieldname];
             }
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/5ab29bd1-1997-4cda-9196-460e1a9b51ab)
![image](https://github.com/user-attachments/assets/1f35f13a-4298-484c-a561-c24f0279eab3)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a "Rounding Difference" row to the summary view footer in the data table, displaying rounding adjustments clearly and prominently when applicable.
  - Introduced dialogs to create and review rounding difference and reverse charge mechanism journal entries after filing GSTR-1.
  - Enabled dynamic currency precision for rounding differences based on system settings.
  - Added functionality to fetch relevant tax and round-off accounts with posting dates for journal entry creation.
  - Enhanced data table support for rendering additional total rows below the main footer with flexible display and styling options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->