### PR TITLE
fix: add hsn bifurcated sheets in excel gstr 1 beta

### DIFF
--- a/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_export.py
+++ b/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_export.py
@@ -3,6 +3,7 @@ Export GSTR-1 data to excel or json
 """
 
 import json
+from collections import defaultdict
 from datetime import datetime
 from enum import Enum
 
@@ -23,6 +24,7 @@ from india_compliance.gst_india.utils.gstr_1 import GSTR1_DataField as df
 from india_compliance.gst_india.utils.gstr_1 import (
     GSTR1_ItemField,
     GSTR1_SubCategory,
+    HSNKey,
 )
 from india_compliance.gst_india.utils.gstr_1.gstr_1_json_map import (
     convert_to_gov_data_format,
@@ -178,7 +180,31 @@ class GovExcel(DataProcessor):
                     }
                 )
 
+        self.process_hsn_data(category_wise_data)
         return category_wise_data
+
+    def process_hsn_data(self, category_wise_data):
+        if not (data := category_wise_data.get(GovJsonKey.HSN.value)):
+            return
+
+        item = data[0]
+        bifurcate_hsn = item.get(df.DOC_TYPE) != GSTR1_SubCategory.HSN.value
+
+        if not bifurcate_hsn:
+            return
+
+        _hsn_data = defaultdict(list)
+        for row in data:
+            key = (
+                HSNKey.HSN_B2B.value
+                if (row.get(df.DOC_TYPE) == GSTR1_SubCategory.HSN_B2B.value)
+                else HSNKey.HSN_B2C.value
+            )
+
+            _hsn_data[key].append(row)
+
+        category_wise_data.pop(GovJsonKey.HSN.value)
+        category_wise_data.update(dict(_hsn_data))
 
     def build_excel(self, data):
         excel = ExcelExporter()
@@ -690,6 +716,12 @@ class GovExcel(DataProcessor):
                 "data_format": {"number_format": self.AMOUNT_FORMAT},
             },
         ]
+
+    def get_hsn_b2b_headers(self):
+        return self.get_hsn_headers()
+
+    def get_hsn_b2c_headers(self):
+        return self.get_hsn_headers()
 
     def get_doc_issue_headers(self):
         return [

--- a/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_export.py
+++ b/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_export.py
@@ -160,6 +160,9 @@ class GovExcel(DataProcessor):
             if category == GovJsonKey.DOC_ISSUE.value:
                 self.process_doc_issue_data(category_wise_data[category])
 
+            elif category == GovJsonKey.HSN.value:
+                self.process_hsn_data(category_wise_data, category)
+
             if category not in [
                 GovJsonKey.CDNR.value,
                 GovJsonKey.CDNUR.value,
@@ -180,31 +183,7 @@ class GovExcel(DataProcessor):
                     }
                 )
 
-        self.process_hsn_data(category_wise_data)
         return category_wise_data
-
-    def process_hsn_data(self, category_wise_data):
-        if not (data := category_wise_data.get(GovJsonKey.HSN.value)):
-            return
-
-        item = data[0]
-        bifurcate_hsn = item.get(df.DOC_TYPE) != GSTR1_SubCategory.HSN.value
-
-        if not bifurcate_hsn:
-            return
-
-        _hsn_data = defaultdict(list)
-        for row in data:
-            key = (
-                HSNKey.HSN_B2B.value
-                if (row.get(df.DOC_TYPE) == GSTR1_SubCategory.HSN_B2B.value)
-                else HSNKey.HSN_B2C.value
-            )
-
-            _hsn_data[key].append(row)
-
-        category_wise_data.pop(GovJsonKey.HSN.value)
-        category_wise_data.update(dict(_hsn_data))
 
     def build_excel(self, data):
         excel = ExcelExporter()
@@ -230,6 +209,28 @@ class GovExcel(DataProcessor):
                 continue
 
             doc[df.CANCELLED_COUNT] += doc.get(df.DRAFT_COUNT, 0)
+
+    def process_hsn_data(self, category_wise_data, category):
+        hsn_data = category_wise_data.pop(category, None)
+        if not hsn_data:
+            return
+
+        MAP = {
+            GSTR1_SubCategory.HSN.value: HSNKey.HSN.value,  # backward compatibility
+            GSTR1_SubCategory.HSN_B2B.value: HSNKey.HSN_B2B.value,
+            GSTR1_SubCategory.HSN_B2C.value: HSNKey.HSN_B2C.value,
+        }
+
+        new_data = defaultdict(list)
+
+        for row in hsn_data:
+            sub_category = row.get(df.DOC_TYPE, GSTR1_SubCategory.HSN.value)
+            if sub_category not in MAP:
+                continue
+
+            new_data[MAP[sub_category]].append(row)
+
+        category_wise_data.update(new_data)
 
     def get_category_headers(self, category):
         return getattr(self, f"get_{category.lower()}_headers")()

--- a/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_export.py
+++ b/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_export.py
@@ -223,7 +223,7 @@ class GovExcel(DataProcessor):
         new_data = defaultdict(list)
 
         for row in hsn_data:
-            sub_category = row.get(df.DOC_TYPE, GSTR1_SubCategory.HSN.value)
+            sub_category = row.get(df.DOC_TYPE)
             if sub_category not in MAP:
                 continue
 
@@ -1019,6 +1019,10 @@ class BooksExcel(DataProcessor):
                 "fieldname": df.TAX_RATE,
                 "data_format": {"number_format": self.PERCENT_FORMAT},
                 "header_format": {"width": ExcelWidth.XS.value},
+            },
+            {
+                "label": _("Document Type"),
+                "fieldname": df.DOC_TYPE,
             },
             {
                 "label": "Upload Status",

--- a/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_export.py
+++ b/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_export.py
@@ -160,9 +160,6 @@ class GovExcel(DataProcessor):
             if category == GovJsonKey.DOC_ISSUE.value:
                 self.process_doc_issue_data(category_wise_data[category])
 
-            elif category == GovJsonKey.HSN.value:
-                self.process_hsn_data(category_wise_data, category)
-
             if category not in [
                 GovJsonKey.CDNR.value,
                 GovJsonKey.CDNUR.value,
@@ -182,6 +179,8 @@ class GovExcel(DataProcessor):
                         if isinstance(value, (int, float))
                     }
                 )
+
+        self.process_hsn_data(category_wise_data)
 
         return category_wise_data
 
@@ -210,8 +209,8 @@ class GovExcel(DataProcessor):
 
             doc[df.CANCELLED_COUNT] += doc.get(df.DRAFT_COUNT, 0)
 
-    def process_hsn_data(self, category_wise_data, category):
-        hsn_data = category_wise_data.pop(category, None)
+    def process_hsn_data(self, category_wise_data):
+        hsn_data = category_wise_data.pop(GovJsonKey.HSN.value, None)
         if not hsn_data:
             return
 

--- a/india_compliance/gst_india/utils/gstr_1/__init__.py
+++ b/india_compliance/gst_india/utils/gstr_1/__init__.py
@@ -283,6 +283,12 @@ class GovJsonKey(Enum):
     RET_SUM = "sec_sum"
 
 
+# only for excel
+class HSNKey(Enum):
+    HSN_B2B = "hsn_b2b"
+    HSN_B2C = "hsn_b2c"
+
+
 class GovExcelSheetName(Enum):
     """
     Categories / Worksheets as per Gov Excel file
@@ -298,6 +304,8 @@ class GovExcelSheetName(Enum):
     AT = "at"
     TXP = "atadj"
     HSN = "hsn"
+    HSN_B2B = "hsn(b2b)"
+    HSN_B2C = "hsn(b2c)"
     DOC_ISSUE = "docs"
 
 
@@ -336,6 +344,9 @@ JSON_CATEGORY_EXCEL_CATEGORY_MAPPING = {
     GovJsonKey.TXP.value: GovExcelSheetName.TXP.value,
     GovJsonKey.HSN.value: GovExcelSheetName.HSN.value,
     GovJsonKey.DOC_ISSUE.value: GovExcelSheetName.DOC_ISSUE.value,
+    # only for excel
+    HSNKey.HSN_B2B.value: GovExcelSheetName.HSN_B2B.value,
+    HSNKey.HSN_B2C.value: GovExcelSheetName.HSN_B2C.value,
 }
 
 

--- a/india_compliance/gst_india/utils/gstr_1/__init__.py
+++ b/india_compliance/gst_india/utils/gstr_1/__init__.py
@@ -285,6 +285,7 @@ class GovJsonKey(Enum):
 
 # only for excel
 class HSNKey(Enum):
+    HSN = "hsn"
     HSN_B2B = "hsn_b2b"
     HSN_B2C = "hsn_b2c"
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/82316512-ccab-45cc-a9e8-acf72dc94a08)

closes: #3421

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - HSN summary data in government Excel exports is now automatically separated into B2B and B2C categories, each with its own dedicated worksheet.
- **Improvements**
  - Enhanced clarity and organization in exported Excel files by providing distinct sheets for B2B and B2C HSN summaries.
  - Added a new "Document Type" column to HSN summary headers for better data context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->