### PR TITLE
fix: Add HSN bifurcation in GSTR-1 Excel export; default value of 'bifurcate hsn' based on 'from date';

### DIFF
--- a/india_compliance/gst_india/report/gstr_1/gstr_1.js
+++ b/india_compliance/gst_india/report/gstr_1/gstr_1.js
@@ -58,6 +58,16 @@ frappe.query_reports["GSTR-1"] = {
             reqd: 1,
             default: india_compliance.last_month_start(),
             width: "80",
+            on_change: report => {
+                let { from_date } = report.get_values();
+                from_date = frappe.datetime.str_to_obj(from_date);
+
+                if (india_compliance.HSN_BIFURCATION_FROM <= from_date) {
+                    report.set_filter_value("bifurcate_hsn", 1);
+                } else {
+                    report.set_filter_value("bifurcate_hsn", 0);
+                }
+            },
         },
         {
             fieldname: "to_date",

--- a/india_compliance/gst_india/report/gstr_1/gstr_1.js
+++ b/india_compliance/gst_india/report/gstr_1/gstr_1.js
@@ -93,7 +93,7 @@ frappe.query_reports["GSTR-1"] = {
             fieldname: "bifurcate_hsn",
             label: __("Bifurcate HSN Summary"),
             fieldtype: "Check",
-            depends_on: "eval: doc.type_of_business == 'HSN'",
+            default: 1,
         },
     ],
     onload(report) {

--- a/india_compliance/gst_india/report/gstr_1/gstr_1.py
+++ b/india_compliance/gst_india/report/gstr_1/gstr_1.py
@@ -2263,8 +2263,14 @@ def create_hsn_excel_sheet(excel, headers, data):
         else:
             b2c_data.append(row)
 
-    create_excel_sheet(excel, "HSN - B2B", headers, b2b_data)
-    create_excel_sheet(excel, "HSN - B2C", headers, b2c_data)
+    if b2b_data:
+        create_excel_sheet(excel, "HSN - B2B", headers, b2b_data)
+
+    if b2c_data:
+        create_excel_sheet(excel, "HSN - B2C", headers, b2c_data)
+
+    if not b2b_data and not b2c_data:
+        create_excel_sheet(excel, "HSN", headers, data)
 
 
 def create_excel_sheet(excel, sheet_name, headers, data):

--- a/india_compliance/gst_india/report/gstr_1/gstr_1.py
+++ b/india_compliance/gst_india/report/gstr_1/gstr_1.py
@@ -2269,9 +2269,6 @@ def create_hsn_excel_sheet(excel, headers, data):
     if b2c_data:
         create_excel_sheet(excel, "HSN - B2C", headers, b2c_data)
 
-    if not b2b_data and not b2c_data:
-        create_excel_sheet(excel, "HSN", headers, data)
-
 
 def create_excel_sheet(excel, sheet_name, headers, data):
     excel.create_sheet(

--- a/india_compliance/gst_india/report/gstr_1/gstr_1.py
+++ b/india_compliance/gst_india/report/gstr_1/gstr_1.py
@@ -2209,7 +2209,10 @@ def get_gstr1_excel(filters, data=None, columns=None):
         if type_of_business == "Document Issued Summary":
             format_doc_issued_excel_data(headers, data)
 
-        create_excel_sheet(excel, type_of_business, headers, data)
+        if type_of_business == "HSN" and filters.get("bifurcate_hsn"):
+            create_hsn_excel_sheet(excel, headers, data)
+        else:
+            create_excel_sheet(excel, type_of_business, headers, data)
 
     else:
         for type_of_business in report_types:
@@ -2221,6 +2224,10 @@ def get_gstr1_excel(filters, data=None, columns=None):
 
             if type_of_business == "Document Issued Summary":
                 format_doc_issued_excel_data(headers, data)
+
+            if type_of_business == "HSN" and filters.get("bifurcate_hsn"):
+                create_hsn_excel_sheet(excel, headers, data)
+                continue
 
             create_excel_sheet(excel, type_of_business, headers, data)
 
@@ -2245,6 +2252,19 @@ def format_doc_issued_excel_data(headers, data):
 
     if total_draft_idx is not None:
         headers.pop(total_draft_idx)
+
+
+def create_hsn_excel_sheet(excel, headers, data):
+    b2b_data = []
+    b2c_data = []
+    for row in data:
+        if row.get("invoice_type") == "B2B":
+            b2b_data.append(row)
+        else:
+            b2c_data.append(row)
+
+    create_excel_sheet(excel, "HSN - B2B", headers, b2b_data)
+    create_excel_sheet(excel, "HSN - B2C", headers, b2c_data)
 
 
 def create_excel_sheet(excel, sheet_name, headers, data):

--- a/india_compliance/gst_india/report/hsn_wise_summary_of_outward_supplies/hsn_wise_summary_of_outward_supplies.js
+++ b/india_compliance/gst_india/report/hsn_wise_summary_of_outward_supplies/hsn_wise_summary_of_outward_supplies.js
@@ -35,7 +35,17 @@ frappe.query_reports["HSN-wise-summary of outward supplies"] = {
 			"label": __("From Date"),
 			"fieldtype": "Date",
 			"width": "80",
-			"default": india_compliance.last_month_start()
+			"default": india_compliance.last_month_start(),
+			on_change: report => {
+				let { from_date } = report.get_values();
+                from_date = frappe.datetime.str_to_obj(from_date);
+
+                if (india_compliance.HSN_BIFURCATION_FROM <= from_date) {
+                    report.set_filter_value("bifurcate_hsn", 1);
+                } else {
+                    report.set_filter_value("bifurcate_hsn", 0);
+                }
+			}
 		},
 		{
 			"fieldname":"to_date",

--- a/india_compliance/gst_india/report/hsn_wise_summary_of_outward_supplies/hsn_wise_summary_of_outward_supplies.js
+++ b/india_compliance/gst_india/report/hsn_wise_summary_of_outward_supplies/hsn_wise_summary_of_outward_supplies.js
@@ -38,13 +38,13 @@ frappe.query_reports["HSN-wise-summary of outward supplies"] = {
 			"default": india_compliance.last_month_start(),
 			on_change: report => {
 				let { from_date } = report.get_values();
-                from_date = frappe.datetime.str_to_obj(from_date);
+				from_date = frappe.datetime.str_to_obj(from_date);
 
-                if (india_compliance.HSN_BIFURCATION_FROM <= from_date) {
-                    report.set_filter_value("bifurcate_hsn", 1);
-                } else {
-                    report.set_filter_value("bifurcate_hsn", 0);
-                }
+				if (india_compliance.HSN_BIFURCATION_FROM <= from_date) {
+					report.set_filter_value("bifurcate_hsn", 1);
+				} else {
+					report.set_filter_value("bifurcate_hsn", 0);
+				}
 			}
 		},
 		{

--- a/india_compliance/public/js/utils.js
+++ b/india_compliance/public/js/utils.js
@@ -31,6 +31,8 @@ Object.assign(india_compliance, {
 
     QUARTER: ["Jan-Mar", "Apr-Jun", "Jul-Sep", "Oct-Dec"],
 
+    HSN_BIFURCATION_FROM: frappe.datetime.str_to_obj("2025-05-01"),
+
     get_month_year_from_period(period) {
         /**
          * Returns month or quarter and year from the period


### PR DESCRIPTION
- Add HSN Bifurcation in GSTR-1 Excel
![image](https://github.com/user-attachments/assets/17e0333c-daa1-4433-8c96-0d4931c1b428)
- Make Bifurcate HSN visible for all the types

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- The GSTR-1 report now allows bifurcation of HSN data into separate "B2B" and "B2C" sheets when exporting to Excel, providing clearer data segmentation.
- **Enhancements**
	- The "Bifurcate HSN" filter is now enabled by default and dynamically updated based on the selected "from_date" in related reports, improving filter usability and accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->