### PR TITLE
fix: roundoff values in nil-rated json export

### DIFF
--- a/india_compliance/gst_india/report/gstr_1/gstr_1.py
+++ b/india_compliance/gst_india/report/gstr_1/gstr_1.py
@@ -1973,13 +1973,13 @@ def get_exempted_json(data):
 
     for i, v in enumerate(data):
         if data[i].get("nil_rated"):
-            out["inv"][i]["nil_amt"] = data[i]["nil_rated"]
+            out["inv"][i]["nil_amt"] = flt(data[i]["nil_rated"], 2)
 
         if data[i].get("exempted"):
-            out["inv"][i]["expt_amt"] = data[i]["exempted"]
+            out["inv"][i]["expt_amt"] = flt(data[i]["exempted"], 2)
 
         if data[i].get("non_gst"):
-            out["inv"][i]["ngsup_amt"] = data[i]["non_gst"]
+            out["inv"][i]["ngsup_amt"] = flt(data[i]["non_gst"], 2)
 
     return out
 


### PR DESCRIPTION
Frappe Support Issue: https://support.frappe.io/app/hd-ticket/40744

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved numeric formatting for nil rated, exempted, and non-GST supply amounts in GSTR-1 report to ensure values display with two decimal places.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->