### PR TITLE
fix: only transform field when field has value

### DIFF
--- a/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_export.py
+++ b/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_export.py
@@ -81,7 +81,7 @@ class DataProcessor:
         Apply transformations to row fields
         """
         for field, modifier in self.FIELD_TRANSFORMATIONS.items():
-            if field in row:
+            if row.get(field):
                 row[field] = modifier(row[field])
 
         return row


### PR DESCRIPTION
Traceback

```
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 98, in application
    response = frappe.api.handle()
               ^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/handler.py", line 49, in handle
    data = execute_cmd(cmd)
           ^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/handler.py", line 84, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/__init__.py", line 1627, in call
    return fn(*args, **newargs)
           ^^^^^^^^^^^^^^^^^^^^
  File "apps/india_compliance/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_export.py", line 2050, in download_filed_as_excel
    GovExcel().generate(company_gstin, get_period(month_or_quarter, year))
  File "apps/india_compliance/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_export.py", line 145, in generate
    data = self.process_data(data)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/india_compliance/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_export.py", line 150, in process_data
    category_wise_data = super().process_data(data)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/india_compliance/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_export.py", line 73, in process_data
    data = [self.apply_transformations(row) for row in data]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/india_compliance/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_export.py", line 73, in <listcomp>
    data = [self.apply_transformations(row) for row in data]
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/india_compliance/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_export.py", line 85, in apply_transformations
    row[field] = modifier(row[field])
                 ^^^^^^^^^^^^^^^^^^^^
  File "apps/india_compliance/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_export.py", line 132, in <lambda>
    df.SHIPPING_BILL_DATE: lambda value: datetime.strptime(value, "%Y-%m-%d"),
                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: strptime() argument 1 must be str, not None
```