### PR TITLE
fix: added adding value 0 for NoneType tax_rate rows, in the item_tax_template validation py file…

### DIFF
--- a/india_compliance/gst_india/overrides/item_tax_template.py
+++ b/india_compliance/gst_india/overrides/item_tax_template.py
@@ -52,6 +52,8 @@ def validate_tax_rates(doc):
         elif row.tax_type in inter_state_accounts and doc.gst_rate != tax_rate:
             invalid_tax_rates[row.idx] = doc.gst_rate
 
+        return
+
     if not invalid_tax_rates:
         return
 


### PR DESCRIPTION
… to fix the error:-
"TypeError: bad operand type for abs(): 'NoneType'"

Check detailed error in the following attachment:-
[py_nontype_ err_msg.txt](https://github.com/user-attachments/files/20738212/py_nontype_.err_msg.txt)