### PR TITLE
fix: for "TypeError bad operand type for abs() 'NoneType'"

### DIFF
--- a/india_compliance/gst_india/overrides/item_tax_template.py
+++ b/india_compliance/gst_india/overrides/item_tax_template.py
@@ -42,6 +42,10 @@ def validate_tax_rates(doc):
 
     invalid_tax_rates = {}
     for row in doc.taxes:
+
+        if row.tax_rate is None:
+            row.tax_rate = 0
+
         tax_rate = abs(row.tax_rate)
 
         # check intra state


### PR DESCRIPTION
After adding 12% CESS in the 28% tax tempate, when we mark CESS as 0% in the rest of the tax templates (5% , 12%) (except in the 0% tax template) we are getting the following error :-
[py_nontype_.err_msg.txt](https://github.com/user-attachments/files/20743967/py_nontype_.err_msg.txt)

Fix: Adding 0 when tax_rate is None.