### PR TITLE
feat: add bifurcate HSN functionality to report and invoice processing

### DIFF
--- a/india_compliance/gst_india/report/hsn_wise_summary_of_inward_supplies/hsn_wise_summary_of_inward_supplies.js
+++ b/india_compliance/gst_india/report/hsn_wise_summary_of_inward_supplies/hsn_wise_summary_of_inward_supplies.js
@@ -47,6 +47,16 @@ frappe.query_reports["HSN-wise-summary of inward supplies"] = {
             width: "80",
             default: india_compliance.last_month_start(),
             reqd: 1,
+            on_change: report => {
+                let { from_date } = report.get_values();
+                from_date = frappe.datetime.str_to_obj(from_date);
+
+                if (india_compliance.HSN_BIFURCATION_FROM <= from_date) {
+                    report.set_filter_value("bifurcate_hsn", 1);
+                } else {
+                    report.set_filter_value("bifurcate_hsn", 0);
+                }
+            },
         },
         {
             fieldname: "to_date",
@@ -55,6 +65,11 @@ frappe.query_reports["HSN-wise-summary of inward supplies"] = {
             width: "80",
             default: india_compliance.last_month_end(),
             reqd: 1,
+        },
+        {
+            fieldname: "bifurcate_hsn",
+            label: __("Bifurcate HSN Summary"),
+            fieldtype: "Check",
         },
     ],
 };

--- a/india_compliance/gst_india/utils/gstr3b/gstr3b_data.py
+++ b/india_compliance/gst_india/utils/gstr3b/gstr3b_data.py
@@ -2,10 +2,15 @@ import frappe
 from frappe.query_builder import Case
 from frappe.query_builder.custom import ConstantColumn
 from frappe.query_builder.functions import IfNull, Sum
+from frappe.utils import getdate
 
 from india_compliance.gst_india.constants import GST_TAX_TYPES
 from india_compliance.gst_india.overrides.transaction import is_inter_state_supply
 from india_compliance.gst_india.utils import get_full_gst_uom
+from india_compliance.gst_india.utils.gstr_1 import (
+    HSN_BIFURCATION_FROM,
+    GSTR1_SubCategory,
+)
 
 PURCHASE_CATEGORY_CONDITIONS = {
     "Composition Scheme, Exempted, Nil Rated": {
@@ -125,6 +130,16 @@ class GSTR3BSubcategory(GSTR3BCategoryConditions):
 
     def set_for_itc_reclaimed(self, invoice):
         invoice.invoice_sub_category = "Reclaim of ITC Reversal"
+
+    def set_hsn_sub_category(self, invoice, bifurcate_hsn):
+        if not bifurcate_hsn:
+            invoice.hsn_sub_category = GSTR1_SubCategory.HSN.value
+
+        elif invoice.gst_category in ("Unregistered", "Overseas"):
+            invoice.hsn_sub_category = GSTR1_SubCategory.HSN_B2C.value
+
+        else:
+            invoice.hsn_sub_category = GSTR1_SubCategory.HSN_B2B.value
 
 
 class GSTR3BQuery:
@@ -325,10 +340,17 @@ class GSTR3BInvoices(GSTR3BQuery, GSTR3BSubcategory):
         processed_invoices = []
         identified_uom = {}
 
+        if (bifurcate_hsn := self.filters.get("bifurcate_hsn")) is None:
+            bifurcate_hsn = (
+                getdate(self.filters.get("from_date")) >= HSN_BIFURCATION_FROM
+            )
+
         for invoice in data:
             if not invoice.invoice_sub_category:
                 self.set_invoice_category(invoice, conditions)
                 self.set_invoice_sub_category(invoice, conditions)
+
+            self.set_hsn_sub_category(invoice, bifurcate_hsn)
 
             if invoice.invoice_category in (
                 "Composition Scheme, Exempted, Nil Rated",


### PR DESCRIPTION
Fixes: https://support.frappe.io/helpdesk/tickets/41649

![image](https://github.com/user-attachments/assets/b647c519-3f31-4c98-b4ea-a0ceaa40290f)

`no_docs`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a "Bifurcate HSN" checkbox filter to the HSN-wise summary of inward supplies report, which automatically toggles based on the selected "From Date".
  - Enhanced GSTR3B invoice processing to assign HSN sub-categories dynamically, reflecting the bifurcation status for more accurate reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->