### PR TITLE
fix: refresh report after setting filter value

### DIFF
--- a/india_compliance/gst_india/report/gstr_1/gstr_1.js
+++ b/india_compliance/gst_india/report/gstr_1/gstr_1.js
@@ -67,6 +67,8 @@ frappe.query_reports["GSTR-1"] = {
                 } else {
                     report.set_filter_value("bifurcate_hsn", 0);
                 }
+
+                report.refresh();
             },
         },
         {

--- a/india_compliance/gst_india/report/gstr_1/gstr_1.js
+++ b/india_compliance/gst_india/report/gstr_1/gstr_1.js
@@ -61,7 +61,7 @@ frappe.query_reports["GSTR-1"] = {
             on_change: report => {
                 let { from_date } = report.get_values();
                 from_date = frappe.datetime.str_to_obj(from_date);
-                
+
                 report.set_filter_value(
                     "bifurcate_hsn",
                     india_compliance.HSN_BIFURCATION_FROM <= from_date ? 1 : 0
@@ -195,7 +195,7 @@ function show_gstr_1_beta_alert(report) {
         <a href="/app/gstr-1-beta" class="alert-link">
             GSTR-1 Beta
         </a>
-        is released with improved features and user experience. Try it out now!
+        ${__("is released with improved features and user experience. Try it out now!")}
         `;
 
     india_compliance.show_dismissable_alert(

--- a/india_compliance/gst_india/report/gstr_1/gstr_1.js
+++ b/india_compliance/gst_india/report/gstr_1/gstr_1.js
@@ -61,12 +61,11 @@ frappe.query_reports["GSTR-1"] = {
             on_change: report => {
                 let { from_date } = report.get_values();
                 from_date = frappe.datetime.str_to_obj(from_date);
-
-                if (india_compliance.HSN_BIFURCATION_FROM <= from_date) {
-                    report.set_filter_value("bifurcate_hsn", 1);
-                } else {
-                    report.set_filter_value("bifurcate_hsn", 0);
-                }
+                
+                report.set_filter_value(
+                    "bifurcate_hsn",
+                    india_compliance.HSN_BIFURCATION_FROM <= from_date ? 1 : 0
+                );
 
                 report.refresh();
             },


### PR DESCRIPTION
> [!NOTE]
> Backport to V-15

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - The GSTR-1 report now refreshes automatically when the "from_date" filter is changed, ensuring that updates are reflected immediately.
  - Alert messages in the GSTR-1 report are now localized for better language support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->