### PR TITLE
fix: handle `NoneType error` for unset row in item_tax_template

### DIFF
--- a/india_compliance/gst_india/overrides/item_tax_template.py
+++ b/india_compliance/gst_india/overrides/item_tax_template.py
@@ -42,7 +42,7 @@ def validate_tax_rates(doc):
 
     invalid_tax_rates = {}
     for row in doc.taxes:
-        tax_rate = abs(row.tax_rate)
+        tax_rate = abs(row.get("tax_rate") or 0)
 
         # check intra state
         if row.tax_type in intra_state_accounts and doc.gst_rate != tax_rate * 2:


### PR DESCRIPTION
continued: https://github.com/resilient-tech/india-compliance/pull/3455
### Traceback
```
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 116, in application
    response = frappe.api.handle(request)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/api/__init__.py", line 60, in handle
    data = endpoint(**arguments)
           ^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/api/v1.py", line 36, in handle_rpc_call
    return frappe.handler.handle()
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/handler.py", line 51, in handle
    data = execute_cmd(cmd)
           ^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/handler.py", line 84, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/__init__.py", line 1476, in call
    return fn(*args, **newargs)
           ^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/utils/typing_validations.py", line 32, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/desk/form/save.py", line 43, in savedocs
    doc.save()
  File "apps/frappe/frappe/model/document.py", line 483, in save
    return self._save(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 519, in _save
    self.run_before_save_methods()
  File "apps/frappe/frappe/model/document.py", line 1276, in run_before_save_methods
    self.run_method("validate")
  File "apps/frappe/frappe/model/document.py", line 1127, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 1516, in composer
    return composed(self, method, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 1498, in runner
    add_to_return_value(self, f(self, method, *args, **kwargs))
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/india_compliance/india_compliance/gst_india/overrides/item_tax_template.py", line 12, in validate
    validate_tax_rates(doc)
  File "apps/india_compliance/india_compliance/gst_india/overrides/item_tax_template.py", line 45, in validate_tax_rates
    tax_rate = abs(row.tax_rate)
               ^^^^^^^^^^^^^^^^^
TypeError: bad operand type for abs(): 'NoneType'

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of missing or null tax rate values during tax validation to prevent errors and ensure smoother processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->