### PR TITLE
fix: HSN sub-category assignment to GSTR3B invoices

### DIFF
--- a/india_compliance/gst_india/utils/gstr3b/gstr3b_data.py
+++ b/india_compliance/gst_india/utils/gstr3b/gstr3b_data.py
@@ -6,6 +6,7 @@ from frappe.query_builder.functions import IfNull, Sum
 from india_compliance.gst_india.constants import GST_TAX_TYPES
 from india_compliance.gst_india.overrides.transaction import is_inter_state_supply
 from india_compliance.gst_india.utils import get_full_gst_uom
+from india_compliance.gst_india.utils.gstr_1 import GSTR1_SubCategory
 
 PURCHASE_CATEGORY_CONDITIONS = {
     "Composition Scheme, Exempted, Nil Rated": {
@@ -329,6 +330,8 @@ class GSTR3BInvoices(GSTR3BQuery, GSTR3BSubcategory):
             if not invoice.invoice_sub_category:
                 self.set_invoice_category(invoice, conditions)
                 self.set_invoice_sub_category(invoice, conditions)
+
+            invoice.hsn_sub_category = GSTR1_SubCategory.HSN.value
 
             if invoice.invoice_category in (
                 "Composition Scheme, Exempted, Nil Rated",


### PR DESCRIPTION
Fixes: https://support.frappe.io/helpdesk/tickets/41649

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Invoices now include an additional attribute for HSN sub-category in processed results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->