### PR TITLE
fix: skip setup wizard if the ERPNext setup wizard already completed

### DIFF
--- a/india_compliance/public/js/setup_wizard.js
+++ b/india_compliance/public/js/setup_wizard.js
@@ -7,6 +7,7 @@ frappe.setup.on("before_load", function () {
         frappe.boot.setup_wizard_completed_apps?.length &&
         frappe.boot.setup_wizard_completed_apps.includes("erpnext")
     ) {
+        complete_setup_wizard();
         return;
     }
 
@@ -24,6 +25,15 @@ frappe.setup.on("before_load", function () {
         }
     };
 });
+
+function complete_setup_wizard() {
+    frappe.call({
+        method: "india_compliance.setup_wizard.enable_setup_wizard_complete",
+        callback: function (r) {
+            frappe.ui.toolbar.clear_cache();
+        }
+    })
+}
 
 function toggle_india_specific_fields(country) {
     if (!country) return;

--- a/india_compliance/public/js/setup_wizard.js
+++ b/india_compliance/public/js/setup_wizard.js
@@ -2,7 +2,13 @@ frappe.require("assets/india_compliance/js/quick_entry.js");
 update_erpnext_slides_settings();
 
 frappe.setup.on("before_load", function () {
-    if (!frappe.setup.slides.length) return;
+    // if setup wizard is already completed for ERPNext, skip the setup wizard
+    if (
+        frappe.boot.setup_wizard_completed_apps?.length &&
+        frappe.boot.setup_wizard_completed_apps.includes("erpnext")
+    ) {
+        return;
+    }
 
     const first_slide = frappe.setup.slides[0];
     const _onload = first_slide.onload;

--- a/india_compliance/setup_wizard.py
+++ b/india_compliance/setup_wizard.py
@@ -16,6 +16,17 @@ from india_compliance.gst_india.utils.gstin_info import get_gstin_info
 # Setup Wizard
 
 
+@frappe.whitelist()
+def enable_setup_wizard_complete():
+    frappe.db.set_value(
+        "Installed Application",
+        {"app_name": "india_compliance"},
+        "is_setup_complete",
+        1,
+    )
+    frappe.clear_cache()
+
+
 def get_setup_wizard_stages(params=None):
     if frappe.db.exists("Company"):
         return []


### PR DESCRIPTION
Backported from https://github.com/resilient-tech/india-compliance/pull/3475 https://github.com/resilient-tech/india-compliance/pull/3476

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved the setup wizard to automatically detect and skip the setup process if ERPNext setup is already completed, preventing redundant steps for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->