### PR TITLE
fix: do not reset the filters in ReconciliationTabs

### DIFF
--- a/india_compliance/public/js/reconciliation_components/tabs.js
+++ b/india_compliance/public/js/reconciliation_components/tabs.js
@@ -15,8 +15,8 @@ reconciliation.reconciliation_tabs = class ReconciliationTabs {
         this.data = data;
         this.filtered_data = data;
 
-        // clear filters
-        this.filter_group.filter_x_button.click();
+        this.apply_filters(true);
+
         this.render_data_tables();
         this.refresh_filter_fields();
     }


### PR DESCRIPTION
fixes: #3473 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the filter clearing mechanism in reconciliation tabs to ensure filters are reset more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->