### PR TITLE
fix: do not hide otp dialog when clicked outside the dialog

### DIFF
--- a/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_beta.js
+++ b/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_beta.js
@@ -2628,6 +2628,7 @@ class FileGSTR1Dialog {
 
                 this.update_actions_for_filing(pan);
             },
+            static: true,
         });
 
         // get last used pan
@@ -2667,6 +2668,7 @@ class FileGSTR1Dialog {
             },
         });
 
+        this.filing_dialog.get_close_btn().show();
         this.filing_dialog.show();
     }
 

--- a/india_compliance/public/js/gst_api_handler.js
+++ b/india_compliance/public/js/gst_api_handler.js
@@ -48,7 +48,9 @@ Object.assign(india_compliance, {
                         },
                     });
                 },
+                static: true,
             });
+            prompt.get_close_btn().show();
             prompt.show();
         });
     },


### PR DESCRIPTION
Fixes: #3397 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Dialogs for filing GSTR-1 and entering GSTIN OTP are now static, preventing accidental closure by clicking outside the dialog.
  * Close buttons on these dialogs are now always visible for easier user access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->