### PR TITLE
Fix: fix the toggle_reverse_charge issue in without item invoice

### DIFF
--- a/india_compliance/gst_india/client_scripts/purchase_invoice.js
+++ b/india_compliance/gst_india/client_scripts/purchase_invoice.js
@@ -106,7 +106,7 @@ function toggle_reverse_charge(frm) {
     let is_read_only = 0;
     if (frm.doc.gst_category !== "Overseas") is_read_only = 0;
     // has_goods_item
-    else if (frm.doc.items.some(item => !item.gst_hsn_code.startsWith("99")))
+    else if (frm.doc.items.length > 0 && frm.doc.items.some(item => !item.gst_hsn_code.startsWith("99")))
         is_read_only = 1;
 
     frm.set_df_property("is_reverse_charge", "read_only", is_read_only);


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/ad4451ce-fe4e-4370-994b-d270aeb11354)
![image](https://github.com/user-attachments/assets/657b0d79-405b-45cd-8b47-d4fca1e99ddc)

 ### **Issue**:
An error occurred in the Purchase Invoice when selecting an Overseas supplier without adding any items.
This was due to the toggle_reverse_charge function attempting to access item properties without checking if any items exist.

### **Solution**:
Added a condition to check if the item list (frm.doc.items) has a length greater than 0 before applying logic to determine the is_reverse_charge field's read-only status.

###  **Updated Function:**

function toggle_reverse_charge(frm) {
    let is_read_only = 0;
    if (frm.doc.gst_category !== "Overseas") is_read_only = 0;
    // has_goods_item
    else if (frm.doc.items.length > 0 && frm.doc.items.some(item => !item.gst_hsn_code.startsWith("99")))
        is_read_only = 1;

    frm.set_df_property("is_reverse_charge", "read_only", is_read_only);
}
This prevents errors when no items are present and ensures proper behavior for Overseas suppliers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of reverse charge logic in purchase invoices, preventing errors when no items are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->