### PR TITLE
fix: avoid undefined gst_hsn_code check when item_code is missing

### DIFF
--- a/india_compliance/gst_india/client_scripts/purchase_invoice.js
+++ b/india_compliance/gst_india/client_scripts/purchase_invoice.js
@@ -106,7 +106,7 @@ function toggle_reverse_charge(frm) {
     let is_read_only = 0;
     if (frm.doc.gst_category !== "Overseas") is_read_only = 0;
     // has_goods_item
-    else if (frm.doc.items.length > 0 && frm.doc.items.some(item => !item.gst_hsn_code.startsWith("99")))
+    else if (frm.doc.items.length > 0 && frm.doc.items.some(item => item?.item_code && !item.gst_hsn_code.startsWith("99")))
         is_read_only = 1;
 
     frm.set_df_property("is_reverse_charge", "read_only", is_read_only);

--- a/india_compliance/gst_india/client_scripts/purchase_invoice.js
+++ b/india_compliance/gst_india/client_scripts/purchase_invoice.js
@@ -106,7 +106,7 @@ function toggle_reverse_charge(frm) {
     let is_read_only = 0;
     if (frm.doc.gst_category !== "Overseas") is_read_only = 0;
     // has_goods_item
-    else if (frm.doc.items.length > 0 && frm.doc.items.some(item => item?.item_code && !item.gst_hsn_code.startsWith("99")))
+    else if (frm.doc.items.length > 0 && frm.doc.items.some(item => item?.item_code && item?.gst_hsn_code && !item.gst_hsn_code.startsWith("99")))
         is_read_only = 1;
 
     frm.set_df_property("is_reverse_charge", "read_only", is_read_only);


### PR DESCRIPTION
Issue: Currency is not getting changed for the USD (Overseas category) supplier.

Ref: [#42620](https://support.frappe.io/helpdesk/tickets/42620)

Before:

https://github.com/user-attachments/assets/ffafe091-820a-40be-b81f-fce3aa162d59

After:

https://github.com/user-attachments/assets/e8aef3d4-85cd-4828-bee4-d4e60463e7d0

Backport needed: v15

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the handling of reverse charge logic in purchase invoices to ensure only items with defined item codes and GST codes are considered, enhancing accuracy and preventing unintended behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->