### PR TITLE
fix: handle None values in date transformation for GSTR-1 export

### DIFF
--- a/india_compliance/gst_india/doctype/gstr_1/gstr_1_export.py
+++ b/india_compliance/gst_india/doctype/gstr_1/gstr_1_export.py
@@ -284,7 +284,7 @@ class GovExcel(DataProcessor):
                 "fieldname": inv_f.DOC_DATE,
                 "data_format": {"number_format": self.DATE_FORMAT},
                 "header_format": {"width": ExcelWidth.XS.value},
-                "transform": lambda x: x.strftime("%d-%b-%y"),
+                "transform": lambda x: x.strftime("%d-%b-%y") if x else None,
             },
             {
                 "label": _(gov_xl.INVOICE_VALUE),
@@ -347,7 +347,7 @@ class GovExcel(DataProcessor):
                 "fieldname": inv_f.DOC_DATE,
                 "data_format": {"number_format": self.DATE_FORMAT},
                 "header_format": {"width": ExcelWidth.XS.value},
-                "transform": lambda x: x.strftime("%d-%b-%y"),
+                "transform": lambda x: x.strftime("%d-%b-%y") if x else None,
             },
             {
                 "label": _(gov_xl.INVOICE_VALUE),
@@ -450,7 +450,7 @@ class GovExcel(DataProcessor):
                 "fieldname": inv_f.DOC_DATE,
                 "data_format": {"number_format": self.DATE_FORMAT},
                 "header_format": {"width": ExcelWidth.XS.value},
-                "transform": lambda x: x.strftime("%d-%b-%y"),
+                "transform": lambda x: x.strftime("%d-%b-%y") if x else None,
             },
             {
                 "label": _(gov_xl.NOTE_TYPE),
@@ -517,7 +517,7 @@ class GovExcel(DataProcessor):
                 "fieldname": inv_f.DOC_DATE,
                 "data_format": {"number_format": self.DATE_FORMAT},
                 "header_format": {"width": ExcelWidth.XS.value},
-                "transform": lambda x: x.strftime("%d-%b-%y"),
+                "transform": lambda x: x.strftime("%d-%b-%y") if x else None,
             },
             {
                 "label": _(gov_xl.NOTE_TYPE),
@@ -573,7 +573,7 @@ class GovExcel(DataProcessor):
                 "fieldname": inv_f.DOC_DATE,
                 "data_format": {"number_format": self.DATE_FORMAT},
                 "header_format": {"width": ExcelWidth.XS.value},
-                "transform": lambda x: x.strftime("%d-%b-%y"),
+                "transform": lambda x: x.strftime("%d-%b-%y") if x else None,
             },
             {
                 "label": _(gov_xl.INVOICE_VALUE),
@@ -594,7 +594,7 @@ class GovExcel(DataProcessor):
                 "fieldname": inv_f.SHIPPING_BILL_DATE,
                 "data_format": {"number_format": self.DATE_FORMAT},
                 "header_format": {"width": ExcelWidth.XS.value},
-                "transform": lambda x: x.strftime("%d-%b-%y"),
+                "transform": lambda x: x.strftime("%d-%b-%y") if x else None,
             },
             {
                 "label": _(gov_xl.TAX_RATE),


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing or empty date fields during Excel export to prevent errors when dates are not provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->