### PR TITLE
fix: update vehicle and transporter info logging to show old values

### DIFF
--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -431,8 +431,8 @@ def _generate_table_rows(old_values, new_values):
         new_value = new_values.get(key)
 
         if key in DATE_FIELDS:
-            old_value = get_date_str(old_value)
-            new_value = get_date_str(new_value)
+            old_value = old_value and get_date_str(old_value)
+            new_value = new_value and get_date_str(new_value)
 
         if old_value == new_value:
             continue

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -8,6 +8,7 @@ from frappe.utils import (
     add_days,
     add_to_date,
     format_date,
+    get_date_str,
     get_datetime,
     get_datetime_str,
     get_fullname,
@@ -324,18 +325,18 @@ def log_and_process_e_waybill_cancellation(doc, values, result):
 def update_vehicle_info(*, doctype, docname, values):
     doc = load_doc(doctype, docname, "submit")
 
-    values_in_comment = {
-        "Vehicle No": doc.vehicle_no,
-        "LR No": doc.lr_no,
-        "LR Date": doc.lr_date,
-        "Mode of Transport": doc.mode_of_transport,
-        "GST Vehicle Type": doc.gst_vehicle_type,
-        # How to get previous values?
-        # "Place of Change": doc.place_of_change,
-        # "State": doc.state,
+    old_values = {
+        "vehicle_no": doc.vehicle_no,
+        "lr_no": doc.lr_no,
+        "lr_date": doc.lr_date,
+        "mode_of_transport": doc.mode_of_transport,
+        "gst_vehicle_type": doc.gst_vehicle_type,
+        "place_of_change": "-",
+        "state": "-",
     }
 
     values = frappe.parse_json(values)
+
     doc.db_set(
         {
             "vehicle_no": values.get("vehicle_no", "").replace(" ", ""),
@@ -355,12 +356,7 @@ def update_vehicle_info(*, doctype, docname, values):
         alert=True,
     )
 
-    comment = _(
-        "Vehicle Info has been updated by {user}.<br><br> Old details are: <br>"
-    ).format(user=frappe.bold(get_fullname()))
-
-    for key, value in values_in_comment.items():
-        comment += "{0}: {1} <br>".format(frappe.bold(_(key)), value or "<empty>")
+    comment = _generate_comment(old_values, values)
 
     log_and_process_e_waybill(
         doc,
@@ -374,6 +370,81 @@ def update_vehicle_info(*, doctype, docname, values):
     )
 
     return send_updated_doc(doc)
+
+
+LABEL_MAP = {
+    "vehicle_no": "Vehicle No",
+    "lr_no": "LR No",
+    "lr_date": "LR Date",
+    "mode_of_transport": "Mode of Transport",
+    "gst_vehicle_type": "GST Vehicle Type",
+    "place_of_change": "Place of Change",
+    "state": "State",
+}
+
+DATE_FIELDS = ("lr_date",)
+
+
+def _generate_comment(old_values, new_values):
+    table = _generate_table(old_values, new_values)
+
+    if not table:
+        return
+
+    return (
+        _("Vehicle Info has been updated by {user}.<br><br>").format(
+            user=frappe.bold(get_fullname())
+        )
+        + table
+    )
+
+
+def _generate_table(old_values, new_values):
+    table_rows = _generate_table_rows(old_values, new_values)
+
+    if not table_rows:
+        return
+
+    return """
+        <table class="table table-bordered">
+            <thead>
+                <tr>
+                    <th>Field</th>
+                    <th>From</th>
+                    <th>To</th>
+                </tr>
+            </thead>
+            <tbody>
+                {table_rows}
+            </tbody>
+        </table>
+    """.format(
+        table_rows=table_rows
+    )
+
+
+def _generate_table_rows(old_values, new_values):
+    table_rows = []
+
+    for key, label in LABEL_MAP.items():
+        old_value = old_values.get(key)
+        new_value = new_values.get(key)
+
+        if key in DATE_FIELDS:
+            old_value = get_date_str(old_value)
+            new_value = get_date_str(new_value)
+
+        if old_value == new_value:
+            continue
+
+        old_value = "<empty>" if old_value is None else old_value
+        new_value = "<empty>" if new_value is None else new_value
+
+        table_rows.append(
+            f"<tr><td>{frappe.bold(_(label))}</td><td>{old_value}</td><td>{new_value}</td></tr>"
+        )
+
+    return "".join(table_rows)
 
 
 def _bulk_update_transporter_in_docs(doctype, docnames, values):

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -323,6 +323,18 @@ def log_and_process_e_waybill_cancellation(doc, values, result):
 @frappe.whitelist()
 def update_vehicle_info(*, doctype, docname, values):
     doc = load_doc(doctype, docname, "submit")
+
+    values_in_comment = {
+        "Vehicle No": doc.vehicle_no,
+        "LR No": doc.lr_no,
+        "LR Date": doc.lr_date,
+        "Mode of Transport": doc.mode_of_transport,
+        "GST Vehicle Type": doc.gst_vehicle_type,
+        # How to get previous values?
+        # "Place of Change": doc.place_of_change,
+        # "State": doc.state,
+    }
+
     values = frappe.parse_json(values)
     doc.db_set(
         {
@@ -344,22 +356,11 @@ def update_vehicle_info(*, doctype, docname, values):
     )
 
     comment = _(
-        "Vehicle Info has been updated by {user}.<br><br> New details are: <br>"
+        "Vehicle Info has been updated by {user}.<br><br> Old details are: <br>"
     ).format(user=frappe.bold(get_fullname()))
 
-    values_in_comment = {
-        "Vehicle No": values.vehicle_no,
-        "LR No": values.lr_no,
-        "LR Date": values.lr_date,
-        "Mode of Transport": values.mode_of_transport,
-        "GST Vehicle Type": values.gst_vehicle_type,
-        "Place of Change": values.place_of_change,
-        "State": values.state,
-    }
-
     for key, value in values_in_comment.items():
-        if value:
-            comment += "{0}: {1} <br>".format(frappe.bold(_(key)), value)
+        comment += "{0}: {1} <br>".format(frappe.bold(_(key)), value or "<empty>")
 
     log_and_process_e_waybill(
         doc,
@@ -437,6 +438,8 @@ def _bulk_update_transporter_in_docs(doctype, docnames, values):
 @frappe.whitelist()
 def update_transporter(*, doctype, docname, values):
     doc = load_doc(doctype, docname, "submit")
+    old_transporter_id = doc.gst_transporter_id
+
     values = frappe.parse_json(values)
     data = EWaybillData(doc).get_update_transporter_data(values)
     EWaybillAPI.create(doc).update_transporter(data)
@@ -463,11 +466,11 @@ def update_transporter(*, doctype, docname, values):
     )
 
     comment = (
-        "Transporter Info has been updated by {user}. New Transporter ID is"
+        "Transporter Info has been updated by {user}. Old Transporter ID was"
         " {transporter_id}."
     ).format(
         user=frappe.bold(get_fullname()),
-        transporter_id=frappe.bold(values.gst_transporter_id),
+        transporter_id=frappe.bold(old_transporter_id or "not set"),
     )
 
     log_and_process_e_waybill(

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -537,11 +537,12 @@ def update_transporter(*, doctype, docname, values):
     )
 
     comment = (
-        "Transporter Info has been updated by {user}. Old Transporter ID was"
-        " {transporter_id}."
+        "Transporter Info has been updated by {user}. Transporter ID changed from"
+        " {old_transporter_id} to {new_transporter_id}."
     ).format(
         user=frappe.bold(get_fullname()),
-        transporter_id=frappe.bold(old_transporter_id or "not set"),
+        old_transporter_id=frappe.bold(old_transporter_id or "<empty>"),
+        new_transporter_id=frappe.bold(values.gst_transporter_id or "<empty>"),
     )
 
     log_and_process_e_waybill(

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -8,7 +8,6 @@ from frappe.utils import (
     add_days,
     add_to_date,
     format_date,
-    get_date_str,
     get_datetime,
     get_datetime_str,
     get_fullname,
@@ -47,6 +46,7 @@ from india_compliance.gst_india.utils import (
     update_onload,
 )
 from india_compliance.gst_india.utils.transaction_data import GSTTransactionData
+from india_compliance.utils.change_log_utils import create_change_log_comment
 
 #######################################################################################
 ### Manual JSON Generation for e-Waybill ##############################################
@@ -356,7 +356,26 @@ def update_vehicle_info(*, doctype, docname, values):
         alert=True,
     )
 
-    comment = _generate_comment(old_values, values)
+    # Vehicle Info update labels and date fields for change log
+    VEHICLE_INFO_LABEL_MAP = {
+        "vehicle_no": "Vehicle No",
+        "lr_no": "LR No",
+        "lr_date": "LR Date",
+        "mode_of_transport": "Mode of Transport",
+        "gst_vehicle_type": "GST Vehicle Type",
+        "place_of_change": "Place of Change",
+        "state": "State",
+    }
+
+    VEHICLE_INFO_DATE_FIELDS = ("lr_date",)
+
+    comment = create_change_log_comment(
+        old_values,
+        values,
+        field_labels=VEHICLE_INFO_LABEL_MAP,
+        date_fields=VEHICLE_INFO_DATE_FIELDS,
+        comment_prefix=_("Vehicle Info has been updated by {user}"),
+    )
 
     log_and_process_e_waybill(
         doc,
@@ -370,81 +389,6 @@ def update_vehicle_info(*, doctype, docname, values):
     )
 
     return send_updated_doc(doc)
-
-
-LABEL_MAP = {
-    "vehicle_no": "Vehicle No",
-    "lr_no": "LR No",
-    "lr_date": "LR Date",
-    "mode_of_transport": "Mode of Transport",
-    "gst_vehicle_type": "GST Vehicle Type",
-    "place_of_change": "Place of Change",
-    "state": "State",
-}
-
-DATE_FIELDS = ("lr_date",)
-
-
-def _generate_comment(old_values, new_values):
-    table = _generate_table(old_values, new_values)
-
-    if not table:
-        return
-
-    return (
-        _("Vehicle Info has been updated by {user}.<br><br>").format(
-            user=frappe.bold(get_fullname())
-        )
-        + table
-    )
-
-
-def _generate_table(old_values, new_values):
-    table_rows = _generate_table_rows(old_values, new_values)
-
-    if not table_rows:
-        return
-
-    return """
-        <table class="table table-bordered">
-            <thead>
-                <tr>
-                    <th>Field</th>
-                    <th>From</th>
-                    <th>To</th>
-                </tr>
-            </thead>
-            <tbody>
-                {table_rows}
-            </tbody>
-        </table>
-    """.format(
-        table_rows=table_rows
-    )
-
-
-def _generate_table_rows(old_values, new_values):
-    table_rows = []
-
-    for key, label in LABEL_MAP.items():
-        old_value = old_values.get(key)
-        new_value = new_values.get(key)
-
-        if key in DATE_FIELDS:
-            old_value = old_value and get_date_str(old_value)
-            new_value = new_value and get_date_str(new_value)
-
-        if old_value == new_value:
-            continue
-
-        old_value = "<empty>" if old_value is None else old_value
-        new_value = "<empty>" if new_value is None else new_value
-
-        table_rows.append(
-            f"<tr><td>{frappe.bold(_(label))}</td><td>{old_value}</td><td>{new_value}</td></tr>"
-        )
-
-    return "".join(table_rows)
 
 
 def _bulk_update_transporter_in_docs(doctype, docnames, values):

--- a/india_compliance/gst_india/utils/test_e_waybill.py
+++ b/india_compliance/gst_india/utils/test_e_waybill.py
@@ -138,7 +138,7 @@ class TestEWaybill(IntegrationTestCase):
             "<td>GJ07DL9009</td>",
             "<td>GJ07DL9001</td>",
             "<td><strong>LR Date</strong></td>",
-            "<td>2025-07-22</td>",
+            f"<td>{today()}</td>",
             "<td>&lt;empty&gt;</td>",
             "<td><strong>Place of Change</strong></td>",
             "<td>-</td>",

--- a/india_compliance/gst_india/utils/test_e_waybill.py
+++ b/india_compliance/gst_india/utils/test_e_waybill.py
@@ -179,7 +179,7 @@ class TestEWaybill(IntegrationTestCase):
             {
                 "reference_doctype": "e-Waybill Log",
                 "reference_name": transporter_data.get("request_data").get("ewbNo"),
-                "content": "Transporter Info has been updated by <strong>Administrator</strong>. New Transporter ID is <strong>05AAACG2140A1ZL</strong>.",
+                "content": "Transporter Info has been updated by <strong>Administrator</strong>. Transporter ID changed from <strong>&lt;empty&gt;</strong> to <strong>05AAACG2140A1ZL</strong>.",
             },
             frappe.get_doc(
                 "Comment",

--- a/india_compliance/gst_india/utils/test_e_waybill.py
+++ b/india_compliance/gst_india/utils/test_e_waybill.py
@@ -198,7 +198,10 @@ class TestEWaybill(IntegrationTestCase):
             {
                 "reference_doctype": "e-Waybill Log",
                 "reference_name": transporter_data.get("request_data").get("ewbNo"),
-                "content": "Transporter Info has been updated by <strong>Administrator</strong>. Transporter ID changed from <strong>&lt;empty&gt;</strong> to <strong>05AAACG2140A1ZL</strong>.",
+                "content": (
+                    "Transporter Info has been updated by <strong>Administrator</strong>. "
+                    "Transporter ID changed from <strong>&lt;empty&gt;</strong> to <strong>05AAACG2140A1ZL</strong>."
+                ),
             },
             frappe.get_doc(
                 "Comment",

--- a/india_compliance/gst_india/utils/test_e_waybill.py
+++ b/india_compliance/gst_india/utils/test_e_waybill.py
@@ -125,25 +125,44 @@ class TestEWaybill(IntegrationTestCase):
             values=frappe._dict(vehicle_data.get("values")),
         )
 
-        # assertions
-        expected_comment = "Vehicle Info has been updated by <strong>Administrator</strong>.<br><br> New details are: <br><strong>Vehicle No</strong>: GJ07DL9001 <br><strong>Mode of Transport</strong>: Road <br><strong>GST Vehicle Type</strong>: Regular <br><strong>Place of Change</strong>: Test City <br><strong>State</strong>: Gujarat <br>"
+        expected_info = [
+            "Vehicle Info has been updated by <strong>Administrator</strong>",
+            '<table class="table table-bordered">',
+            "<thead>",
+            "<th>Field</th>",
+            "<th>From</th>",
+            "<th>To</th>",
+            "</thead>",
+            "<tbody>",
+            "<td><strong>Vehicle No</strong></td>",
+            "<td>GJ07DL9009</td>",
+            "<td>GJ07DL9001</td>",
+            "<td><strong>LR Date</strong></td>",
+            "<td>2025-07-22</td>",
+            "<td>&lt;empty&gt;</td>",
+            "<td><strong>Place of Change</strong></td>",
+            "<td>-</td>",
+            "<td>Test City</td>",
+            "<td><strong>State</strong></td>",
+            "<td>Gujarat</td>",
+            "</tbody>",
+            "</table>",
+        ]
 
+        # assertions
         self.assertDocumentEqual(
             {"name": vehicle_data.get("request_data").get("ewbNo")},
             frappe.get_doc("e-Waybill Log", {"reference_name": si.name}),
         )
 
-        self.assertDocumentEqual(
-            {
-                "reference_doctype": "e-Waybill Log",
-                "reference_name": vehicle_data.get("request_data").get("ewbNo"),
-                "content": expected_comment,
-            },
-            frappe.get_doc(
-                "Comment",
-                {"reference_name": vehicle_data.get("request_data").get("ewbNo")},
-            ),
+        comment_doc = frappe.get_doc(
+            "Comment",
+            {"reference_name": vehicle_data.get("request_data").get("ewbNo")},
         )
+
+        # Test that all expected strings are present in the comment content
+        for expected_string in expected_info:
+            self.assertIn(expected_string, comment_doc.content)
 
     @responses.activate
     def test_update_transporter(self):

--- a/india_compliance/utils/change_log_utils.py
+++ b/india_compliance/utils/change_log_utils.py
@@ -1,0 +1,91 @@
+import frappe
+from frappe import _
+from frappe.utils import get_date_str, get_fullname
+
+
+def create_change_log_comment(
+    old_values,
+    new_values,
+    field_labels=None,
+    date_fields=None,
+    comment_prefix=None,
+    user=None,
+):
+    """
+    Generate an HTML comment showing field changes.
+
+    Args:
+        old_values (dict): Dictionary of old field values
+        new_values (dict): Dictionary of new field values
+        field_labels (dict): Optional mapping of field names to display labels
+        date_fields (list/tuple): Optional list of fields to format as dates
+        comment_prefix (str): Optional comment prefix (default: "Updated by {user}")
+        user (str): Optional user name (default: current user)
+
+    Returns:
+        str: HTML formatted comment or None if no changes
+    """
+    field_labels = field_labels or {}
+    date_fields = date_fields or []
+
+    # Find changed fields
+    changed_fields = []
+    all_fields = set(old_values.keys()) | set(new_values.keys())
+
+    for field in all_fields:
+        # Skip if field not in labels map when labels are provided
+        if field_labels and field not in field_labels:
+            continue
+
+        old_val, new_val = old_values.get(field), new_values.get(field)
+
+        # Format dates
+        if field in date_fields:
+            old_val = old_val and get_date_str(old_val)
+            new_val = new_val and get_date_str(new_val)
+
+        # Skip unchanged fields
+        if old_val == new_val:
+            continue
+
+        # Get display label
+        label = field_labels.get(field, field.replace("_", " ").title())
+
+        # Format values
+        old_display = "<empty>" if old_val is None else str(old_val)
+        new_display = "<empty>" if new_val is None else str(new_val)
+
+        changed_fields.append((label, old_display, new_display))
+
+    if not changed_fields:
+        return None
+
+    # Build comment
+    user = user or get_fullname()
+    prefix = comment_prefix or _("Updated by {user}")
+    comment_header = (prefix + ".<br><br>").format(user=frappe.bold(user))
+
+    # Build table
+    table_rows = "".join(
+        [
+            f"<tr><td>{frappe.bold(_(label))}</td><td>{old_val}</td><td>{new_val}</td></tr>"
+            for label, old_val, new_val in changed_fields
+        ]
+    )
+
+    table = f"""
+    <table class="table table-bordered">
+        <thead>
+            <tr>
+                <th>{_("Field")}</th>
+                <th>{_("From")}</th>
+                <th>{_("To")}</th>
+            </tr>
+        </thead>
+        <tbody>
+            {table_rows}
+        </tbody>
+    </table>
+    """
+
+    return comment_header + table


### PR DESCRIPTION
<img width="706" height="348" alt="image" src="https://github.com/user-attachments/assets/3b34bd52-1587-46cc-b4f5-8a7df81e4c47" />


<img width="659" height="134" alt="image" src="https://github.com/user-attachments/assets/bc252b71-6cdb-4390-86d4-2ac191a1e865" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Enhanced update comments for vehicle and transporter information by showing changes with old and new values in a clear, structured table format.
* **Tests**
  * Improved test validations to verify the detailed comment format reflecting specific changes in transporter and vehicle details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->