### PR TITLE
fix: ignore links while saving GST Return Log; as integration requests could be deleted

### DIFF
--- a/india_compliance/gst_india/doctype/gstr_action/gstr_action.py
+++ b/india_compliance/gst_india/doctype/gstr_action/gstr_action.py
@@ -24,4 +24,6 @@ def set_gstr_actions(doc, request_type, token, request_id, status=None):
         row["status"] = status
 
     doc.append("actions", row)
+    # Integration Requests may be cleared by a scheduler job
+    doc.flags.ignore_links = True
     doc.save()


### PR DESCRIPTION
closes: #3533

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved saving process for certain documents by allowing them to be saved without link validation, enhancing compatibility with integration requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->