### PR TITLE
fix: create custom fields for Healthcare doctypes

### DIFF
--- a/india_compliance/gst_india/constants/custom_fields.py
+++ b/india_compliance/gst_india/constants/custom_fields.py
@@ -1335,6 +1335,80 @@ EDUCATION_CUSTOM_FIELDS = {
     ]
 }
 
+HEALTHCARE_CUSTOM_FIELDS = {
+    "Clinical Procedure Template": [
+        {
+            "fieldname": "gst_hsn_code",
+            "label": "HSN/SAC",
+            "fieldtype": "Link",
+            "options": "GST HSN Code",
+            "insert_after": "item_group",
+            "reqd": 1,
+            "read_only_depends_on": "eval:doc.link_existing_item",
+            "description": "You can search code by the description of the category.",
+        }
+    ],
+    "Observation Template": [
+        {
+            "fieldname": "gst_hsn_code",
+            "label": "HSN/SAC",
+            "fieldtype": "Link",
+            "options": "GST HSN Code",
+            "insert_after": "item_group",
+            "mandatory_depends_on": "eval:doc.is_billable;",
+            "depends_on": "eval:doc.is_billable;",
+            "read_only_depends_on": "eval:doc.link_existing_item",
+            "description": "You can search code by the description of the category.",
+        }
+    ],
+    "Therapy Type": [
+        {
+            "fieldname": "gst_hsn_code",
+            "label": "HSN/SAC",
+            "fieldtype": "Link",
+            "options": "GST HSN Code",
+            "insert_after": "item_group",
+            "reqd": 1,
+            "description": "You can search code by the description of the category.",
+        }
+    ],
+    "Healthcare Service Unit Type": [
+        {
+            "fieldname": "gst_hsn_code",
+            "label": "HSN/SAC",
+            "fieldtype": "Link",
+            "options": "GST HSN Code",
+            "insert_after": "item_group",
+            "mandatory_depends_on": "eval:doc.is_billable;",
+            "depends_on": "eval:doc.is_billable;",
+            "description": "You can search code by the description of the category.",
+        }
+    ],
+    "Therapy Plan Template": [
+        {
+            "fieldname": "gst_hsn_code",
+            "label": "HSN/SAC",
+            "fieldtype": "Link",
+            "options": "GST HSN Code",
+            "insert_after": "item_group",
+            "reqd": 1,
+            "read_only_depends_on": "eval:doc.link_existing_item",
+            "description": "You can search code by the description of the category.",
+        }
+    ],
+    "Medication Linked Item": [
+        {
+            "fieldname": "gst_hsn_code",
+            "label": "HSN/SAC",
+            "fieldtype": "Link",
+            "options": "GST HSN Code",
+            "insert_after": "item_group",
+            "in_list_view": 1,
+            "description": "You can search code by the description of the category.",
+        }
+    ],
+}
+
 reverse_charge_field = {
     "fieldname": "is_reverse_charge",
     "label": "Is Reverse Charge",

--- a/india_compliance/gst_india/constants/custom_fields.py
+++ b/india_compliance/gst_india/constants/custom_fields.py
@@ -1322,89 +1322,58 @@ HRMS_CUSTOM_FIELDS = {
     ],
 }
 
+HSN_CODE_FIELD = {
+    "fieldname": "gst_hsn_code",
+    "label": "HSN/SAC",
+    "fieldtype": "Link",
+    "options": "GST HSN Code",
+    "description": "You can search code by the description of the category.",
+}
+
 EDUCATION_CUSTOM_FIELDS = {
-    "Fee Category": [
-        {
-            "fieldname": "gst_hsn_code",
-            "label": "HSN/SAC",
-            "fieldtype": "Link",
-            "options": "GST HSN Code",
-            "insert_after": "description",
-            "description": "You can search code by the description of the category.",
-        }
-    ]
+    "Fee Category": [{**HSN_CODE_FIELD, "insert_after": "description"}]
 }
 
 HEALTHCARE_CUSTOM_FIELDS = {
     "Clinical Procedure Template": [
         {
-            "fieldname": "gst_hsn_code",
-            "label": "HSN/SAC",
-            "fieldtype": "Link",
-            "options": "GST HSN Code",
+            **HSN_CODE_FIELD,
             "insert_after": "item_group",
             "reqd": 1,
             "read_only_depends_on": "eval:doc.link_existing_item",
-            "description": "You can search code by the description of the category.",
         }
     ],
     "Observation Template": [
         {
-            "fieldname": "gst_hsn_code",
-            "label": "HSN/SAC",
-            "fieldtype": "Link",
-            "options": "GST HSN Code",
+            **HSN_CODE_FIELD,
             "insert_after": "item_group",
             "mandatory_depends_on": "eval:doc.is_billable;",
             "depends_on": "eval:doc.is_billable;",
             "read_only_depends_on": "eval:doc.link_existing_item",
-            "description": "You can search code by the description of the category.",
         }
     ],
-    "Therapy Type": [
-        {
-            "fieldname": "gst_hsn_code",
-            "label": "HSN/SAC",
-            "fieldtype": "Link",
-            "options": "GST HSN Code",
-            "insert_after": "item_group",
-            "reqd": 1,
-            "description": "You can search code by the description of the category.",
-        }
-    ],
+    "Therapy Type": [{**HSN_CODE_FIELD, "insert_after": "item_group", "reqd": 1}],
     "Healthcare Service Unit Type": [
         {
-            "fieldname": "gst_hsn_code",
-            "label": "HSN/SAC",
-            "fieldtype": "Link",
-            "options": "GST HSN Code",
+            **HSN_CODE_FIELD,
             "insert_after": "item_group",
             "mandatory_depends_on": "eval:doc.is_billable;",
             "depends_on": "eval:doc.is_billable;",
-            "description": "You can search code by the description of the category.",
         }
     ],
     "Therapy Plan Template": [
         {
-            "fieldname": "gst_hsn_code",
-            "label": "HSN/SAC",
-            "fieldtype": "Link",
-            "options": "GST HSN Code",
+            **HSN_CODE_FIELD,
             "insert_after": "item_group",
             "reqd": 1,
             "read_only_depends_on": "eval:doc.link_existing_item",
-            "description": "You can search code by the description of the category.",
         }
     ],
     "Medication Linked Item": [
         {
-            "fieldname": "gst_hsn_code",
-            "label": "HSN/SAC",
-            "fieldtype": "Link",
-            "options": "GST HSN Code",
+            **HSN_CODE_FIELD,
             "insert_after": "item_group",
             "in_list_view": 1,
-            "description": "You can search code by the description of the category.",
         }
     ],
 }

--- a/india_compliance/gst_india/overrides/cross_app_hsn_code.py
+++ b/india_compliance/gst_india/overrides/cross_app_hsn_code.py
@@ -3,4 +3,4 @@ import frappe
 
 def before_update(doc, method=None):
     if doc.gst_hsn_code:
-        frappe.flags.category_hsn_code = doc.gst_hsn_code
+        frappe.flags.cross_app_hsn_code = doc.gst_hsn_code

--- a/india_compliance/gst_india/overrides/item.py
+++ b/india_compliance/gst_india/overrides/item.py
@@ -13,13 +13,13 @@ def validate(doc, method=None):
 
 def update_hsn_code(doc):
     """
-    Update HSN Code from Fee Category (education)
+    Update HSN Code from Fee Category (education), Healthcare Services (healthcare)
     """
-    if not frappe.flags.category_hsn_code:
+    if not frappe.flags.cross_app_hsn_code:
         return
 
-    doc.gst_hsn_code = frappe.flags.category_hsn_code
-    del frappe.flags.category_hsn_code
+    doc.gst_hsn_code = frappe.flags.cross_app_hsn_code
+    del frappe.flags.cross_app_hsn_code
 
 
 def validate_hsn_code(doc):

--- a/india_compliance/gst_india/setup/__init__.py
+++ b/india_compliance/gst_india/setup/__init__.py
@@ -12,6 +12,7 @@ from india_compliance.gst_india.constants.custom_fields import (
     E_INVOICE_FIELDS,
     E_WAYBILL_FIELDS,
     EDUCATION_CUSTOM_FIELDS,
+    HEALTHCARE_CUSTOM_FIELDS,
     HRMS_CUSTOM_FIELDS,
     SALES_REVERSE_CHARGE_FIELDS,
 )
@@ -52,6 +53,9 @@ def create_custom_fields():
     if "education" in installed_apps:
         create_education_custom_fields()
 
+    if "healthcare" in installed_apps:
+        create_healthcare_custom_fields()
+
 
 def create_hrms_custom_fields():
     _create_custom_fields(HRMS_CUSTOM_FIELDS, ignore_validate=True)
@@ -59,6 +63,10 @@ def create_hrms_custom_fields():
 
 def create_education_custom_fields():
     _create_custom_fields(EDUCATION_CUSTOM_FIELDS, ignore_validate=True)
+
+
+def create_healthcare_custom_fields():
+    _create_custom_fields(HEALTHCARE_CUSTOM_FIELDS, ignore_validate=True)
 
 
 def create_accounting_dimension_fields():

--- a/india_compliance/gst_india/uninstall.py
+++ b/india_compliance/gst_india/uninstall.py
@@ -2,8 +2,8 @@ import frappe
 
 from india_compliance.gst_india.setup import (
     EDUCATION_CUSTOM_FIELDS,
-    HRMS_CUSTOM_FIELDS,
     HEALTHCARE_CUSTOM_FIELDS,
+    HRMS_CUSTOM_FIELDS,
     ITEM_VARIANT_FIELDNAMES,
     get_all_custom_fields,
     get_property_setters,

--- a/india_compliance/gst_india/uninstall.py
+++ b/india_compliance/gst_india/uninstall.py
@@ -3,6 +3,7 @@ import frappe
 from india_compliance.gst_india.setup import (
     EDUCATION_CUSTOM_FIELDS,
     HRMS_CUSTOM_FIELDS,
+    HEALTHCARE_CUSTOM_FIELDS,
     ITEM_VARIANT_FIELDNAMES,
     get_all_custom_fields,
     get_property_setters,
@@ -14,6 +15,7 @@ def before_uninstall():
     delete_custom_fields(get_all_custom_fields())
     delete_hrms_custom_fields()
     delete_education_custom_fields()
+    delete_healthcare_custom_fields()
     delete_property_setters()
     delete_accounting_dimension_fields()
     remove_fields_from_item_variant_settings()
@@ -25,6 +27,10 @@ def delete_hrms_custom_fields():
 
 def delete_education_custom_fields():
     delete_custom_fields(EDUCATION_CUSTOM_FIELDS)
+
+
+def delete_healthcare_custom_fields():
+    delete_custom_fields(HEALTHCARE_CUSTOM_FIELDS)
 
 
 def delete_property_setters():

--- a/india_compliance/hooks.py
+++ b/india_compliance/hooks.py
@@ -345,8 +345,28 @@ doc_events = {
         "on_trash": "india_compliance.audit_trail.overrides.version.on_trash",
     },
     "Fee Category": {
-        "before_insert": "india_compliance.gst_india.overrides.fee_category.before_update",
-        "before_validate": "india_compliance.gst_india.overrides.fee_category.before_update",
+        "before_insert": "india_compliance.gst_india.overrides.cross_app_hsn_code.before_update",
+        "before_validate": "india_compliance.gst_india.overrides.cross_app_hsn_code.before_update",
+    },
+    "Clinical Procedure Template": {
+        "before_insert": "india_compliance.gst_india.overrides.cross_app_hsn_code.before_update",
+        "before_validate": "india_compliance.gst_india.overrides.cross_app_hsn_code.before_update",
+    },
+    "Observation Template": {
+        "before_insert": "india_compliance.gst_india.overrides.cross_app_hsn_code.before_update",
+        "before_validate": "india_compliance.gst_india.overrides.cross_app_hsn_code.before_update",
+    },
+    "Therapy Type": {
+        "before_insert": "india_compliance.gst_india.overrides.cross_app_hsn_code.before_update",
+        "before_validate": "india_compliance.gst_india.overrides.cross_app_hsn_code.before_update",
+    },
+    "Healthcare Service Unit Type": {
+        "before_insert": "india_compliance.gst_india.overrides.cross_app_hsn_code.before_update",
+        "before_validate": "india_compliance.gst_india.overrides.cross_app_hsn_code.before_update",
+    },
+    "Therapy Plan Template": {
+        "before_insert": "india_compliance.gst_india.overrides.cross_app_hsn_code.before_update",
+        "before_validate": "india_compliance.gst_india.overrides.cross_app_hsn_code.before_update",
     },
 }
 

--- a/india_compliance/hooks.py
+++ b/india_compliance/hooks.py
@@ -344,27 +344,16 @@ doc_events = {
         "validate": "india_compliance.audit_trail.overrides.version.validate",
         "on_trash": "india_compliance.audit_trail.overrides.version.on_trash",
     },
-    "Fee Category": {
-        "before_insert": "india_compliance.gst_india.overrides.cross_app_hsn_code.before_update",
-        "before_validate": "india_compliance.gst_india.overrides.cross_app_hsn_code.before_update",
-    },
-    "Clinical Procedure Template": {
-        "before_insert": "india_compliance.gst_india.overrides.cross_app_hsn_code.before_update",
-        "before_validate": "india_compliance.gst_india.overrides.cross_app_hsn_code.before_update",
-    },
-    "Observation Template": {
-        "before_insert": "india_compliance.gst_india.overrides.cross_app_hsn_code.before_update",
-        "before_validate": "india_compliance.gst_india.overrides.cross_app_hsn_code.before_update",
-    },
-    "Therapy Type": {
-        "before_insert": "india_compliance.gst_india.overrides.cross_app_hsn_code.before_update",
-        "before_validate": "india_compliance.gst_india.overrides.cross_app_hsn_code.before_update",
-    },
-    "Healthcare Service Unit Type": {
-        "before_insert": "india_compliance.gst_india.overrides.cross_app_hsn_code.before_update",
-        "before_validate": "india_compliance.gst_india.overrides.cross_app_hsn_code.before_update",
-    },
-    "Therapy Plan Template": {
+    # Update HSN Code from other doctypes to Item
+    (
+        "Fee Category",
+        "Clinical Procedure Template",
+        "Observation Template",
+        "Therapy Type",
+        "Healthcare Service Unit Type",
+        "Therapy Plan Template",
+        "Medication Linked Item",
+    ): {
         "before_insert": "india_compliance.gst_india.overrides.cross_app_hsn_code.before_update",
         "before_validate": "india_compliance.gst_india.overrides.cross_app_hsn_code.before_update",
     },

--- a/india_compliance/install.py
+++ b/india_compliance/install.py
@@ -7,8 +7,8 @@ from india_compliance.gst_india.constants import BUG_REPORT_URL
 from india_compliance.gst_india.setup import after_install as setup_gst
 from india_compliance.gst_india.setup import (
     create_education_custom_fields,
-    create_hrms_custom_fields,
     create_healthcare_custom_fields,
+    create_hrms_custom_fields,
 )
 from india_compliance.income_tax_india.setup import after_install as setup_income_tax
 

--- a/india_compliance/install.py
+++ b/india_compliance/install.py
@@ -8,6 +8,7 @@ from india_compliance.gst_india.setup import after_install as setup_gst
 from india_compliance.gst_india.setup import (
     create_education_custom_fields,
     create_hrms_custom_fields,
+    create_healthcare_custom_fields,
 )
 from india_compliance.income_tax_india.setup import after_install as setup_income_tax
 
@@ -112,3 +113,6 @@ def after_app_install(app_name):
 
     if app_name == "education":
         create_education_custom_fields()
+
+    if app_name == "healthcare":
+        create_healthcare_custom_fields()

--- a/india_compliance/patches.txt
+++ b/india_compliance/patches.txt
@@ -4,7 +4,7 @@ india_compliance.patches.v15.remove_duplicate_web_template
 
 [post_model_sync]
 india_compliance.patches.v14.set_default_for_overridden_accounts_setting
-execute:from india_compliance.gst_india.setup import create_custom_fields; create_custom_fields() #63
+execute:from india_compliance.gst_india.setup import create_custom_fields; create_custom_fields() #64
 execute:from india_compliance.gst_india.setup import create_property_setters; create_property_setters() #11
 execute:from india_compliance.income_tax_india.setup import create_custom_fields; create_custom_fields() #4
 india_compliance.patches.post_install.remove_old_fields #2

--- a/india_compliance/uninstall.py
+++ b/india_compliance/uninstall.py
@@ -5,6 +5,7 @@ from india_compliance.gst_india.uninstall import before_uninstall as remove_gst
 from india_compliance.gst_india.uninstall import (
     delete_education_custom_fields,
     delete_hrms_custom_fields,
+    delete_healthcare_custom_fields,
 )
 from india_compliance.income_tax_india.uninstall import (
     before_uninstall as remove_income_tax,
@@ -37,3 +38,6 @@ def before_app_uninstall(app_name):
 
     if app_name == "education":
         delete_education_custom_fields()
+
+    if app_name == "healthcare":
+        delete_healthcare_custom_fields()

--- a/india_compliance/uninstall.py
+++ b/india_compliance/uninstall.py
@@ -4,8 +4,8 @@ from india_compliance.gst_india.constants import BUG_REPORT_URL
 from india_compliance.gst_india.uninstall import before_uninstall as remove_gst
 from india_compliance.gst_india.uninstall import (
     delete_education_custom_fields,
-    delete_hrms_custom_fields,
     delete_healthcare_custom_fields,
+    delete_hrms_custom_fields,
 )
 from india_compliance.income_tax_india.uninstall import (
     before_uninstall as remove_income_tax,


### PR DESCRIPTION
Issue:
Healthcare doctypes such as `Clinical Procedure Template`, `Observation Template`, `Therapy Type`, `Therapy Plan Template`, `Healthcare Service Unit Type` and `Medication` can be linked to the Item master.

However, when the India Compliance app is installed, these templates fail to save due to a mandatory field validation error.
This prevents the creation or update of healthcare doctypes that reference Items.

<img width="1905" height="704" alt="Screenshot from 2025-07-28 07-45-43" src="https://github.com/user-attachments/assets/db89e9c7-8f2c-4d2c-acaa-4031253f46f6" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GST HSN code custom fields for multiple healthcare-related forms, enabling category-based code search.
  * Extended setup and installation to support automatic creation of healthcare-specific custom fields when the healthcare app is installed.
  * Enhanced uninstall procedures to remove healthcare custom fields when the healthcare app is uninstalled.

* **Bug Fixes**
  * Updated internal handling to ensure HSN codes are correctly assigned and updated across both education and healthcare modules.

* **Chores**
  * Updated system hooks to apply HSN code logic to additional healthcare forms.
  * Incremented patch sequence for custom field creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->