### PR TITLE
fix: handle response type as list in _make_request method of StandardEWaybillAPI

### DIFF
--- a/india_compliance/gst_india/api_classes/nic/e_waybill.py
+++ b/india_compliance/gst_india/api_classes/nic/e_waybill.py
@@ -167,6 +167,9 @@ class StandardEWaybillAPI(EWaybillAPI):
     def _make_request(self, *args, **kwargs):
         response = super()._make_request(*args, **kwargs)
 
+        if isinstance(response, list | tuple):
+            return response
+
         # Invalid Token
         if response.error_code == "238":
             self.auth_token = None


### PR DESCRIPTION
closes: #3564 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request handling to correctly process responses that are lists or tuples, ensuring smoother and more reliable API interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->