### PR TITLE
fix: add option to exclude ISD in get_gstin_list function

### DIFF
--- a/india_compliance/gst_india/doctype/bill_of_entry/bill_of_entry.js
+++ b/india_compliance/gst_india/doctype/bill_of_entry/bill_of_entry.js
@@ -69,7 +69,7 @@ frappe.ui.form.on("Bill of Entry", {
             return;
         }
 
-        const options = await india_compliance.set_gstin_options(frm);
+        const options = await india_compliance.set_gstin_options(frm, false, true);
         frm.set_value("company_gstin", options[0]);
 
         const { message } = await frappe.db.get_value("Company", frm.doc.company, [

--- a/india_compliance/gst_india/doctype/gst_invoice_management_system/gst_invoice_management_system.js
+++ b/india_compliance/gst_india/doctype/gst_invoice_management_system/gst_invoice_management_system.js
@@ -54,7 +54,7 @@ frappe.ui.form.on(DOCTYPE, {
     async company(frm) {
         render_empty_state(frm);
         if (!frm.doc.company) return;
-        const options = await india_compliance.set_gstin_options(frm);
+        const options = await india_compliance.set_gstin_options(frm, false, true);
         frm.set_value("company_gstin", options[0]);
 
         set_period_options(frm);

--- a/india_compliance/gst_india/doctype/gstr_1/gstr_1.js
+++ b/india_compliance/gst_india/doctype/gstr_1/gstr_1.js
@@ -3113,7 +3113,7 @@ async function set_default_company_gstin(frm) {
 
     const { message: gstin_list } = await frappe.call(
         "india_compliance.gst_india.utils.get_gstin_list",
-        { party: company }
+        { party: company, exclude_isd: true }
     );
 
     if (gstin_list && gstin_list.length) {

--- a/india_compliance/gst_india/doctype/gstr_1/gstr_1.js
+++ b/india_compliance/gst_india/doctype/gstr_1/gstr_1.js
@@ -200,7 +200,7 @@ frappe.ui.form.on(DOCTYPE, {
         render_empty_state(frm);
 
         if (!frm.doc.company) return;
-        const options = await india_compliance.set_gstin_options(frm);
+        const options = await india_compliance.set_gstin_options(frm, false, true);
 
         frm.set_value("company_gstin", options[0]);
     },

--- a/india_compliance/gst_india/doctype/gstr_3b_report/gstr_3b_report.js
+++ b/india_compliance/gst_india/doctype/gstr_3b_report/gstr_3b_report.js
@@ -10,7 +10,7 @@ frappe.ui.form.on("GSTR 3B Report", {
         set_options_for_year_month(frm);
 
         if (frm.doc.company)
-            india_compliance.set_gstin_options(frm).then(options => {
+            india_compliance.set_gstin_options(frm, false, true).then(options => {
                 frm.set_value("company_gstin", options[0]);
             });
 
@@ -97,7 +97,7 @@ frappe.ui.form.on("GSTR 3B Report", {
             return;
         }
 
-        const options = await india_compliance.set_gstin_options(frm);
+        const options = await india_compliance.set_gstin_options(frm, false, true);
         frm.set_value("company_gstin", options[0]);
     },
 });

--- a/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.js
+++ b/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.js
@@ -94,7 +94,7 @@ frappe.ui.form.on(DOCTYPE, {
     async company(frm) {
         render_empty_state(frm);
         if (!frm.doc.company) return;
-        const options = await india_compliance.set_gstin_options(frm, true);
+        const options = await india_compliance.set_gstin_options(frm, true, true);
 
         frm.set_value("company_gstin", options[0]);
     },

--- a/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.js
+++ b/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.js
@@ -1094,7 +1094,7 @@ class ImportDialog {
                 get_query: async () => {
                     let { message: gstin_list } = await frappe.call({
                         method: "india_compliance.gst_india.utils.get_gstin_list",
-                        args: { party: this.frm.doc.company },
+                        args: { party: this.frm.doc.company, exclude_isd: true },
                     });
 
                     gstin_list.unshift("All");

--- a/india_compliance/gst_india/utils/__init__.py
+++ b/india_compliance/gst_india/utils/__init__.py
@@ -92,19 +92,24 @@ def send_updated_doc(doc, set_docinfo=False):
 
 
 @frappe.whitelist()
-def get_gstin_list(party, party_type="Company"):
+def get_gstin_list(party, party_type="Company", include_isd=False):
     """
     Returns a list the party's GSTINs.
     """
     frappe.has_permission(party_type, doc=party, throw=True)
 
+    filters = {
+        "link_doctype": party_type,
+        "link_name": party,
+        "gstin": ("is", "set"),
+    }
+
+    if not include_isd:
+        filters.update({"gst_category": ["!=", "Input Service Distributor"]})
+
     gstin_list = frappe.get_all(
         "Address",
-        filters={
-            "link_doctype": party_type,
-            "link_name": party,
-            "gstin": ("is", "set"),
-        },
+        filters=filters,
         pluck="gstin",
         distinct=True,
     )

--- a/india_compliance/gst_india/utils/__init__.py
+++ b/india_compliance/gst_india/utils/__init__.py
@@ -92,7 +92,7 @@ def send_updated_doc(doc, set_docinfo=False):
 
 
 @frappe.whitelist()
-def get_gstin_list(party, party_type="Company", include_isd=False):
+def get_gstin_list(party, party_type="Company", exclude_isd=False):
     """
     Returns a list the party's GSTINs.
     """
@@ -104,7 +104,7 @@ def get_gstin_list(party, party_type="Company", include_isd=False):
         "gstin": ("is", "set"),
     }
 
-    if not include_isd:
+    if exclude_isd:
         filters.update({"gst_category": ["!=", "Input Service Distributor"]})
 
     gstin_list = frappe.get_all(

--- a/india_compliance/gst_india/utils/__init__.py
+++ b/india_compliance/gst_india/utils/__init__.py
@@ -92,7 +92,7 @@ def send_updated_doc(doc, set_docinfo=False):
 
 
 @frappe.whitelist()
-def get_gstin_list(party, party_type="Company", exclude_isd=False):
+def get_gstin_list(party: str, party_type: str = "Company", exclude_isd: bool = False):
     """
     Returns a list the party's GSTINs.
     """

--- a/india_compliance/public/js/components/set_gstin_options.js
+++ b/india_compliance/public/js/components/set_gstin_options.js
@@ -3,7 +3,7 @@ frappe.provide("india_compliance");
 india_compliance.set_gstin_options = async function (
     frm,
     show_all_option = false,
-    exclude_isd = true
+    exclude_isd = false
 ) {
     const { query, params } = india_compliance.get_gstin_query(
         frm.doc.company,

--- a/india_compliance/public/js/components/set_gstin_options.js
+++ b/india_compliance/public/js/components/set_gstin_options.js
@@ -1,7 +1,15 @@
 frappe.provide("india_compliance");
 
-india_compliance.set_gstin_options = async function (frm, show_all_option = false) {
-    const { query, params } = india_compliance.get_gstin_query(frm.doc.company);
+india_compliance.set_gstin_options = async function (
+    frm,
+    show_all_option = false,
+    exclude_isd = true
+) {
+    const { query, params } = india_compliance.get_gstin_query(
+        frm.doc.company,
+        "Company",
+        exclude_isd
+    );
     const { message } = await frappe.call({
         method: query,
         args: params,

--- a/india_compliance/public/js/utils.js
+++ b/india_compliance/public/js/utils.js
@@ -70,7 +70,7 @@ Object.assign(india_compliance, {
         return `${month}${year}`;
     },
 
-    get_gstin_query(party, party_type = "Company") {
+    get_gstin_query(party, party_type = "Company", exclude_isd = false) {
         if (!party) {
             frappe.show_alert({
                 message: __("Please select {0} to get GSTIN options", [__(party_type)]),
@@ -81,7 +81,7 @@ Object.assign(india_compliance, {
 
         return {
             query: "india_compliance.gst_india.utils.get_gstin_list",
-            params: { party, party_type },
+            params: { party, party_type, exclude_isd },
         };
     },
 


### PR DESCRIPTION
closes: #3538

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to include or exclude "Input Service Distributor" (ISD) GSTINs when retrieving a party's GSTIN list; UI components can now request ISD exclusion which may change default GSTIN selection.
* **Refactor**
  * Unified GSTIN filtering and query parameters across server and UI helpers; GSTIN option helpers now accept the ISD exclude flag for consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->