### PR TITLE
feat: add support for auto-cancellation of e-Waybill for certain document type

### DIFF
--- a/india_compliance/gst_india/doctype/gst_settings/gst_settings.json
+++ b/india_compliance/gst_india/doctype/gst_settings/gst_settings.json
@@ -632,10 +632,10 @@
   {
    "default": "0",
    "depends_on": "eval: doc.enable_e_waybill",
-   "description": "e-Waybill will be automatically cancelled after Sales Invoice cancellation if possible",
+   "description": "e-Waybill will be automatically cancelled after Sales Invoice, Delivery Note, Purchase Invoice, Purchase Receipt, Stock Entry and Subcontracting Receipt cancellation if possible",
    "fieldname": "auto_cancel_e_waybill",
    "fieldtype": "Check",
-   "label": "Automatically Cancel e-Waybill on Invoice Cancellation",
+   "label": "Automatically Cancel e-Waybill on Cancellation",
    "read_only_depends_on": "eval: doc.enable_e_invoice"
   },
   {

--- a/india_compliance/gst_india/overrides/delivery_note.py
+++ b/india_compliance/gst_india/overrides/delivery_note.py
@@ -17,14 +17,12 @@ def onload(doc, method=None):
 
     gst_settings = frappe.get_cached_doc("GST Settings")
 
-    if not (
+    if (
         is_api_enabled(gst_settings)
         and gst_settings.enable_e_waybill
         and gst_settings.enable_e_waybill_from_dn
+        and (e_waybill_info := get_e_waybill_info(doc))
     ):
-        return
-
-    if e_waybill_info := get_e_waybill_info(doc):
         doc.set_onload("e_waybill_info", e_waybill_info)
 
 

--- a/india_compliance/gst_india/overrides/delivery_note.py
+++ b/india_compliance/gst_india/overrides/delivery_note.py
@@ -24,7 +24,8 @@ def onload(doc, method=None):
     ):
         return
 
-    doc.set_onload("e_waybill_info", get_e_waybill_info(doc))
+    if e_waybill_info := get_e_waybill_info(doc):
+        doc.set_onload("e_waybill_info", e_waybill_info)
 
 
 def before_cancel(doc, method=None):

--- a/india_compliance/gst_india/overrides/delivery_note.py
+++ b/india_compliance/gst_india/overrides/delivery_note.py
@@ -1,10 +1,14 @@
 import frappe
+from frappe.desk.form.load import run_onload
 
 from india_compliance.gst_india.overrides.sales_invoice import (
     update_dashboard_with_gst_logs,
 )
 from india_compliance.gst_india.utils import is_api_enabled
-from india_compliance.gst_india.utils.e_waybill import get_e_waybill_info
+from india_compliance.gst_india.utils.e_waybill import (
+    auto_cancel_e_waybill,
+    get_e_waybill_info,
+)
 
 
 def onload(doc, method=None):
@@ -21,6 +25,16 @@ def onload(doc, method=None):
         return
 
     doc.set_onload("e_waybill_info", get_e_waybill_info(doc))
+
+
+def before_cancel(doc, method=None):
+    run_onload(doc)
+    gst_settings = frappe.get_cached_doc("GST Settings")
+
+    if not is_api_enabled(gst_settings):
+        return
+
+    auto_cancel_e_waybill(doc, gst_settings=gst_settings)
 
 
 def get_dashboard_data(data):

--- a/india_compliance/gst_india/overrides/delivery_note.py
+++ b/india_compliance/gst_india/overrides/delivery_note.py
@@ -1,14 +1,10 @@
 import frappe
-from frappe.desk.form.load import run_onload
 
 from india_compliance.gst_india.overrides.sales_invoice import (
     update_dashboard_with_gst_logs,
 )
 from india_compliance.gst_india.utils import is_api_enabled
-from india_compliance.gst_india.utils.e_waybill import (
-    auto_cancel_e_waybill,
-    get_e_waybill_info,
-)
+from india_compliance.gst_india.utils.e_waybill import get_e_waybill_info
 
 
 def onload(doc, method=None):
@@ -24,16 +20,6 @@ def onload(doc, method=None):
         and (e_waybill_info := get_e_waybill_info(doc))
     ):
         doc.set_onload("e_waybill_info", e_waybill_info)
-
-
-def before_cancel(doc, method=None):
-    run_onload(doc)
-    gst_settings = frappe.get_cached_doc("GST Settings")
-
-    if not is_api_enabled(gst_settings):
-        return
-
-    auto_cancel_e_waybill(doc, gst_settings=gst_settings)
 
 
 def get_dashboard_data(data):

--- a/india_compliance/gst_india/overrides/delivery_note.py
+++ b/india_compliance/gst_india/overrides/delivery_note.py
@@ -16,7 +16,9 @@ def onload(doc, method=None):
     if (
         is_api_enabled(gst_settings)
         and gst_settings.enable_e_waybill
-        and gst_settings.enable_e_waybill_from_dn
+        and (
+            gst_settings.enable_e_waybill_from_dn or gst_settings.auto_cancel_e_waybill
+        )
         and (e_waybill_info := get_e_waybill_info(doc))
     ):
         doc.set_onload("e_waybill_info", e_waybill_info)

--- a/india_compliance/gst_india/overrides/purchase_invoice.py
+++ b/india_compliance/gst_india/overrides/purchase_invoice.py
@@ -37,7 +37,6 @@ def onload(doc, method=None):
     if (
         gst_settings.enable_e_waybill
         and gst_settings.enable_e_waybill_from_pi
-        and doc.ewaybill
         and (e_waybill_info := get_e_waybill_info(doc))
     ):
         doc.set_onload("e_waybill_info", e_waybill_info)

--- a/india_compliance/gst_india/overrides/purchase_invoice.py
+++ b/india_compliance/gst_india/overrides/purchase_invoice.py
@@ -41,8 +41,9 @@ def onload(doc, method=None):
         gst_settings.enable_e_waybill
         and gst_settings.enable_e_waybill_from_pi
         and doc.ewaybill
+        and (e_waybill_info := get_e_waybill_info(doc))
     ):
-        doc.set_onload("e_waybill_info", get_e_waybill_info(doc))
+        doc.set_onload("e_waybill_info", e_waybill_info)
 
 
 def validate(doc, method=None):

--- a/india_compliance/gst_india/overrides/purchase_invoice.py
+++ b/india_compliance/gst_india/overrides/purchase_invoice.py
@@ -1,5 +1,6 @@
 import frappe
 from frappe import _
+from frappe.desk.form.load import run_onload
 from frappe.model.meta import get_field_precision
 from frappe.utils import flt
 
@@ -12,7 +13,10 @@ from india_compliance.gst_india.overrides.transaction import (
     validate_transaction,
 )
 from india_compliance.gst_india.utils import is_api_enabled, validate_invoice_number
-from india_compliance.gst_india.utils.e_waybill import get_e_waybill_info
+from india_compliance.gst_india.utils.e_waybill import (
+    auto_cancel_e_waybill,
+    get_e_waybill_info,
+)
 
 
 def onload(doc, method=None):
@@ -56,6 +60,16 @@ def validate(doc, method=None):
     validate_with_inward_supply(doc)
     set_reconciliation_status(doc)
     set_pending_boe_qty(doc)
+
+
+def before_cancel(doc, method=None):
+    run_onload(doc)
+    gst_settings = frappe.get_cached_doc("GST Settings")
+
+    if not is_api_enabled(gst_settings):
+        return
+
+    auto_cancel_e_waybill(doc, gst_settings=gst_settings)
 
 
 def on_cancel(doc, method=None):

--- a/india_compliance/gst_india/overrides/purchase_invoice.py
+++ b/india_compliance/gst_india/overrides/purchase_invoice.py
@@ -1,6 +1,5 @@
 import frappe
 from frappe import _
-from frappe.desk.form.load import run_onload
 from frappe.model.meta import get_field_precision
 from frappe.utils import flt
 
@@ -13,10 +12,7 @@ from india_compliance.gst_india.overrides.transaction import (
     validate_transaction,
 )
 from india_compliance.gst_india.utils import is_api_enabled, validate_invoice_number
-from india_compliance.gst_india.utils.e_waybill import (
-    auto_cancel_e_waybill,
-    get_e_waybill_info,
-)
+from india_compliance.gst_india.utils.e_waybill import get_e_waybill_info
 
 
 def onload(doc, method=None):
@@ -57,16 +53,6 @@ def validate(doc, method=None):
     validate_with_inward_supply(doc)
     set_reconciliation_status(doc)
     set_pending_boe_qty(doc)
-
-
-def before_cancel(doc, method=None):
-    run_onload(doc)
-    gst_settings = frappe.get_cached_doc("GST Settings")
-
-    if not is_api_enabled(gst_settings):
-        return
-
-    auto_cancel_e_waybill(doc, gst_settings=gst_settings)
 
 
 def on_cancel(doc, method=None):

--- a/india_compliance/gst_india/overrides/purchase_invoice.py
+++ b/india_compliance/gst_india/overrides/purchase_invoice.py
@@ -20,10 +20,7 @@ from india_compliance.gst_india.utils.e_waybill import (
 
 
 def onload(doc, method=None):
-    if doc.docstatus != 1:
-        return
-
-    if doc.gst_category == "Overseas":
+    if doc.docstatus == 1 and doc.gst_category == "Overseas":
         doc.set_onload(
             "bill_of_entry_exists",
             not any(item.pending_boe_qty > 0 for item in doc.items),

--- a/india_compliance/gst_india/overrides/purchase_invoice.py
+++ b/india_compliance/gst_india/overrides/purchase_invoice.py
@@ -32,7 +32,9 @@ def onload(doc, method=None):
 
     if (
         gst_settings.enable_e_waybill
-        and gst_settings.enable_e_waybill_from_pi
+        and (
+            gst_settings.enable_e_waybill_from_pi or gst_settings.auto_cancel_e_waybill
+        )
         and (e_waybill_info := get_e_waybill_info(doc))
     ):
         doc.set_onload("e_waybill_info", e_waybill_info)

--- a/india_compliance/gst_india/overrides/purchase_receipt.py
+++ b/india_compliance/gst_india/overrides/purchase_receipt.py
@@ -47,7 +47,9 @@ def onload(doc, method=None):
     if (
         is_api_enabled(gst_settings)
         and gst_settings.enable_e_waybill
-        and gst_settings.enable_e_waybill_from_pr
+        and (
+            gst_settings.enable_e_waybill_from_pr or gst_settings.auto_cancel_e_waybill
+        )
         and (e_waybill_info := get_e_waybill_info(doc))
     ):
         doc.set_onload("e_waybill_info", e_waybill_info)

--- a/india_compliance/gst_india/overrides/purchase_receipt.py
+++ b/india_compliance/gst_india/overrides/purchase_receipt.py
@@ -49,8 +49,9 @@ def onload(doc, method=None):
             is_api_enabled(gst_settings)
             and gst_settings.enable_e_waybill
             and gst_settings.enable_e_waybill_from_pr
+            and (e_waybill_info := get_e_waybill_info(doc))
         ):
-            doc.set_onload("e_waybill_info", get_e_waybill_info(doc))
+            doc.set_onload("e_waybill_info", e_waybill_info)
 
 
 def validate(doc, method=None):

--- a/india_compliance/gst_india/overrides/purchase_receipt.py
+++ b/india_compliance/gst_india/overrides/purchase_receipt.py
@@ -1,5 +1,4 @@
 import frappe
-from frappe.desk.form.load import run_onload
 
 from india_compliance.gst_india.overrides.purchase_invoice import (
     set_ineligibility_reason,
@@ -13,10 +12,7 @@ from india_compliance.gst_india.overrides.transaction import (
     validate_transaction,
 )
 from india_compliance.gst_india.utils import is_api_enabled
-from india_compliance.gst_india.utils.e_waybill import (
-    auto_cancel_e_waybill,
-    get_e_waybill_info,
-)
+from india_compliance.gst_india.utils.e_waybill import get_e_waybill_info
 
 
 def get_dashboard_data(data):
@@ -62,13 +58,3 @@ def validate(doc, method=None):
         return
 
     set_ineligibility_reason(doc)
-
-
-def before_cancel(doc, method=None):
-    run_onload(doc)
-    gst_settings = frappe.get_cached_doc("GST Settings")
-
-    if not is_api_enabled(gst_settings):
-        return
-
-    auto_cancel_e_waybill(doc, gst_settings=gst_settings)

--- a/india_compliance/gst_india/overrides/purchase_receipt.py
+++ b/india_compliance/gst_india/overrides/purchase_receipt.py
@@ -43,15 +43,18 @@ def onload(doc, method=None):
     set_ineligibility_reason(doc, show_alert=False)
 
     # Load e-waybill info if applicable
-    if doc.get("ewaybill"):
-        gst_settings = frappe.get_cached_doc("GST Settings")
-        if (
-            is_api_enabled(gst_settings)
-            and gst_settings.enable_e_waybill
-            and gst_settings.enable_e_waybill_from_pr
-            and (e_waybill_info := get_e_waybill_info(doc))
-        ):
-            doc.set_onload("e_waybill_info", e_waybill_info)
+    if not doc.get("ewaybill"):
+        return
+
+    gst_settings = frappe.get_cached_doc("GST Settings")
+
+    if (
+        is_api_enabled(gst_settings)
+        and gst_settings.enable_e_waybill
+        and gst_settings.enable_e_waybill_from_pr
+        and (e_waybill_info := get_e_waybill_info(doc))
+    ):
+        doc.set_onload("e_waybill_info", e_waybill_info)
 
 
 def validate(doc, method=None):

--- a/india_compliance/gst_india/overrides/purchase_receipt.py
+++ b/india_compliance/gst_india/overrides/purchase_receipt.py
@@ -1,3 +1,6 @@
+import frappe
+from frappe.desk.form.load import run_onload
+
 from india_compliance.gst_india.overrides.purchase_invoice import (
     set_ineligibility_reason,
 )
@@ -8,6 +11,11 @@ from india_compliance.gst_india.overrides.transaction import (
     ignore_gst_validations,
     validate_mandatory_fields,
     validate_transaction,
+)
+from india_compliance.gst_india.utils import is_api_enabled
+from india_compliance.gst_india.utils.e_waybill import (
+    auto_cancel_e_waybill,
+    get_e_waybill_info,
 )
 
 
@@ -34,9 +42,29 @@ def onload(doc, method=None):
 
     set_ineligibility_reason(doc, show_alert=False)
 
+    # Load e-waybill info if applicable
+    if doc.get("ewaybill"):
+        gst_settings = frappe.get_cached_doc("GST Settings")
+        if (
+            is_api_enabled(gst_settings)
+            and gst_settings.enable_e_waybill
+            and gst_settings.enable_e_waybill_from_pr
+        ):
+            doc.set_onload("e_waybill_info", get_e_waybill_info(doc))
+
 
 def validate(doc, method=None):
     if validate_transaction(doc) is False:
         return
 
     set_ineligibility_reason(doc)
+
+
+def before_cancel(doc, method=None):
+    run_onload(doc)
+    gst_settings = frappe.get_cached_doc("GST Settings")
+
+    if not is_api_enabled(gst_settings):
+        return
+
+    auto_cancel_e_waybill(doc, gst_settings=gst_settings)

--- a/india_compliance/gst_india/overrides/sales_invoice.py
+++ b/india_compliance/gst_india/overrides/sales_invoice.py
@@ -58,8 +58,12 @@ def onload(doc, method=None):
     ):
         doc.set_onload("e_waybill_info", e_waybill_info)
 
-    if gst_settings.enable_e_invoice and doc.irn:
-        doc.set_onload("e_invoice_info", get_e_invoice_info(doc))
+    if (
+        gst_settings.enable_e_invoice
+        and doc.irn
+        and (e_invoice_info := get_e_invoice_info(doc))
+    ):
+        doc.set_onload("e_invoice_info", e_invoice_info)
 
 
 def validate(doc, method=None):

--- a/india_compliance/gst_india/overrides/sales_invoice.py
+++ b/india_compliance/gst_india/overrides/sales_invoice.py
@@ -51,8 +51,12 @@ def onload(doc, method=None):
     if not is_api_enabled(gst_settings):
         return
 
-    if gst_settings.enable_e_waybill and doc.ewaybill:
-        doc.set_onload("e_waybill_info", get_e_waybill_info(doc))
+    if (
+        gst_settings.enable_e_waybill
+        and doc.ewaybill
+        and (e_waybill_info := get_e_waybill_info(doc))
+    ):
+        doc.set_onload("e_waybill_info", e_waybill_info)
 
     if gst_settings.enable_e_invoice and doc.irn:
         doc.set_onload("e_invoice_info", get_e_invoice_info(doc))

--- a/india_compliance/gst_india/overrides/sales_invoice.py
+++ b/india_compliance/gst_india/overrides/sales_invoice.py
@@ -1,7 +1,7 @@
 import frappe
 from frappe import _, bold
 from frappe.desk.form.load import run_onload
-from frappe.utils import add_days, flt, fmt_money, get_datetime
+from frappe.utils import flt, fmt_money
 
 from india_compliance.gst_india.overrides.payment_entry import get_taxes_summary
 from india_compliance.gst_india.overrides.transaction import (
@@ -22,13 +22,13 @@ from india_compliance.gst_india.utils import (
     validate_invoice_number,
 )
 from india_compliance.gst_india.utils.e_invoice import (
-    _cancel_e_invoice,
+    auto_cancel_e_invoice,
     get_e_invoice_info,
     validate_e_invoice_applicability,
     validate_if_e_invoice_can_be_cancelled,
 )
 from india_compliance.gst_india.utils.e_waybill import (
-    _cancel_e_waybill,
+    auto_cancel_e_waybill,
     get_e_waybill_info,
 )
 from india_compliance.gst_india.utils.transaction_data import (
@@ -246,40 +246,10 @@ def cancel_e_waybill_e_invoice(doc, method=None):
     if not is_api_enabled(gst_settings):
         return
 
-    def auto_cancel(cancel_func, action_type):
-        if action_type == "e_invoice":
-            generated_on = (
-                doc.get_onload().get("e_invoice_info", {}).get("acknowledged_on")
-            )
-            reason = gst_settings.reason_for_e_invoice_cancellation
-
-        else:
-            generated_on = doc.get_onload().get("e_waybill_info", {}).get("created_on")
-            reason = gst_settings.reason_for_e_waybill_cancellation
-
-        if not generated_on or (add_days(generated_on, 1) < get_datetime()):
-            return
-
-        values = frappe._dict(
-            {
-                "irn": doc.irn or "",
-                "reason": reason,
-                "ewaybill": doc.ewaybill or "",
-                "remark": "",
-            }
-        )
-        cancel_func(doc, values)
-
-    if doc.irn and gst_settings.enable_e_invoice and gst_settings.auto_cancel_e_invoice:
-        auto_cancel(_cancel_e_invoice, "e_invoice")
+    if auto_cancel_e_invoice(doc, gst_settings=gst_settings):
         return
 
-    if (
-        doc.ewaybill
-        and gst_settings.enable_e_waybill
-        and gst_settings.auto_cancel_e_waybill
-    ):
-        auto_cancel(_cancel_e_waybill, "e_waybill")
+    auto_cancel_e_waybill(doc, gst_settings=gst_settings)
 
 
 def is_e_waybill_applicable(doc, gst_settings=None):

--- a/india_compliance/gst_india/overrides/subcontracting_transaction.py
+++ b/india_compliance/gst_india/overrides/subcontracting_transaction.py
@@ -3,6 +3,7 @@ from pypika import Order
 import frappe
 from frappe import _, bold
 from frappe.contacts.doctype.address.address import get_address_display
+from frappe.desk.form.load import run_onload
 from frappe.utils import flt
 from erpnext.accounts.party import get_address_tax_category
 from erpnext.stock.get_item_details import get_item_tax_template
@@ -31,7 +32,10 @@ from india_compliance.gst_india.utils import (
 from india_compliance.gst_india.utils import (
     validate_invoice_number as validate_transaction_name,
 )
-from india_compliance.gst_india.utils.e_waybill import get_e_waybill_info
+from india_compliance.gst_india.utils.e_waybill import (
+    auto_cancel_e_waybill,
+    get_e_waybill_info,
+)
 from india_compliance.gst_india.utils.taxes_controller import (
     CustomTaxController,
     update_gst_details,
@@ -217,6 +221,16 @@ def before_save(doc, method=None):
                     "Tax Row #{0}: Charge Type cannot be {1}. Try setting it to 'On Net Total' or 'On Item Quantity'."
                 ).format(row.idx, bold(row.charge_type))
             )
+
+
+def before_cancel(doc, method=None):
+    run_onload(doc)
+    gst_settings = frappe.get_cached_doc("GST Settings")
+
+    if not is_api_enabled(gst_settings):
+        return
+
+    auto_cancel_e_waybill(doc, gst_settings=gst_settings)
 
 
 def validate_doc_references(doc, method=None):

--- a/india_compliance/gst_india/overrides/subcontracting_transaction.py
+++ b/india_compliance/gst_india/overrides/subcontracting_transaction.py
@@ -171,7 +171,7 @@ def onload(doc, method=None):
     if (
         is_api_enabled(gst_settings)
         and gst_settings.enable_e_waybill
-        and gst_settings.enable_e_waybill_for_sc
+        and (gst_settings.enable_e_waybill_for_sc or gst_settings.auto_cancel_e_waybill)
         and (e_waybill_info := get_e_waybill_info(doc))
     ):
         doc.set_onload("e_waybill_info", e_waybill_info)

--- a/india_compliance/gst_india/overrides/subcontracting_transaction.py
+++ b/india_compliance/gst_india/overrides/subcontracting_transaction.py
@@ -179,7 +179,8 @@ def onload(doc, method=None):
     ):
         return
 
-    doc.set_onload("e_waybill_info", get_e_waybill_info(doc))
+    if e_waybill_info := get_e_waybill_info(doc):
+        doc.set_onload("e_waybill_info", e_waybill_info)
 
 
 def validate(doc, method=None):

--- a/india_compliance/gst_india/overrides/subcontracting_transaction.py
+++ b/india_compliance/gst_india/overrides/subcontracting_transaction.py
@@ -172,14 +172,12 @@ def onload(doc, method=None):
 
     gst_settings = frappe.get_cached_doc("GST Settings")
 
-    if not (
+    if (
         is_api_enabled(gst_settings)
         and gst_settings.enable_e_waybill
         and gst_settings.enable_e_waybill_for_sc
+        and (e_waybill_info := get_e_waybill_info(doc))
     ):
-        return
-
-    if e_waybill_info := get_e_waybill_info(doc):
         doc.set_onload("e_waybill_info", e_waybill_info)
 
 

--- a/india_compliance/gst_india/overrides/subcontracting_transaction.py
+++ b/india_compliance/gst_india/overrides/subcontracting_transaction.py
@@ -3,7 +3,6 @@ from pypika import Order
 import frappe
 from frappe import _, bold
 from frappe.contacts.doctype.address.address import get_address_display
-from frappe.desk.form.load import run_onload
 from frappe.utils import flt
 from erpnext.accounts.party import get_address_tax_category
 from erpnext.stock.get_item_details import get_item_tax_template
@@ -32,10 +31,7 @@ from india_compliance.gst_india.utils import (
 from india_compliance.gst_india.utils import (
     validate_invoice_number as validate_transaction_name,
 )
-from india_compliance.gst_india.utils.e_waybill import (
-    auto_cancel_e_waybill,
-    get_e_waybill_info,
-)
+from india_compliance.gst_india.utils.e_waybill import get_e_waybill_info
 from india_compliance.gst_india.utils.taxes_controller import (
     CustomTaxController,
     update_gst_details,
@@ -220,16 +216,6 @@ def before_save(doc, method=None):
                     "Tax Row #{0}: Charge Type cannot be {1}. Try setting it to 'On Net Total' or 'On Item Quantity'."
                 ).format(row.idx, bold(row.charge_type))
             )
-
-
-def before_cancel(doc, method=None):
-    run_onload(doc)
-    gst_settings = frappe.get_cached_doc("GST Settings")
-
-    if not is_api_enabled(gst_settings):
-        return
-
-    auto_cancel_e_waybill(doc, gst_settings=gst_settings)
 
 
 def validate_doc_references(doc, method=None):

--- a/india_compliance/gst_india/utils/e_invoice.py
+++ b/india_compliance/gst_india/utils/e_invoice.py
@@ -1020,7 +1020,6 @@ def auto_cancel_e_invoice(doc, gst_settings=None):
 
     values = frappe._dict(
         {
-            "irn": doc.irn,
             "reason": reason,
             "remark": "",
         }

--- a/india_compliance/gst_india/utils/e_invoice.py
+++ b/india_compliance/gst_india/utils/e_invoice.py
@@ -5,6 +5,7 @@ import jwt
 import frappe
 from frappe import _
 from frappe.utils import (
+    add_days,
     add_to_date,
     cstr,
     flt,
@@ -996,3 +997,35 @@ class EInvoiceData(GSTTransactionData):
             export_details["Port"] = self.doc.port_code
 
         return export_details
+
+
+#######################################################################################
+### Auto Cancel e-Invoice Functions ###################################################
+#######################################################################################
+
+
+def auto_cancel_e_invoice(doc, gst_settings=None):
+    gst_settings = gst_settings or frappe.get_cached_doc("GST Settings")
+
+    if not (
+        doc.irn and gst_settings.enable_e_invoice and gst_settings.auto_cancel_e_invoice
+    ):
+        return
+
+    generated_on = doc.get_onload().get("e_invoice_info", {}).get("acknowledged_on")
+    reason = gst_settings.reason_for_e_invoice_cancellation
+
+    if not generated_on or (add_days(generated_on, 1) < get_datetime()):
+        return
+
+    values = frappe._dict(
+        {
+            "irn": doc.irn,
+            "reason": reason,
+            "remark": "",
+        }
+    )
+
+    _cancel_e_invoice(doc, values)
+
+    return True

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -3,7 +3,7 @@ import os
 
 import frappe
 from frappe import _
-from frappe.desk.form.load import get_docinfo
+from frappe.desk.form.load import get_docinfo, run_onload
 from frappe.utils import (
     add_days,
     add_to_date,
@@ -1793,7 +1793,19 @@ class EWaybillData(GSTTransactionData):
 #######################################################################################
 
 
-def auto_cancel_e_waybill(doc, gst_settings=None):
+def before_cancel(doc, method=None):
+    if not doc.get("ewaybill"):
+        return
+
+    run_onload(doc)
+
+    if not (e_waybill_info := doc.get_onload().get("e_waybill_info")):
+        return
+
+    auto_cancel_e_waybill(doc, e_waybill_info=e_waybill_info)
+
+
+def auto_cancel_e_waybill(doc, gst_settings=None, e_waybill_info=None):
     gst_settings = gst_settings or frappe.get_cached_doc("GST Settings")
 
     if not (
@@ -1803,7 +1815,8 @@ def auto_cancel_e_waybill(doc, gst_settings=None):
     ):
         return
 
-    generated_on = doc.get_onload().get("e_waybill_info", {}).get("created_on")
+    e_waybill_info = e_waybill_info or doc.get_onload().get("e_waybill_info", {})
+    generated_on = e_waybill_info.get("created_on")
     reason = gst_settings.reason_for_e_waybill_cancellation
 
     if not generated_on or (add_days(generated_on, 1) < get_datetime()):

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -1786,3 +1786,37 @@ class EWaybillData(GSTTransactionData):
             "cessRate": item_details.cess_rate,
             "cessNonAdvol": item_details.cess_non_advol_rate,
         }
+
+
+#######################################################################################
+### Auto Cancel e-Waybill Functions ###################################################
+#######################################################################################
+
+
+def auto_cancel_e_waybill(doc, gst_settings=None):
+    gst_settings = gst_settings or frappe.get_cached_doc("GST Settings")
+
+    if not (
+        doc.ewaybill
+        and gst_settings.enable_e_waybill
+        and gst_settings.auto_cancel_e_waybill
+    ):
+        return
+
+    generated_on = doc.get_onload().get("e_waybill_info", {}).get("created_on")
+    reason = gst_settings.reason_for_e_waybill_cancellation
+
+    if not generated_on or (add_days(generated_on, 1) < get_datetime()):
+        return
+
+    values = frappe._dict(
+        {
+            "ewaybill": doc.ewaybill,
+            "reason": reason,
+            "remark": "",
+        }
+    )
+
+    _cancel_e_waybill(doc, values)
+
+    return True

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -38,6 +38,7 @@ from india_compliance.gst_india.constants.e_waybill import (
 )
 from india_compliance.gst_india.utils import (
     handle_server_errors,
+    is_api_enabled,
     is_foreign_doc,
     is_outward_stock_entry,
     load_doc,
@@ -1797,12 +1798,14 @@ def before_cancel(doc, method=None):
     if not doc.get("ewaybill"):
         return
 
-    run_onload(doc)
+    gst_settings = frappe.get_cached_doc("GST Settings")
 
-    if not (e_waybill_info := doc.get_onload().get("e_waybill_info")):
+    if not is_api_enabled(gst_settings):
         return
 
-    auto_cancel_e_waybill(doc, e_waybill_info=e_waybill_info)
+    run_onload(doc)
+
+    auto_cancel_e_waybill(doc, gst_settings=gst_settings)
 
 
 def auto_cancel_e_waybill(doc, gst_settings=None, e_waybill_info=None):
@@ -1824,7 +1827,6 @@ def auto_cancel_e_waybill(doc, gst_settings=None, e_waybill_info=None):
 
     values = frappe._dict(
         {
-            "ewaybill": doc.ewaybill,
             "reason": reason,
             "remark": "",
         }

--- a/india_compliance/gst_india/utils/test_e_waybill.py
+++ b/india_compliance/gst_india/utils/test_e_waybill.py
@@ -1,3 +1,4 @@
+import copy
 import datetime
 import random
 import re
@@ -319,6 +320,230 @@ class TestEWaybill(IntegrationTestCase):
                 frappe._dict(e_waybill_cancel_data.get("values"))
             ),
         )
+
+    @change_settings(
+        "GST Settings",
+        {
+            "auto_cancel_e_waybill": 1,
+            "reason_for_e_waybill_cancellation": "Data Entry Mistake",
+        },
+    )
+    @responses.activate
+    def test_auto_cancel_e_waybill_on_si_cancel(self):
+        """Test that e-waybill is automatically cancelled when document is cancelled and auto_cancel_e_waybill is enabled"""
+        si = self.create_sales_invoice_for("goods_item_with_ewaybill")
+        self._generate_e_waybill(si.name)
+
+        ewaybill_log = frappe.get_doc("e-Waybill Log", {"reference_name": si.name})
+        self.assertFalse(ewaybill_log.is_cancelled)
+
+        e_waybill_cancel_data = self.e_waybill_test_data.get("cancel_e_waybill")
+
+        self._mock_e_waybill_response(
+            data=e_waybill_cancel_data.get("response_data"),
+            match_list=[
+                matchers.query_string_matcher(e_waybill_cancel_data.get("params")),
+                matchers.json_params_matcher(
+                    {
+                        "ewbNo": e_waybill_cancel_data.get("request_data").get("ewbNo"),
+                        "cancelRsnCode": "3",  # Data Entry Mistake
+                        "cancelRmrk": "Data Entry Mistake",
+                    }
+                ),
+            ],
+        )
+
+        si.reload()
+        si.cancel()
+
+        ewaybill_log.reload()
+        self.assertTrue(ewaybill_log.is_cancelled)
+        self.assertEqual(ewaybill_log.cancel_reason_code, "3")  # Data Entry Mistake
+        self.assertEqual(ewaybill_log.cancel_remark, "Data Entry Mistake")
+
+        si.reload()
+        self.assertEqual(si.ewaybill, "")
+        self.assertEqual(si.e_waybill_status, "Cancelled")
+
+    @change_settings("GST Settings", {"auto_cancel_e_waybill": 0})
+    @responses.activate
+    def test_no_auto_cancel_when_setting_disabled(self):
+        """Test that e-waybill is NOT automatically cancelled when auto_cancel_e_waybill is disabled"""
+        si = self.create_sales_invoice_for("goods_item_with_ewaybill")
+        self._generate_e_waybill(si.name)
+
+        ewaybill_log = frappe.get_doc("e-Waybill Log", {"reference_name": si.name})
+        self.assertFalse(ewaybill_log.is_cancelled)
+
+        si.reload()
+        si.cancel()
+
+        ewaybill_log.reload()
+        self.assertFalse(ewaybill_log.is_cancelled)
+
+        si.reload()
+        self.assertNotEqual(si.ewaybill, "")
+
+    @change_settings(
+        "GST Settings",
+        {
+            "auto_cancel_e_waybill": 1,
+            "reason_for_e_waybill_cancellation": "Data Entry Mistake",
+            "enable_e_waybill_from_dn": 1,
+        },
+    )
+    @responses.activate
+    def test_auto_cancel_e_waybill_on_dn_cancel(self):
+        """Test that e-waybill is automatically cancelled when delivery note is cancelled and auto_cancel_e_waybill is enabled"""
+        dn = self._create_delivery_note("dn_with_different_gstin")
+        dn_test_data = self.e_waybill_test_data.get("dn_with_different_gstin")
+
+        self._generate_e_waybill(dn.name, "Delivery Note", dn_test_data)
+
+        ewaybill_log = frappe.get_doc("e-Waybill Log", {"reference_name": dn.name})
+        self.assertFalse(ewaybill_log.is_cancelled)
+
+        e_waybill_cancel_data = self.e_waybill_test_data.get("cancel_e_waybill")
+
+        actual_ewaybill_no = ewaybill_log.name
+
+        cancel_response_data = copy.deepcopy(e_waybill_cancel_data.get("response_data"))
+        cancel_response_data["result"]["ewayBillNo"] = actual_ewaybill_no
+
+        self._mock_e_waybill_response(
+            data=cancel_response_data,
+            match_list=[
+                matchers.query_string_matcher(e_waybill_cancel_data.get("params")),
+                matchers.json_params_matcher(
+                    {
+                        "ewbNo": actual_ewaybill_no,
+                        "cancelRsnCode": "3",  # Data Entry Mistake
+                        "cancelRmrk": "Data Entry Mistake",
+                    }
+                ),
+            ],
+        )
+
+        dn.reload()
+        dn.cancel()
+
+        ewaybill_log.reload()
+        self.assertTrue(ewaybill_log.is_cancelled)
+        self.assertEqual(ewaybill_log.cancel_reason_code, "3")  # Data Entry Mistake
+        self.assertEqual(ewaybill_log.cancel_remark, "Data Entry Mistake")
+
+        dn.reload()
+        self.assertEqual(dn.ewaybill, "")
+
+    @change_settings(
+        "GST Settings",
+        {
+            "auto_cancel_e_waybill": 1,
+            "reason_for_e_waybill_cancellation": "Data Entry Mistake",
+            "enable_e_waybill_from_pi": 1,
+        },
+    )
+    @responses.activate
+    def test_auto_cancel_e_waybill_on_pi_cancel(self):
+        """Test that e-waybill is automatically cancelled when purchase invoice is cancelled and auto_cancel_e_waybill is enabled"""
+        purchase_invoice_data = self.e_waybill_test_data.get(
+            "pi_data_for_registered_supplier"
+        )
+
+        pi = create_purchase_invoice(
+            **purchase_invoice_data.get("kwargs"), do_not_submit=True
+        )
+
+        pi.bill_no = "1234"
+        pi.submit()
+
+        self._generate_e_waybill(pi.name, "Purchase Invoice", purchase_invoice_data)
+
+        ewaybill_log = frappe.get_doc("e-Waybill Log", {"reference_name": pi.name})
+        self.assertFalse(ewaybill_log.is_cancelled)
+
+        e_waybill_cancel_data = self.e_waybill_test_data.get("cancel_e_waybill")
+
+        actual_ewaybill_no = ewaybill_log.name
+
+        cancel_response_data = copy.deepcopy(e_waybill_cancel_data.get("response_data"))
+        cancel_response_data["result"]["ewayBillNo"] = actual_ewaybill_no
+
+        self._mock_e_waybill_response(
+            data=cancel_response_data,
+            match_list=[
+                matchers.query_string_matcher(e_waybill_cancel_data.get("params")),
+                matchers.json_params_matcher(
+                    {
+                        "ewbNo": actual_ewaybill_no,
+                        "cancelRsnCode": "3",  # Data Entry Mistake
+                        "cancelRmrk": "Data Entry Mistake",
+                    }
+                ),
+            ],
+        )
+
+        pi.reload()
+        pi.cancel()
+
+        ewaybill_log.reload()
+        self.assertTrue(ewaybill_log.is_cancelled)
+        self.assertEqual(ewaybill_log.cancel_reason_code, "3")  # Data Entry Mistake
+        self.assertEqual(ewaybill_log.cancel_remark, "Data Entry Mistake")
+
+        pi.reload()
+        self.assertEqual(pi.ewaybill, "")
+
+    @change_settings(
+        "GST Settings",
+        {
+            "auto_cancel_e_waybill": 1,
+            "reason_for_e_waybill_cancellation": "Data Entry Mistake",
+            "enable_e_waybill_for_sc": 1,
+        },
+    )
+    @responses.activate
+    def test_auto_cancel_e_waybill_on_se_cancel(self):
+        """Test that e-waybill is automatically cancelled when stock entry is cancelled and auto_cancel_e_waybill is enabled"""
+        se = self._create_stock_entry("stock_entry")
+        se_test_data = self.e_waybill_test_data.get("stock_entry")
+
+        self._generate_e_waybill(se.name, "Stock Entry", se_test_data)
+
+        ewaybill_log = frappe.get_doc("e-Waybill Log", {"reference_name": se.name})
+        self.assertFalse(ewaybill_log.is_cancelled)
+
+        e_waybill_cancel_data = self.e_waybill_test_data.get("cancel_e_waybill")
+
+        actual_ewaybill_no = ewaybill_log.name
+
+        cancel_response_data = copy.deepcopy(e_waybill_cancel_data.get("response_data"))
+        cancel_response_data["result"]["ewayBillNo"] = actual_ewaybill_no
+
+        self._mock_e_waybill_response(
+            data=cancel_response_data,
+            match_list=[
+                matchers.query_string_matcher(e_waybill_cancel_data.get("params")),
+                matchers.json_params_matcher(
+                    {
+                        "ewbNo": actual_ewaybill_no,
+                        "cancelRsnCode": "3",  # Data Entry Mistake
+                        "cancelRmrk": "Data Entry Mistake",
+                    }
+                ),
+            ],
+        )
+
+        se.reload()
+        se.cancel()
+
+        ewaybill_log.reload()
+        self.assertTrue(ewaybill_log.is_cancelled)
+        self.assertEqual(ewaybill_log.cancel_reason_code, "3")  # Data Entry Mistake
+        self.assertEqual(ewaybill_log.cancel_remark, "Data Entry Mistake")
+
+        se.reload()
+        self.assertEqual(se.ewaybill, "")
 
     def test_get_all_item_details(self):
         """Tests:

--- a/india_compliance/gst_india/utils/test_e_waybill.py
+++ b/india_compliance/gst_india/utils/test_e_waybill.py
@@ -440,6 +440,60 @@ class TestEWaybill(IntegrationTestCase):
         {
             "auto_cancel_e_waybill": 1,
             "reason_for_e_waybill_cancellation": "Data Entry Mistake",
+            "enable_e_waybill_from_pr": 1,
+        },
+    )
+    @responses.activate
+    def test_auto_cancel_e_waybill_on_pr_cancel(self):
+        """Test that e-waybill is automatically cancelled when purchase receipt is cancelled and auto_cancel_e_waybill is enabled"""
+        # Use PI registered supplier data as PR shares same buying address mapping
+        pr_test_data = self.e_waybill_test_data.get("pi_data_for_registered_supplier")
+
+        pr = self._create_purchase_receipt("pi_data_for_registered_supplier")
+
+        # Generate e-waybill for Purchase Receipt using PI data (structure matches PR)
+        self._generate_e_waybill(pr.name, "Purchase Receipt", pr_test_data)
+
+        ewaybill_log = frappe.get_doc("e-Waybill Log", {"reference_name": pr.name})
+        self.assertFalse(ewaybill_log.is_cancelled)
+
+        e_waybill_cancel_data = self.e_waybill_test_data.get("cancel_e_waybill")
+
+        actual_ewaybill_no = ewaybill_log.name
+
+        cancel_response_data = copy.deepcopy(e_waybill_cancel_data.get("response_data"))
+        cancel_response_data["result"]["ewayBillNo"] = actual_ewaybill_no
+
+        self._mock_e_waybill_response(
+            data=cancel_response_data,
+            match_list=[
+                matchers.query_string_matcher(e_waybill_cancel_data.get("params")),
+                matchers.json_params_matcher(
+                    {
+                        "ewbNo": actual_ewaybill_no,
+                        "cancelRsnCode": "3",  # Data Entry Mistake
+                        "cancelRmrk": "Data Entry Mistake",
+                    }
+                ),
+            ],
+        )
+
+        pr.reload()
+        pr.cancel()
+
+        ewaybill_log.reload()
+        self.assertTrue(ewaybill_log.is_cancelled)
+        self.assertEqual(ewaybill_log.cancel_reason_code, "3")  # Data Entry Mistake
+        self.assertEqual(ewaybill_log.cancel_remark, "Data Entry Mistake")
+
+        pr.reload()
+        self.assertEqual(pr.ewaybill, "")
+
+    @change_settings(
+        "GST Settings",
+        {
+            "auto_cancel_e_waybill": 1,
+            "reason_for_e_waybill_cancellation": "Data Entry Mistake",
             "enable_e_waybill_from_pi": 1,
         },
     )
@@ -1280,6 +1334,14 @@ class TestEWaybill(IntegrationTestCase):
 
         stock_entry = create_transaction(**doc_args)
         return stock_entry
+
+    def _create_purchase_receipt(self, test_case):
+        """Generate Purchase Receipt to test e-Waybill functionalities"""
+        doc_args = self.e_waybill_test_data.get(test_case).get("kwargs")
+        doc_args.update({"doctype": "Purchase Receipt"})
+
+        purchase_receipt = create_transaction(**doc_args)
+        return purchase_receipt
 
     @change_settings("GST Settings", {"enable_e_waybill_for_sc": 1})
     @responses.activate

--- a/india_compliance/hooks.py
+++ b/india_compliance/hooks.py
@@ -147,6 +147,7 @@ doc_events = {
         "before_print": "india_compliance.gst_india.overrides.transaction.before_print",
         "before_save": "india_compliance.gst_india.overrides.transaction.update_gst_details",
         "before_submit": "india_compliance.gst_india.overrides.transaction.update_gst_details",
+        "before_cancel": "india_compliance.gst_india.overrides.delivery_note.before_cancel",
         "before_validate": "india_compliance.gst_india.overrides.transaction.set_gst_tax_type",
         "validate": (
             "india_compliance.gst_india.overrides.transaction.validate_transaction"
@@ -190,6 +191,7 @@ doc_events = {
         "before_submit": [
             "india_compliance.gst_india.overrides.transaction.update_gst_details",
         ],
+        "before_cancel": "india_compliance.gst_india.overrides.purchase_invoice.before_cancel",
         "after_mapping": "india_compliance.gst_india.overrides.transaction.after_mapping",
         "on_cancel": "india_compliance.gst_india.overrides.purchase_invoice.on_cancel",
     },
@@ -225,6 +227,7 @@ doc_events = {
         "before_submit": [
             "india_compliance.gst_india.overrides.transaction.update_gst_details",
         ],
+        "before_cancel": "india_compliance.gst_india.overrides.purchase_receipt.before_cancel",
     },
     "Sales Invoice": {
         "onload": [
@@ -266,6 +269,7 @@ doc_events = {
         "validate": "india_compliance.gst_india.overrides.subcontracting_transaction.validate",
         "before_save": "india_compliance.gst_india.overrides.subcontracting_transaction.before_save",
         "before_submit": "india_compliance.gst_india.overrides.subcontracting_transaction.validate_doc_references",
+        "before_cancel": "india_compliance.gst_india.overrides.subcontracting_transaction.before_cancel",
         "after_mapping": "india_compliance.gst_india.overrides.subcontracting_transaction.after_mapping_stock_entry",
     },
     "Subcontracting Order": {
@@ -280,6 +284,7 @@ doc_events = {
             "india_compliance.gst_india.overrides.subcontracting_transaction.before_save",
             "india_compliance.gst_india.overrides.subcontracting_transaction.validate_doc_references",
         ],
+        "before_cancel": "india_compliance.gst_india.overrides.subcontracting_transaction.before_cancel",
         "before_mapping": "india_compliance.gst_india.overrides.subcontracting_transaction.before_mapping_subcontracting_receipt",
     },
     "Supplier": {

--- a/india_compliance/hooks.py
+++ b/india_compliance/hooks.py
@@ -147,7 +147,7 @@ doc_events = {
         "before_print": "india_compliance.gst_india.overrides.transaction.before_print",
         "before_save": "india_compliance.gst_india.overrides.transaction.update_gst_details",
         "before_submit": "india_compliance.gst_india.overrides.transaction.update_gst_details",
-        "before_cancel": "india_compliance.gst_india.overrides.delivery_note.before_cancel",
+        "before_cancel": "india_compliance.gst_india.utils.e_waybill.before_cancel",
         "before_validate": "india_compliance.gst_india.overrides.transaction.set_gst_tax_type",
         "validate": (
             "india_compliance.gst_india.overrides.transaction.validate_transaction"
@@ -191,7 +191,7 @@ doc_events = {
         "before_submit": [
             "india_compliance.gst_india.overrides.transaction.update_gst_details",
         ],
-        "before_cancel": "india_compliance.gst_india.overrides.purchase_invoice.before_cancel",
+        "before_cancel": "india_compliance.gst_india.utils.e_waybill.before_cancel",
         "after_mapping": "india_compliance.gst_india.overrides.transaction.after_mapping",
         "on_cancel": "india_compliance.gst_india.overrides.purchase_invoice.on_cancel",
     },
@@ -227,7 +227,7 @@ doc_events = {
         "before_submit": [
             "india_compliance.gst_india.overrides.transaction.update_gst_details",
         ],
-        "before_cancel": "india_compliance.gst_india.overrides.purchase_receipt.before_cancel",
+        "before_cancel": "india_compliance.gst_india.utils.e_waybill.before_cancel",
     },
     "Sales Invoice": {
         "onload": [
@@ -269,7 +269,7 @@ doc_events = {
         "validate": "india_compliance.gst_india.overrides.subcontracting_transaction.validate",
         "before_save": "india_compliance.gst_india.overrides.subcontracting_transaction.before_save",
         "before_submit": "india_compliance.gst_india.overrides.subcontracting_transaction.validate_doc_references",
-        "before_cancel": "india_compliance.gst_india.overrides.subcontracting_transaction.before_cancel",
+        "before_cancel": "india_compliance.gst_india.utils.e_waybill.before_cancel",
         "after_mapping": "india_compliance.gst_india.overrides.subcontracting_transaction.after_mapping_stock_entry",
     },
     "Subcontracting Order": {
@@ -284,7 +284,7 @@ doc_events = {
             "india_compliance.gst_india.overrides.subcontracting_transaction.before_save",
             "india_compliance.gst_india.overrides.subcontracting_transaction.validate_doc_references",
         ],
-        "before_cancel": "india_compliance.gst_india.overrides.subcontracting_transaction.before_cancel",
+        "before_cancel": "india_compliance.gst_india.utils.e_waybill.before_cancel",
         "before_mapping": "india_compliance.gst_india.overrides.subcontracting_transaction.before_mapping_subcontracting_receipt",
     },
     "Supplier": {


### PR DESCRIPTION
closes: #3444

<img width="869" height="440" alt="image" src="https://github.com/user-attachments/assets/38fcaa82-0ba7-4c49-a892-9fc119a3bf1e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Auto-cancels e-Waybills and e-Invoices (within 24 hours when eligible) on cancellation of Sales Invoices, Delivery Notes, Purchase Invoices, Purchase Receipts, Stock Entries and Subcontracting Receipts; pre-cancel hooks added for these DocTypes.
  - Onload now loads e-Waybill info only when API/settings allow and data exists.

- **Style**
  - GST Settings: shortened auto-cancel label and expanded description listing supported document types.

- **Tests**
  - Added tests covering automatic e-Waybill cancellation across affected document types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->