### PR TITLE
fix: add script to remove legacy report fixtures

### DIFF
--- a/india_compliance/patches.txt
+++ b/india_compliance/patches.txt
@@ -76,3 +76,4 @@ india_compliance.patches.v15.update_supplier_filing_status
 india_compliance.patches.v14.set_pending_boe_qty #1
 india_compliance.patches.v15.remove_itc_amount_custom_fields
 india_compliance.patches.v14.update_tax_withholding_categories
+india_compliance.patches.v16.remove_legacy_report_fixtures

--- a/india_compliance/patches/v16/remove_legacy_report_fixtures.py
+++ b/india_compliance/patches/v16/remove_legacy_report_fixtures.py
@@ -1,0 +1,24 @@
+import frappe
+
+
+def execute():
+    legacy_reports = [
+        "GSTR-1",
+        "GST Sales Register Beta",
+        "GST Purchase Register Beta",
+        "GST Itemised Sales Register",
+        "GST Itemised Purchase Register",
+    ]
+
+    for report_name in legacy_reports:
+        try:
+            frappe.delete_doc(
+                "Report",
+                report_name,
+                force=True,
+                ignore_permissions=True,
+                delete_permanently=True,
+            )
+
+        except Exception as e:
+            print(f"Error removing report {report_name}: {str(e)}")

--- a/india_compliance/patches/v16/remove_legacy_report_fixtures.py
+++ b/india_compliance/patches/v16/remove_legacy_report_fixtures.py
@@ -11,9 +11,16 @@ def execute():
     ]
 
     try:
+        reports = frappe.get_all(
+            "Report",
+            filters={"reference_report": ("in", legacy_reports)},
+            fields="name",
+            pluck="name",
+        )
+
         frappe.delete_doc(
             "Report",
-            legacy_reports,
+            legacy_reports + reports,
             force=True,
             ignore_permissions=True,
             delete_permanently=True,

--- a/india_compliance/patches/v16/remove_legacy_report_fixtures.py
+++ b/india_compliance/patches/v16/remove_legacy_report_fixtures.py
@@ -10,15 +10,14 @@ def execute():
         "GST Itemised Purchase Register",
     ]
 
-    for report_name in legacy_reports:
-        try:
-            frappe.delete_doc(
-                "Report",
-                report_name,
-                force=True,
-                ignore_permissions=True,
-                delete_permanently=True,
-            )
+    try:
+        frappe.delete_doc(
+            "Report",
+            legacy_reports,
+            force=True,
+            ignore_permissions=True,
+            delete_permanently=True,
+        )
 
-        except Exception as e:
-            print(f"Error removing report {report_name}: {str(e)}")
+    except Exception as e:
+        print(f"Error removing report: {str(e)}")

--- a/india_compliance/patches/v16/remove_legacy_report_fixtures.py
+++ b/india_compliance/patches/v16/remove_legacy_report_fixtures.py
@@ -26,5 +26,5 @@ def execute():
             delete_permanently=True,
         )
 
-    except Exception as e:
-        print(f"Error removing report: {str(e)}")
+    except Exception:
+        frappe.log_error(title="remove_legacy_report_fixtures failed")


### PR DESCRIPTION
closes: #3565
`no-docs`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Patch list updated to include a new cleanup action.
  * During patch execution, an automated cleanup permanently removes several outdated legacy reports (GSTR-1, GST Sales Register Beta, GST Purchase Register Beta, GST Itemised Sales Register, GST Itemised Purchase Register). Any failures during the cleanup are recorded in error logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->