### PR TITLE
fix: update posting_time in TestITC04Export

### DIFF
--- a/india_compliance/gst_india/utils/itc_04/test_itc_04_export.py
+++ b/india_compliance/gst_india/utils/itc_04/test_itc_04_export.py
@@ -104,7 +104,13 @@ class TestITC04Export(IntegrationTestCase):
         cls.se.submit()
 
         cls.scr = make_subcontracting_receipt(sco.name)
-        cls.scr.update({"posting_date": "2025-01-10", "set_posting_time": 1})
+        cls.scr.update(
+            {
+                "posting_date": "2025-01-10",
+                "posting_time": "00:00:00",
+                "set_posting_time": 1,
+            }
+        )
         cls.scr.save()
 
         cls.scr.append(


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved stability of ITC-04 export tests by standardizing the posting time to midnight, ensuring consistent, time-independent behavior across environments and time zones.
  * Reduces intermittent test failures and flakiness, leading to more reliable CI results and smoother local development.
  * Enhances determinism in scheduled builds and repeatability of outcomes without altering any user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->