### PR TITLE
fix: update valid HSN length for e-Invoice and e-Waybill validation

### DIFF
--- a/india_compliance/gst_india/overrides/sales_invoice.py
+++ b/india_compliance/gst_india/overrides/sales_invoice.py
@@ -108,7 +108,7 @@ def validate_fields_and_set_status_for_e_invoice(doc, gst_settings=None):
     # Mandatory for e-Invoice before save
     _validate_hsn_codes(
         doc,
-        valid_hsn_length=[6, 8],
+        valid_hsn_length=[4, 6, 8],
         message=_("Since HSN/SAC Code is mandatory for generating e-Invoices.<br>"),
     )
 

--- a/india_compliance/gst_india/utils/transaction_data.py
+++ b/india_compliance/gst_india/utils/transaction_data.py
@@ -300,7 +300,7 @@ class GSTTransactionData:
 
         _validate_hsn_codes(
             self.doc,
-            valid_hsn_length=[6, 8],
+            valid_hsn_length=[4, 6, 8],
             message=_(
                 "Since HSN/SAC Code is mandatory for generating e-Waybill/e-Invoices.<br>"
             ),


### PR DESCRIPTION
closes: #3584

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * e-Invoice validation now accepts 4-digit HSN/SAC codes in addition to 6- and 8-digit codes, allowing invoices to be saved without validation errors when using 4-digit codes.
  * GST transaction validation updated to permit 4-digit HSN/SAC codes, expanding accepted code formats during transaction checks and reducing unnecessary rejections for shorter, valid codes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->