### PR TITLE
fix: correct typo in validation message for purchase invoice

### DIFF
--- a/india_compliance/gst_india/overrides/purchase_invoice.py
+++ b/india_compliance/gst_india/overrides/purchase_invoice.py
@@ -198,7 +198,7 @@ def validate_with_inward_supply(doc):
 
     if mismatch_fields:
         message = (
-            "Purchase Invoice does not match with releted GST Inward Supply.<br>"
+            "Purchase Invoice does not match with related GST Inward Supply.<br>"
             "Following values are not matching from 2A/2B: <br>"
         )
         for field, value in mismatch_fields.items():


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - No new features in this release.
- Bug Fixes
  - Corrected a typo in the validation message shown when a Purchase Invoice doesn’t match the related GST Inward Supply. The message now uses the correct spelling, improving clarity and professionalism. No changes to validation behavior or results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->