### PR TITLE
fix: ensure error is raised if IRN is not present in the response

### DIFF
--- a/india_compliance/gst_india/api_classes/nic/e_invoice.py
+++ b/india_compliance/gst_india/api_classes/nic/e_invoice.py
@@ -101,15 +101,14 @@ class EInvoiceAPI(BaseAPI):
     def generate_irn(self, data):
         result = self.post(endpoint="invoice", json=data)
 
-        # In case of Duplicate IRN, result is a list
-        if isinstance(result, list):
-            result = result[0]
-
-        # Duplicate IRN: Standard APIs
-        if not result.Irn and result.InfoDtls and isinstance(result.InfoDtls, list):
-            result = result.InfoDtls[0]
+        # Handle duplicate IRN scenarios
+        result = self.handle_duplicate_irn_response(result)
 
         self.update_distance(result)
+        return result
+
+    def handle_duplicate_irn_response(self, result):
+        # This method will be overridden in subclasses
         return result
 
     def cancel_irn(self, data):
@@ -164,6 +163,15 @@ class EnrichedEInvoiceAPI(EInvoiceAPI):
 
     def get_response_info(self):
         return self.response.get("info")
+
+    def handle_duplicate_irn_response(self, result):
+        if isinstance(result, list):
+            dup_info = next(
+                (info for info in result if info.get("InfCd") == "DUPIRN"), None
+            )
+            result = dup_info or result[0]
+
+        return result
 
 
 class StandardEInvoiceAPI(EInvoiceAPI):
@@ -246,3 +254,13 @@ class StandardEInvoiceAPI(EInvoiceAPI):
 
     def get_response_info(self):
         return self.response.get("InfoDtls")
+
+    def handle_duplicate_irn_response(self, result):
+        info_details = result.get("InfoDtls")
+        if not result.Irn and isinstance(info_details, list):
+            dup_info = next(
+                (info for info in info_details if info.get("InfCd") == "DUPIRN"), None
+            )
+            result = dup_info or info_details[0]
+
+        return result

--- a/india_compliance/gst_india/api_classes/nic/e_invoice.py
+++ b/india_compliance/gst_india/api_classes/nic/e_invoice.py
@@ -105,6 +105,10 @@ class EInvoiceAPI(BaseAPI):
         if isinstance(result, list):
             result = result[0]
 
+        # Duplicate IRN: Standard APIs
+        if not result.Irn and result.InfoDtls and isinstance(result.InfoDtls, list):
+            result = result.InfoDtls[0]
+
         self.update_distance(result)
         return result
 

--- a/india_compliance/gst_india/data/test_e_invoice.json
+++ b/india_compliance/gst_india/data/test_e_invoice.json
@@ -812,5 +812,92 @@
             },
             "success": true
         }
+    },
+    "failed_e_invoice_generation": {
+        "kwargs": {
+            "company_address": "_Test Indian Registered Company-Billing"
+        },
+        "request_data": {
+            "BuyerDtls": {
+                "Addr1": "Test Address - 3",
+                "Gstin": "36AMBPG7773M002",
+                "LglNm": "_Test Registered Customer",
+                "Loc": "Test City",
+                "Pin": 500055,
+                "Pos": "02",
+                "Stcd": "36",
+                "TrdNm": "_Test Registered Customer"
+            },
+            "DocDtls": {
+                "Dt": "03/10/2023",
+                "No": "test_invoice_no",
+                "Typ": "INV"
+            },
+            "ItemList": [
+                {
+                    "AssAmt": 1000.0,
+                    "CesAmt": 0,
+                    "CesNonAdvlAmt": 0,
+                    "CesRt": 0,
+                    "CgstAmt": 90.0,
+                    "Discount": 0,
+                    "GstRt": 18.0,
+                    "HsnCd": "61149090",
+                    "IgstAmt": 0,
+                    "IsServc": "N",
+                    "PrdDesc": "Test Trading Goods 1",
+                    "Qty": 1.0,
+                    "SgstAmt": 90.0,
+                    "SlNo": "1",
+                    "TotAmt": 1000.0,
+                    "TotItemVal": 1180.0,
+                    "Unit": "NOS",
+                    "UnitPrice": 1000.0
+                }
+            ],
+            "PayDtls": {
+                "CrDay": 0,
+                "PaidAmt": 0,
+                "PaymtDue": 1180.0
+            },
+            "SellerDtls": {
+                "Addr1": "Test Address - 1",
+                "Gstin": "02AMBPG7773M002",
+                "LglNm": "_Test Indian Registered Company",
+                "Loc": "Test City",
+                "Pin": 171302,
+                "Stcd": "02",
+                "TrdNm": "_Test Indian Registered Company"
+            },
+            "TranDtls": {
+                "RegRev": "N",
+                "SupTyp": "B2B",
+                "TaxSch": "GST"
+            },
+            "ValDtls": {
+                "AssVal": 1000.0,
+                "CesVal": 0,
+                "CgstVal": 90.0,
+                "Discount": 0,
+                "IgstVal": 0,
+                "OthChrg": 0.0,
+                "RndOffAmt": 0.0,
+                "SgstVal": 90.0,
+                "TotInvVal": 1180.0
+            },
+            "Version": "1.1"
+        },
+        "response_data": {
+            "result": {
+                "Irn": "",
+                "AckDt": null,
+                "AckNo": null,
+                "EwbNo": null,
+                "EwbDt": null,
+                "EwbValidTill": null
+            },
+            "success": false,
+            "message": "e-Invoice generation failed"
+        }
     }
 }

--- a/india_compliance/gst_india/utils/e_invoice.py
+++ b/india_compliance/gst_india/utils/e_invoice.py
@@ -165,6 +165,9 @@ def generate_e_invoice(docname, throw=True, force=False):
 
             result = api.generate_irn(data)
 
+        if not result.Irn:
+            frappe.throw(_("e-Invoice generation failed"))
+
     except GSPServerError as e:
         handle_server_errors(settings, doc, "e-Invoice", e)
         return
@@ -251,6 +254,9 @@ def handle_duplicate_irn_error(
 
     if response.error_code:
         response = irn_data
+
+    if not response.Irn:
+        frappe.throw(_("e-Invoice generation failed"))
 
     return log_and_process_e_invoice_generation(doc, response, api.sandbox_mode)
 

--- a/india_compliance/gst_india/utils/test_e_invoice.py
+++ b/india_compliance/gst_india/utils/test_e_invoice.py
@@ -818,6 +818,156 @@ class TestEInvoice(IntegrationTestCase):
             si.name,
         )
 
+    @responses.activate
+    def test_failed_e_invoice_generation(self):
+        """Test error handling when e-Invoice generation fails (empty IRN)"""
+        test_data = self.e_invoice_test_data.get("failed_e_invoice_generation")
+
+        si = create_sales_invoice(
+            rate=1000,
+            is_in_state=True,
+            company_address="_Test Indian Registered Company-Billing",
+        )
+
+        # Mock response for failed e-Invoice generation
+        self._mock_e_invoice_response(data=test_data)
+
+        # Assert that proper error is thrown when IRN is empty
+        self.assertRaisesRegex(
+            frappe.ValidationError,
+            re.compile(r"^(e-Invoice generation failed)$"),
+            generate_e_invoice,
+            si.name,
+        )
+
+        # Ensure no e-Invoice Log is created
+        self.assertFalse(
+            frappe.db.get_value("e-Invoice Log", {"reference_name": si.name}, "name")
+        )
+
+        # Ensure Sales Invoice status is not updated
+        si.reload()
+        self.assertEqual(si.einvoice_status, "Failed")
+
+    def test_handle_duplicate_irn_response_enriched_api(self):
+        """Test handle_duplicate_irn_response method for Enriched API"""
+        from india_compliance.gst_india.api_classes.nic.e_invoice import (
+            EnrichedEInvoiceAPI,
+        )
+
+        # Create API instance without initialization to avoid setup issues
+        api = EnrichedEInvoiceAPI.__new__(EnrichedEInvoiceAPI)
+
+        # Test case 1: Result is a list (typical for enriched API duplicate IRN)
+        result_list = [
+            frappe._dict(
+                {
+                    "InfCd": "DUPIRN",
+                    "Desc": {
+                        "Irn": "duplicate_irn_123",
+                        "AckDt": "2025-08-20 12:00:00",
+                        "AckNo": "123456789",
+                    },
+                }
+            ),
+            frappe._dict(
+                {
+                    "InfCd": "OTHER",
+                    "Desc": {"Irn": "other_irn_456", "AckDt": "2025-08-20 13:00:00"},
+                }
+            ),
+        ]
+
+        processed_result = api.handle_duplicate_irn_response(result_list)
+
+        # Should return the first DUPIRN info or first item
+        self.assertEqual(processed_result.Desc.get("Irn"), "duplicate_irn_123")
+        self.assertEqual(processed_result.InfCd, "DUPIRN")
+
+        # Test case 2: Result is already a dict (normal case)
+        result_dict = frappe._dict(
+            {"Irn": "normal_irn_789", "AckDt": "2025-08-20 14:00:00"}
+        )
+
+        processed_result = api.handle_duplicate_irn_response(result_dict)
+
+        # Should return the same dict
+        self.assertEqual(processed_result.Irn, "normal_irn_789")
+
+    def test_handle_duplicate_irn_response_standard_api(self):
+        """Test handle_duplicate_irn_response method for Standard API"""
+        from india_compliance.gst_india.api_classes.nic.e_invoice import (
+            StandardEInvoiceAPI,
+        )
+
+        # Create API instance with mock setup to avoid initialization issues
+        api = StandardEInvoiceAPI.__new__(StandardEInvoiceAPI)
+
+        # Test case 1: Empty IRN with InfoDtls containing DUPIRN
+        result_with_info_dtls = frappe._dict(
+            {
+                "Irn": "",
+                "Status": 0,
+                "InfoDtls": [
+                    {
+                        "InfCd": "DUPIRN",
+                        "Desc": {
+                            "Irn": "duplicate_irn_123",
+                            "AckDt": "2025-08-20 12:00:00",
+                            "AckNo": "123456789",
+                        },
+                    },
+                    {
+                        "InfCd": "OTHER",
+                        "Desc": {
+                            "Irn": "other_irn_456",
+                            "AckDt": "2025-08-20 13:00:00",
+                        },
+                    },
+                ],
+            }
+        )
+
+        processed_result = api.handle_duplicate_irn_response(result_with_info_dtls)
+
+        # Should return the DUPIRN info from InfoDtls
+        self.assertEqual(processed_result.get("InfCd"), "DUPIRN")
+        self.assertEqual(processed_result.get("Desc").get("Irn"), "duplicate_irn_123")
+
+        # Test case 2: Empty IRN with InfoDtls but no DUPIRN
+        result_no_dupirn = frappe._dict(
+            {
+                "Irn": "",
+                "Status": 0,
+                "InfoDtls": [
+                    {
+                        "InfCd": "OTHER",
+                        "Desc": {
+                            "Irn": "other_irn_789",
+                            "AckDt": "2025-08-20 15:00:00",
+                        },
+                    }
+                ],
+            }
+        )
+
+        processed_result = api.handle_duplicate_irn_response(result_no_dupirn)
+
+        # Should return the first item from InfoDtls
+        self.assertEqual(processed_result.get("InfCd"), "OTHER")
+        self.assertEqual(processed_result.get("Desc").get("Irn"), "other_irn_789")
+
+        # Test case 3: Normal result with IRN (no processing needed)
+        result_normal = frappe._dict(
+            {"Irn": "normal_irn_999", "AckDt": "2025-08-20 16:00:00", "Status": 1}
+        )
+
+        processed_result = api.handle_duplicate_irn_response(result_normal)
+
+        # Should return the same result unchanged
+        self.assertEqual(processed_result.Irn, "normal_irn_999")
+        self.assertEqual(processed_result.Status, 1)
+
     @change_settings("GST Settings", {"enable_overseas_transactions": 1})
     @change_settings("System Settings", {"currency_precision": 3})
     def test_refund_transaction_invoice_total(self):


### PR DESCRIPTION
closes: #3616

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Normalizes duplicate-IRN responses across enriched and standard e‑invoice APIs so the correct duplicate entry is used.
  * Fails fast when an IRN isn’t produced or retrievable, preventing processing with incomplete invoice data and improving error clarity and reliability.
* **Tests**
  * Adds tests for failed e‑Invoice generation and for duplicate-IRN handling in both enriched and standard API paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->