### PR TITLE
fix: do not update gst details if company is unregistered

### DIFF
--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -861,8 +861,15 @@ def get_gst_details(party_details, doctype, company, *, update_place_of_supply=F
      - tax template
      - taxes in the tax template
     """
-    is_sales_transaction = doctype in SALES_DOCTYPES or doctype == "Payment Entry"
     party_details = frappe.parse_json(party_details)
+
+    if not (
+        party_details.company_gstin
+        or is_indian_registered_company(frappe._dict(company=company))
+    ):
+        return {}
+
+    is_sales_transaction = doctype in SALES_DOCTYPES or doctype == "Payment Entry"
     gst_details = frappe._dict()
 
     allow_same_gstin = False


### PR DESCRIPTION
Fixes: #3621

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents GST calculations and fields from appearing when neither a GSTIN is provided nor the company is Indian-registered, reducing incorrect tax application and related errors on inapplicable transactions.
* **Performance**
  * Skips GST processing for non-Indian or non-registered scenarios, improving transaction load and save times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->