### PR TITLE
fix: add type hints for boolean parameters in various functions

### DIFF
--- a/india_compliance/gst_india/doctype/gstin/gstin.py
+++ b/india_compliance/gst_india/doctype/gstin/gstin.py
@@ -134,7 +134,7 @@ def get_and_validate_gstin_status(gstin, doc):
 
 
 @frappe.whitelist()
-def get_gstin_status(gstin, doc=None, force_update=False):
+def get_gstin_status(gstin, doc=None, force_update: bool = False):
     """
     Get GSTIN status. Responds immediately, and best suited for Frontend use.
     Permission check not required as GSTIN details are public where GSTIN is known.

--- a/india_compliance/gst_india/doctype/gstr_1/gstr_1.py
+++ b/india_compliance/gst_india/doctype/gstr_1/gstr_1.py
@@ -62,7 +62,11 @@ class GSTR1(Document):
     @frappe.whitelist()
     @otp_handler
     def generate_gstr1(
-        self, sync_for=None, recompute_books=False, only_books_data=None, message=None
+        self,
+        sync_for=None,
+        recompute_books: bool = False,
+        only_books_data=None,
+        message=None,
     ):
         period = get_period(self.month_or_quarter, self.year)
         log_name = f"GSTR1-{period}-{self.company_gstin}"
@@ -234,7 +238,7 @@ def check_action_status(month_or_quarter, year, company_gstin, action):
 
 
 @frappe.whitelist()
-def mark_as_unfiled(filters, force):
+def mark_as_unfiled(filters, force: bool):
     frappe.has_permission("GST Return Log", "write", throw=True)
 
     filters = frappe._dict(json.loads(filters))

--- a/india_compliance/gst_india/doctype/gstr_1/gstr_1_export.py
+++ b/india_compliance/gst_india/doctype/gstr_1/gstr_1_export.py
@@ -2117,8 +2117,8 @@ def get_gstr_1_json(
     company_gstin,
     year,
     month_or_quarter,
-    include_uploaded=False,
-    delete_missing=False,
+    include_uploaded: bool = False,
+    delete_missing: bool = False,
 ):
     frappe.has_permission("GSTR-1", "export", throw=True)
 

--- a/india_compliance/gst_india/doctype/pan/pan.py
+++ b/india_compliance/gst_india/doctype/pan/pan.py
@@ -48,7 +48,7 @@ class PAN(Document):
 
 
 @frappe.whitelist()
-def get_pan_status(pan, force_update=False):
+def get_pan_status(pan, force_update: bool = False):
     if not force_update and (
         pan_status := frappe.db.get_value("PAN", pan, ["pan_status", "last_updated_on"])
     ):

--- a/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.py
+++ b/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.py
@@ -128,7 +128,7 @@ class PurchaseReconciliationTool(Document):
         date_range,
         return_type=None,
         return_period=None,
-        force=False,
+        force: bool = False,
         gst_categories=None,
     ):
         frappe.has_permission("Purchase Reconciliation Tool", "write", throw=True)
@@ -150,7 +150,7 @@ class PurchaseReconciliationTool(Document):
 
     @frappe.whitelist()
     def get_import_history(
-        self, company_gstin, return_type, date_range, for_download=True
+        self, company_gstin, return_type, date_range, for_download: bool = True
     ):
         frappe.has_permission("Purchase Reconciliation Tool", "write", throw=True)
 
@@ -522,7 +522,7 @@ def generate_excel_attachment(data, doc):
 
 
 @frappe.whitelist()
-def download_excel_report(data, doc, is_supplier_specific=False):
+def download_excel_report(data, doc, is_supplier_specific: bool = False):
     frappe.has_permission("Purchase Reconciliation Tool", "export", throw=True)
 
     build_data = BuildExcel(doc, data, is_supplier_specific)

--- a/india_compliance/gst_india/overrides/payment_entry.py
+++ b/india_compliance/gst_india/overrides/payment_entry.py
@@ -21,7 +21,7 @@ from india_compliance.gst_india.utils import get_all_gst_accounts
 
 
 @frappe.whitelist()
-def get_outstanding_reference_documents(args, validate=False):
+def get_outstanding_reference_documents(args, validate: bool = False):
     from erpnext.accounts.doctype.payment_entry.payment_entry import (
         get_outstanding_reference_documents,
     )

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -851,7 +851,9 @@ def get_party_details_for_subcontracting(party_details, doctype, company):
 
 
 @frappe.whitelist()
-def get_gst_details(party_details, doctype, company, *, update_place_of_supply=False):
+def get_gst_details(
+    party_details, doctype, company, *, update_place_of_supply: bool = False
+):
     """
     This function does not check for permissions since it returns insensitive data
     based on already sensitive input (party details)

--- a/india_compliance/gst_india/utils/e_invoice.py
+++ b/india_compliance/gst_india/utils/e_invoice.py
@@ -117,7 +117,7 @@ def generate_e_invoices(docnames, force=False):
 
 
 @frappe.whitelist()
-def generate_e_invoice(docname, throw=True, force=False):
+def generate_e_invoice(docname, throw: bool = True, force: bool = False):
     doc = load_doc("Sales Invoice", docname, "submit")
 
     settings = frappe.get_cached_doc("GST Settings")
@@ -205,7 +205,7 @@ def handle_duplicate_irn_error(
     current_invoice_amount,
     doc=None,
     docname=None,
-    taxpayer_api=False,
+    taxpayer_api: bool = False,
 ):
     """
     Handle Duplicate IRN errors by fetching the IRN details and comparing with the current invoice.

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -138,7 +138,7 @@ def generate_e_waybills(doctype, docnames, force=False):
 
 
 @frappe.whitelist()
-def generate_e_waybill(*, doctype, docname, values=None, force=False):
+def generate_e_waybill(*, doctype, docname, values=None, force: bool = False):
     doc = load_doc(doctype, docname, "submit")
     if values:
         update_transaction(doc, frappe.parse_json(values))
@@ -503,7 +503,7 @@ def update_transporter(*, doctype, docname, values):
 
 
 @frappe.whitelist()
-def extend_validity(*, doctype, docname, values, scheduled=False):
+def extend_validity(*, doctype, docname, values, scheduled: bool = False):
     doc = load_doc(doctype, docname, "submit")
     values = frappe.parse_json(values)
 
@@ -655,7 +655,7 @@ def generate_pending_e_waybills():
 
 
 @frappe.whitelist()
-def fetch_e_waybill_data(*, doctype, docname, attach=False):
+def fetch_e_waybill_data(*, doctype, docname, attach: bool = False):
     doc = load_doc(doctype, docname, "write" if attach else "print")
     log = frappe.get_doc("e-Waybill Log", doc.ewaybill)
     if not log.is_latest_data:

--- a/india_compliance/gst_india/utils/gstin_info.py
+++ b/india_compliance/gst_india/utils/gstin_info.py
@@ -40,7 +40,7 @@ CHARACTERS_TO_STRIP = f"{whitespace},"
 
 
 @frappe.whitelist()
-def get_gstin_info(gstin, *, doc=None, throw_error=True):
+def get_gstin_info(gstin, *, doc=None, throw_error: bool = True):
     if doc and isinstance(doc, str):
         doc = frappe.parse_json(doc)
 


### PR DESCRIPTION
- Issue: Missing type hints caused JS booleans to arrive as Python strings ("true"/"false").
- Fix: Added explicit type annotations to all pre-pre whitelisted methods in India compliance.
- Result: Correct type deserialization (bool/int/float/str), fewer logic errors, better IDE/CI checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Standardized boolean type hints across multiple GST features, including GSTIN/PAN status checks, GSTR-1 generation/export, payment references, transaction GST details, e-Invoice/e-Waybill operations, and purchase reconciliation tools. No changes to behavior or defaults.
- Chores
  - Improved code readability and static typing consistency for better maintainability and tooling support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->