### PR TITLE
fix: use sbool for boolean conversions for frappe.whitelist

### DIFF
--- a/india_compliance/gst_india/doctype/gstin/gstin.py
+++ b/india_compliance/gst_india/doctype/gstin/gstin.py
@@ -4,7 +4,7 @@
 import frappe
 from frappe import _
 from frappe.model.document import Document
-from frappe.utils import date_diff, format_date, get_datetime
+from frappe.utils import date_diff, format_date, get_datetime, sbool
 
 from india_compliance.gst_india.utils import is_api_enabled, validate_gstin_check_digit
 from india_compliance.gst_india.utils.gstin_info import (
@@ -133,6 +133,7 @@ def get_gstin_status(gstin, transaction_date=None, docstatus=0, force_update=Fal
     if isinstance(docstatus, str):
         docstatus = int(docstatus)
 
+    force_update = sbool(force_update)
     if not force_update and not is_status_refresh_required(
         gstin, transaction_date, docstatus
     ):

--- a/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_beta.py
+++ b/india_compliance/gst_india/doctype/gstr_1_beta/gstr_1_beta.py
@@ -7,7 +7,7 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 from frappe.query_builder.functions import Date, Sum
-from frappe.utils import get_last_day, getdate
+from frappe.utils import get_last_day, getdate, sbool
 
 from india_compliance.gst_india.utils import get_gst_accounts_by_type
 from india_compliance.gst_india.utils.gstin_info import get_gstr_1_return_status
@@ -47,13 +47,13 @@ class GSTR1Beta(Document):
 
     @frappe.whitelist()
     def generate_gstr1(self, sync_for=None, recompute_books=False):
+        recompute_books = sbool(recompute_books)
         period = get_period(self.month_or_quarter, self.year)
 
         # get gstr1 log
         if log_name := frappe.db.exists(
             "GST Return Log", f"GSTR1-{period}-{self.company_gstin}"
         ):
-
             gstr1_log = frappe.get_doc("GST Return Log", log_name)
 
             message = None

--- a/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.py
+++ b/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.py
@@ -9,7 +9,7 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 from frappe.query_builder.functions import IfNull
-from frappe.utils import add_to_date, cint, now_datetime
+from frappe.utils import add_to_date, cint, now_datetime, sbool
 from frappe.utils.response import json_handler
 
 from india_compliance.gst_india.api_classes.taxpayer_base import TaxpayerBaseAPI
@@ -119,7 +119,7 @@ class PurchaseReconciliationTool(Document):
             company_gstins=company_gstins,
             date_range=date_range,
             return_type=return_type,
-            force=force,
+            force=sbool(force),
             gst_categories=gst_categories,
         )
 
@@ -142,7 +142,7 @@ class PurchaseReconciliationTool(Document):
         history = get_import_history(company_gstins, return_type, periods)
         history = {(log.return_period, log.gstin): log for log in history}
 
-        action = "Download" if for_download else "Upload"
+        action = "Download" if sbool(for_download) else "Upload"
         has_single_gstin = company_gstin != "All"
 
         pending_download = defaultdict(set)
@@ -613,7 +613,7 @@ def generate_excel_attachment(data, doc):
 def download_excel_report(data, doc, is_supplier_specific=False):
     frappe.has_permission("Purchase Reconciliation Tool", "export", throw=True)
 
-    build_data = BuildExcel(doc, data, is_supplier_specific)
+    build_data = BuildExcel(doc, data, sbool(is_supplier_specific))
     build_data.export_data()
 
 

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 import frappe
 from frappe import _, bold
 from frappe.model import delete_doc
-from frappe.utils import cint, flt, format_date
+from frappe.utils import cint, flt, format_date, sbool
 from erpnext.controllers.accounts_controller import get_taxes_and_charges
 from erpnext.controllers.taxes_and_totals import (
     get_itemised_tax,
@@ -941,7 +941,7 @@ def get_gst_details(party_details, doctype, company, *, update_place_of_supply=F
             gst_details.update(party_gst_details)
 
     # POS
-    if not update_place_of_supply and party_details.place_of_supply:
+    if not sbool(update_place_of_supply) and party_details.place_of_supply:
         gst_details.place_of_supply = party_details.place_of_supply
     else:
         place_of_supply = get_place_of_supply(party_details, doctype)

--- a/india_compliance/gst_india/utils/e_invoice.py
+++ b/india_compliance/gst_india/utils/e_invoice.py
@@ -12,6 +12,7 @@ from frappe.utils import (
     get_datetime,
     getdate,
     random_string,
+    sbool,
 )
 
 from india_compliance.exceptions import GSPServerError
@@ -116,6 +117,7 @@ def generate_e_invoices(docnames, force=False):
 
 @frappe.whitelist()
 def generate_e_invoice(docname, throw=True, force=False):
+    throw, force = sbool(throw), sbool(force)
     doc = load_doc("Sales Invoice", docname, "submit")
 
     settings = frappe.get_cached_doc("GST Settings")

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -13,6 +13,7 @@ from frappe.utils import (
     get_fullname,
     get_link_to_form,
     random_string,
+    sbool,
 )
 from frappe.utils.file_manager import save_file
 
@@ -138,7 +139,7 @@ def generate_e_waybill(*, doctype, docname, values=None, force=False):
     if values:
         update_transaction(doc, frappe.parse_json(values))
 
-    _generate_e_waybill(doc, throw=True if values else False, force=force)
+    _generate_e_waybill(doc, throw=True if values else False, force=sbool(force))
 
 
 def _generate_e_waybill(doc, throw=True, force=False):
@@ -498,6 +499,7 @@ def update_transporter(*, doctype, docname, values):
 
 @frappe.whitelist()
 def extend_validity(*, doctype, docname, values, scheduled=False):
+    scheduled = sbool(scheduled)
     doc = load_doc(doctype, docname, "submit")
     values = frappe.parse_json(values)
 
@@ -650,7 +652,7 @@ def generate_pending_e_waybills():
 
 @frappe.whitelist()
 def fetch_e_waybill_data(*, doctype, docname, attach=False):
-    doc = load_doc(doctype, docname, "write" if attach else "print")
+    doc = load_doc(doctype, docname, "write" if sbool(attach) else "print")
     log = frappe.get_doc("e-Waybill Log", doc.ewaybill)
     if not log.is_latest_data:
         _fetch_e_waybill_data(doc, log)
@@ -1233,7 +1235,6 @@ class EWaybillData(GSTTransactionData):
         return extension_details
 
     def validate_transaction(self):
-
         super().validate_transaction()
 
         if self.doc.ewaybill:

--- a/india_compliance/gst_india/utils/gstin_info.py
+++ b/india_compliance/gst_india/utils/gstin_info.py
@@ -4,7 +4,7 @@ from string import whitespace
 
 import frappe
 from frappe import _
-from frappe.utils import add_to_date
+from frappe.utils import add_to_date, sbool
 
 from india_compliance.exceptions import GSPServerError
 from india_compliance.gst_india.api_classes.base import BASE_URL
@@ -40,7 +40,7 @@ def get_gstin_info(gstin, *, throw_error=True):
     if not frappe.get_cached_doc("User", frappe.session.user).has_desk_access():
         frappe.throw(_("Not allowed"), frappe.PermissionError)
 
-    return _get_gstin_info(gstin, throw_error=throw_error)
+    return _get_gstin_info(gstin, throw_error=sbool(throw_error))
 
 
 def _get_gstin_info(gstin, *, throw_error=True):


### PR DESCRIPTION
#3629 - frappe version 14 does not convert the arguments to the type hint specified so we have to explicitly convert it to bool