### PR TITLE
fix: enhance error handling for GSTIN in e-invoice and e-waybill for error 3028, 3029

### DIFF
--- a/india_compliance/gst_india/api_classes/nic/e_invoice.py
+++ b/india_compliance/gst_india/api_classes/nic/e_invoice.py
@@ -183,12 +183,12 @@ class StandardEInvoiceAPI(EInvoiceAPI):
         if not self.company_gstin:
             frappe.throw(_("Company GSTIN is required to use the e-Invoice API"))
 
-        self.fetch_credentials(self.company_gstin, "e-Waybill / e-Invoice")
-        self.app_key = base64.b64encode(self.app_key.encode()).decode()
-        self.set_default_headers()
-
-        self.auth_strategy = StandardAuth(self)
-        self.auth_strategy.authenticate()
+        if not frappe.flags.in_test:
+            self.set_default_headers()
+            self.fetch_credentials(self.company_gstin, "e-Waybill / e-Invoice")
+            self.app_key = base64.b64encode(self.app_key.encode()).decode()
+            self.auth_strategy = StandardAuth(self)
+            self.auth_strategy.authenticate()
 
     def _make_request(self, method, endpoint="", params=None, headers=None, json=None):
         response = super()._make_request(method, endpoint, params, headers, json)

--- a/india_compliance/gst_india/api_classes/nic/e_invoice.py
+++ b/india_compliance/gst_india/api_classes/nic/e_invoice.py
@@ -183,10 +183,10 @@ class StandardEInvoiceAPI(EInvoiceAPI):
         if not self.company_gstin:
             frappe.throw(_("Company GSTIN is required to use the e-Invoice API"))
 
-        if not frappe.flags.in_test:
-            self.set_default_headers()
+        if not frappe.flags.bypass_auth:
             self.fetch_credentials(self.company_gstin, "e-Waybill / e-Invoice")
             self.app_key = base64.b64encode(self.app_key.encode()).decode()
+            self.set_default_headers()
             self.auth_strategy = StandardAuth(self)
             self.auth_strategy.authenticate()
 

--- a/india_compliance/gst_india/api_classes/nic/e_invoice.py
+++ b/india_compliance/gst_india/api_classes/nic/e_invoice.py
@@ -246,8 +246,11 @@ class StandardEInvoiceAPI(EInvoiceAPI):
             return False
 
         error_code = error_details[0].get("ErrorCode")
+        error_message = error_details[0].get("ErrorMessage", "")
+
         if error_code in self.IGNORED_ERROR_CODES:
             response.error_code = error_code
+            response.message = f"{error_code}: {error_message}"
             return True
 
         return False

--- a/india_compliance/gst_india/api_classes/nic/e_invoice.py
+++ b/india_compliance/gst_india/api_classes/nic/e_invoice.py
@@ -88,6 +88,7 @@ class EInvoiceAPI(BaseAPI):
         for error_code in self.IGNORED_ERROR_CODES:
             if message.startswith(error_code):
                 response_json.error_code = error_code
+                response_json.error_message = message
                 return True
 
         return False
@@ -250,7 +251,7 @@ class StandardEInvoiceAPI(EInvoiceAPI):
 
         if error_code in self.IGNORED_ERROR_CODES:
             response.error_code = error_code
-            response.message = f"{error_code}: {error_message}"
+            response.error_message = f"{error_code}: {error_message}"
             return True
 
         return False

--- a/india_compliance/gst_india/api_classes/nic/e_waybill.py
+++ b/india_compliance/gst_india/api_classes/nic/e_waybill.py
@@ -158,7 +158,7 @@ class StandardEWaybillAPI(EWaybillAPI):
         if not self.company_gstin:
             frappe.throw(_("Company GSTIN is required to use the e-Waybill API"))
 
-        if not frappe.flags.in_test:
+        if not frappe.flags.bypass_auth:
             self.fetch_credentials(self.company_gstin, "e-Waybill / e-Invoice")
             self.set_default_headers()
 

--- a/india_compliance/gst_india/api_classes/nic/e_waybill.py
+++ b/india_compliance/gst_india/api_classes/nic/e_waybill.py
@@ -158,11 +158,12 @@ class StandardEWaybillAPI(EWaybillAPI):
         if not self.company_gstin:
             frappe.throw(_("Company GSTIN is required to use the e-Waybill API"))
 
-        self.fetch_credentials(self.company_gstin, "e-Waybill / e-Invoice")
-        self.set_default_headers()
+        if not frappe.flags.in_test:
+            self.fetch_credentials(self.company_gstin, "e-Waybill / e-Invoice")
+            self.set_default_headers()
 
-        self.auth_strategy = StandardAuth(self)
-        self.auth_strategy.authenticate()
+            self.auth_strategy = StandardAuth(self)
+            self.auth_strategy.authenticate()
 
     def _make_request(self, *args, **kwargs):
         response = super()._make_request(*args, **kwargs)

--- a/india_compliance/gst_india/constants/__init__.py
+++ b/india_compliance/gst_india/constants/__init__.py
@@ -1423,6 +1423,8 @@ UNBODY = re.compile(r"^[0-9]{4}[A-Z]{3}[0-9]{5}[UO]{1}[N][A-Z0-9]{1}$")
 TDS = re.compile(r"^[0-9]{2}[A-Z]{4}[A-Z0-9]{1}[0-9]{4}[A-Z]{1}[1-9A-Z]{1}[D][0-9A-Z]$")
 TCS = re.compile(r"^[0-9]{2}[A-Z]{5}[0-9]{4}[A-Z]{1}[1-9A-Z]{1}[C]{1}[0-9A-Z]{1}$")
 
+GSTIN_FORMAT = re.compile(r"[0-9]{2}[A-Z]{5}[0-9]{4}[A-Z]{1}[1-9A-Z]{1}Z[0-9A-Z]{1}")
+
 GSTIN_FORMATS = {
     "Registered Regular": REGISTERED,
     "Registered Composition": REGISTERED,

--- a/india_compliance/gst_india/data/test_e_invoice.json
+++ b/india_compliance/gst_india/data/test_e_invoice.json
@@ -899,5 +899,108 @@
             "success": false,
             "message": "e-Invoice generation failed"
         }
+    },
+    "gstin_error_3029_cancelled": {
+        "kwargs": {
+            "vehicle_no": "GJ07DL9009",
+            "company_address": "_Test Indian Registered Company-Billing"
+        },
+        "request_data": {
+            "BuyerDtls": {
+                "Addr1": "Test Address - 3",
+                "Gstin": "29ABCDE1234F1Z5",
+                "LglNm": "_Test Registered Customer",
+                "Loc": "Test City",
+                "Pin": 500055,
+                "Pos": "29",
+                "Stcd": "29",
+                "TrdNm": "_Test Registered Customer"
+            },
+            "DocDtls": {
+                "Dt": "16/09/2022",
+                "No": "test_invoice_no",
+                "Typ": "INV"
+            },
+            "ItemList": [
+                {
+                    "AssAmt": 100000.0,
+                    "CesAmt": 0,
+                    "CesNonAdvlAmt": 0,
+                    "CesRt": 0,
+                    "CgstAmt": 9000.0,
+                    "Discount": 0,
+                    "GstRt": 18,
+                    "HsnCd": "61149090",
+                    "IgstAmt": 0,
+                    "IsServc": "N",
+                    "PrdDesc": "Test Trading Goods 1",
+                    "Qty": 1000.0,
+                    "SgstAmt": 9000.0,
+                    "SlNo": "1",
+                    "TotAmt": 100000.0,
+                    "TotItemVal": 118000.0,
+                    "Unit": "NOS",
+                    "UnitPrice": 100.0
+                }
+            ],
+            "SellerDtls": {
+                "Addr1": "Test Address - 1",
+                "Gstin": "02AMBPG7773M002",
+                "LglNm": "_Test Indian Registered Company",
+                "Loc": "Test City",
+                "Pin": 171302,
+                "Stcd": "02",
+                "TrdNm": "_Test Indian Registered Company"
+            },
+            "TranDtls": {
+                "RegRev": "N",
+                "SupTyp": "B2B",
+                "TaxSch": "GST"
+            },
+            "ValDtls": {
+                "AssVal": 100000.0,
+                "CesVal": 0,
+                "CgstVal": 9000.0,
+                "Discount": 0,
+                "IgstVal": 0,
+                "OthChrg": 0.0,
+                "RndOffAmt": 0.0,
+                "SgstVal": 9000.0,
+                "TotInvVal": 118000.0
+            },
+            "Version": "1.1"
+        },
+        "error_response_standard": {
+            "ErrorDetails": [
+                {
+                    "ErrorCode": "3029",
+                    "ErrorMessage": "GSTIN -29ABCDE1234F1Z5 is inactive or cancelled"
+                }
+            ],
+            "Status": 0,
+            "error_code": "3029"
+        },
+        "error_response_enriched": {
+            "message": "3029: GSTIN -29ABCDE1234F1Z5 is inactive or cancelled",
+            "success": false
+        },
+        "sync_gstin_response_inactive": {
+            "Status": "CAN",
+            "StatusDesc": "Cancelled",
+            "CtjCd": "29",
+            "LgnNm": "Test Company Name",
+            "TrdNm": "Test Trade Name",
+            "Adt": {
+                "Addr": {
+                    "Bnm": "Test Building",
+                    "St": "Test Street",
+                    "Loc": "Test Location",
+                    "Pncd": "500055",
+                    "Stcd": "29"
+                }
+            },
+            "ErrCd": "",
+            "ErrMsg": ""
+        }
     }
 }

--- a/india_compliance/gst_india/data/test_e_waybill.json
+++ b/india_compliance/gst_india/data/test_e_waybill.json
@@ -1271,5 +1271,85 @@
             },
             "success": true
         }
+    },
+    "ewaybill_gstin_error_3029": {
+        "kwargs": {
+            "vehicle_no": "GJ07DL9009",
+            "company_address": "_Test Indian Registered Company-Billing",
+            "customer": "_Test Registered Customer",
+            "currency": "INR",
+            "is_in_state": false
+        },
+        "request_data": {
+            "userGstin": "05AAACG2115R1ZN",
+            "supplyType": "O",
+            "subSupplyType": 1,
+            "docType": "BIL",
+            "docNo": "test_invoice_no",
+            "docDate": "25/02/2024",
+            "transactionType": 1,
+            "fromTrdName": "_Test Indian Registered Company",
+            "fromGstin": "05AAACG2115R1ZN",
+            "fromAddr1": "Test Address - 1",
+            "fromPlace": "Test City",
+            "fromPincode": 380015,
+            "fromStateCode": 5,
+            "actFromStateCode": 5,
+            "toTrdName": "_Test Registered Customer",
+            "toGstin": "29ABCDE1234F1Z5",
+            "toAddr1": "Test Address - 3",
+            "toPlace": "Test City",
+            "toPincode": 500055,
+            "toStateCode": 29,
+            "actToStateCode": 29,
+            "totalValue": 100000.0,
+            "cgstValue": 0,
+            "sgstValue": 0,
+            "igstValue": 18000.0,
+            "cessValue": 0,
+            "cessNonAdvolValue": 0,
+            "otherValue": 0.0,
+            "totInvValue": 118000.0,
+            "transMode": 1,
+            "transDistance": 10,
+            "transporterName": "Test Common Supplier",
+            "vehicleNo": "GJ07DL9009",
+            "vehicleType": "R",
+            "itemList": [
+                {
+                    "itemNo": 1,
+                    "productDesc": "Test Trading Goods 1",
+                    "hsnCode": "61149090",
+                    "qtyUnit": "NOS",
+                    "quantity": 1000.0,
+                    "taxableAmount": 100000.0,
+                    "sgstRate": 0,
+                    "cgstRate": 0,
+                    "igstRate": 18,
+                    "cessRate": 0,
+                    "cessNonAdvolRate": 0
+                }
+            ],
+            "mainHsnCode": "61149090"
+        },
+        "params": "action=GENEWAYBILL",
+        "error_response_standard": {
+            "ErrorDetails": [
+                {
+                    "ErrorCode": "3029",
+                    "ErrorMessage": "GSTIN -29ABCDE1234F1Z5 is inactive or cancelled"
+                }
+            ],
+            "Status": 0,
+            "error_code": "3029"
+        },
+        "error_response_enriched": {
+            "message": "3029: GSTIN -29ABCDE1234F1Z5 is inactive or cancelled",
+            "success": false
+        },
+        "sync_gstin_response_inactive": {
+            "Status": "CAN",
+            "StatusDesc": "Cancelled"
+        }
     }
 }

--- a/india_compliance/gst_india/utils/e_invoice.py
+++ b/india_compliance/gst_india/utils/e_invoice.py
@@ -24,6 +24,7 @@ from india_compliance.gst_india.constants import (
     CURRENCY_CODES,
     EXPORT_TYPES,
     GST_CATEGORIES,
+    GSTIN_FORMAT,
     PORT_CODES,
     TAXABLE_GST_TREATMENTS,
 )
@@ -157,7 +158,11 @@ def generate_e_invoice(docname, throw: bool = True, force: bool = False):
 
         # Handle Invalid GSTIN Error
         if result.error_code in ("3028", "3029", "3001"):
-            gstin = data.get("BuyerDtls").get("Gstin")
+            if result.error_code == "3001":
+                gstin = data.get("BuyerDtls").get("Gstin")
+            else:
+                gstin = GSTIN_FORMAT.search(result.message).group()
+
             response = api.sync_gstin_info(gstin)
 
             if response.Status != "ACT":

--- a/india_compliance/gst_india/utils/e_invoice.py
+++ b/india_compliance/gst_india/utils/e_invoice.py
@@ -161,12 +161,14 @@ def generate_e_invoice(docname, throw: bool = True, force: bool = False):
             if result.error_code == "3001":
                 gstin = data.get("BuyerDtls").get("Gstin")
             else:
-                gstin = GSTIN_FORMAT.search(result.message).group()
+                gstin = GSTIN_FORMAT.search(result.error_message).group()
 
             response = api.sync_gstin_info(gstin)
 
             if response.Status != "ACT":
-                frappe.throw(_("GSTIN {0} status is not Active").format(gstin))
+                frappe.throw(
+                    result.error_message, title=_("Error Generating e-Invoice")
+                )
 
             result = api.generate_irn(data)
 

--- a/india_compliance/gst_india/utils/e_invoice.py
+++ b/india_compliance/gst_india/utils/e_invoice.py
@@ -161,7 +161,15 @@ def generate_e_invoice(docname, throw: bool = True, force: bool = False):
             if result.error_code == "3001":
                 gstin = data.get("BuyerDtls").get("Gstin")
             else:
-                gstin = GSTIN_FORMAT.search(result.error_message).group()
+                match = GSTIN_FORMAT.search(result.error_message)
+                if not match:
+                    frappe.throw(
+                        _("Could not identify GSTIN from error: {0}").format(
+                            result.error_message or _("Unknown error")
+                        )
+                    )
+
+                gstin = match.group()
 
             response = api.sync_gstin_info(gstin)
 

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -183,6 +183,8 @@ def _generate_e_waybill(doc, throw=True, force=False):
                     result.error_message, title=_("Error Generating e-Waybill")
                 )
 
+            result = api.generate_e_waybill(data)
+
         if result.error_code == "4002":
             result = api.get_e_waybill_by_irn(doc.get("irn"))
 
@@ -190,6 +192,9 @@ def _generate_e_waybill(doc, throw=True, force=False):
             with_irn = False
             data = EWaybillData(doc).get_data(with_irn=with_irn)
             result = EWaybillAPI.create(doc).generate_e_waybill(data)
+
+        if not result.get("ewayBillNo" if not with_irn else "EwbNo"):
+            frappe.throw(_("e-Waybill generation failed"))
 
     except GSPServerError as e:
         handle_server_errors(settings, doc, "e-Waybill", e)

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -21,6 +21,7 @@ from india_compliance.gst_india.api_classes.nic.e_invoice import EInvoiceAPI
 from india_compliance.gst_india.api_classes.nic.e_waybill import EWaybillAPI
 from india_compliance.gst_india.constants import (
     GST_TAX_TYPES,
+    GSTIN_FORMAT,
     SALES_DOCTYPES,
     STATE_NUMBERS,
     TAXABLE_GST_TREATMENTS,
@@ -168,6 +169,14 @@ def _generate_e_waybill(doc, throw=True, force=False):
 
         api = EWaybillAPI if not with_irn else EInvoiceAPI
         result = api.create(doc).generate_e_waybill(data)
+
+        if result.error_code in ("3028", "3029"):
+            gstin = GSTIN_FORMAT.search(result.message).group()
+
+            response = api.sync_gstin_info(gstin)
+
+            if response.Status != "ACT":
+                frappe.throw(_("GSTIN {0} status is not Active").format(gstin))
 
         if result.error_code == "4002":
             result = api.create(doc).get_e_waybill_by_irn(doc.get("irn"))

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -174,12 +174,14 @@ def _generate_e_waybill(doc, throw=True, force=False):
 
         if result.error_code in ("3028", "3029"):
             # if the code reaches here, than api will always be EInvoiceAPI instance
-            gstin = GSTIN_FORMAT.search(result.message).group()
+            gstin = GSTIN_FORMAT.search(result.error_message).group()
 
             response = api.sync_gstin_info(gstin)
 
             if response.Status != "ACT":
-                frappe.throw(_("GSTIN {0} status is not Active").format(gstin))
+                frappe.throw(
+                    result.error_message, title=_("Error Generating e-Waybill")
+                )
 
         if result.error_code == "4002":
             result = api.get_e_waybill_by_irn(doc.get("irn"))

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -168,9 +168,12 @@ def _generate_e_waybill(doc, throw=True, force=False):
         data = EWaybillData(doc).get_data(with_irn=with_irn)
 
         api = EWaybillAPI if not with_irn else EInvoiceAPI
-        result = api.create(doc).generate_e_waybill(data)
+        api = api.create(doc)
+
+        result = api.generate_e_waybill(data)
 
         if result.error_code in ("3028", "3029"):
+            # if the code reaches here, than api will always be EInvoiceAPI instance
             gstin = GSTIN_FORMAT.search(result.message).group()
 
             response = api.sync_gstin_info(gstin)
@@ -179,7 +182,7 @@ def _generate_e_waybill(doc, throw=True, force=False):
                 frappe.throw(_("GSTIN {0} status is not Active").format(gstin))
 
         if result.error_code == "4002":
-            result = api.create(doc).get_e_waybill_by_irn(doc.get("irn"))
+            result = api.get_e_waybill_by_irn(doc.get("irn"))
 
         if result.error_code == "2148":
             with_irn = False

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -174,7 +174,16 @@ def _generate_e_waybill(doc, throw=True, force=False):
 
         if result.error_code in ("3028", "3029"):
             # if the code reaches here, than api will always be EInvoiceAPI instance
-            gstin = GSTIN_FORMAT.search(result.error_message).group()
+            match = GSTIN_FORMAT.search(result.error_message)
+
+            if not match:
+                frappe.throw(
+                    _("Could not identify GSTIN from error: {0}").format(
+                        result.error_message or _("Unknown error")
+                    )
+                )
+
+            gstin = match.group()
 
             response = api.sync_gstin_info(gstin)
 

--- a/india_compliance/gst_india/utils/test_e_invoice.py
+++ b/india_compliance/gst_india/utils/test_e_invoice.py
@@ -242,6 +242,7 @@ class TestEInvoice(IntegrationTestCase):
         responses.add(
             responses.GET,
             BASE_URL + "/test/ei/api/master/syncgstin",
+            match=[matchers.query_param_matcher({"gstin": "29ABCDE1234F1Z5"})],
             json=sync_gstin_response,
             status=200,
         )
@@ -279,6 +280,7 @@ class TestEInvoice(IntegrationTestCase):
         responses.add(
             responses.GET,
             BASE_URL + "/standard/ei/api/master/syncgstin",
+            match=[matchers.query_param_matcher({"gstin": "29ABCDE1234F1Z5"})],
             json=sync_gstin_response,
             status=200,
         )

--- a/india_compliance/gst_india/utils/test_e_invoice.py
+++ b/india_compliance/gst_india/utils/test_e_invoice.py
@@ -282,6 +282,7 @@ class TestEInvoice(IntegrationTestCase):
         )
 
         with self.assertRaises(frappe.exceptions.ValidationError) as cm:
+            frappe.flags.bypass_auth = True
             generate_e_invoice(si.name)
 
         self.assertIn("GSTIN 29ABCDE1234F1Z5 status is not Active", str(cm.exception))

--- a/india_compliance/gst_india/utils/test_e_invoice.py
+++ b/india_compliance/gst_india/utils/test_e_invoice.py
@@ -290,6 +290,10 @@ class TestEInvoice(IntegrationTestCase):
     @responses.activate
     def test_generate_e_invoice_with_goods_item(self):
         """Generate test e-Invoice for goods item"""
+        frappe.db.set_single_value(
+            "GST Settings", {"auto_cancel_e_waybill": 0, "fetch_e_waybill_data": 0}
+        )
+
         test_data = self.e_invoice_test_data.get("goods_item_with_ewaybill")
 
         si = create_sales_invoice(
@@ -665,6 +669,10 @@ class TestEInvoice(IntegrationTestCase):
     @responses.activate
     def test_mark_e_invoice_as_cancelled(self):
         """Test for mark e-Invoice as cancelled"""
+        frappe.db.set_single_value(
+            "GST Settings", {"auto_cancel_e_waybill": 0, "fetch_e_waybill_data": 0}
+        )
+
         test_data = self.e_invoice_test_data.get("goods_item_with_ewaybill")
 
         si = create_sales_invoice(
@@ -841,6 +849,10 @@ class TestEInvoice(IntegrationTestCase):
 
     @responses.activate
     def test_invoice_update_after_submit(self):
+        frappe.db.set_single_value(
+            "GST Settings", {"auto_cancel_e_waybill": 0, "fetch_e_waybill_data": 0}
+        )
+
         test_data = self.e_invoice_test_data.get("goods_item_with_ewaybill")
 
         si = create_sales_invoice(**test_data.get("kwargs"), qty=1000, is_in_state=True)

--- a/india_compliance/gst_india/utils/test_e_invoice.py
+++ b/india_compliance/gst_india/utils/test_e_invoice.py
@@ -219,7 +219,7 @@ class TestEInvoice(IntegrationTestCase):
     @responses.activate
     @change_settings("GST Settings", {"use_fallback_for_nic": 1})
     def test_generate_e_invoice_with_cancelled_shipping_gstin_enriched(self):
-        """Test error handling for cancelled shipping GSTIN (error 3029)"""
+        """Test error handling for cancelled shipping GSTIN - Enriched API (error 3029)"""
 
         test_data = self.e_invoice_test_data.get("gstin_error_3029_cancelled")
         si = create_sales_invoice(
@@ -249,12 +249,14 @@ class TestEInvoice(IntegrationTestCase):
         with self.assertRaises(frappe.exceptions.ValidationError) as cm:
             generate_e_invoice(si.name)
 
-        self.assertIn("GSTIN 29ABCDE1234F1Z5 status is not Active", str(cm.exception))
+        self.assertIn(
+            "GSTIN -29ABCDE1234F1Z5 is inactive or cancelled", str(cm.exception)
+        )
 
     @responses.activate
     @change_settings("GST Settings", {"use_fallback_for_nic": 0, "sandbox_mode": 0})
     def test_generate_e_invoice_with_cancelled_shipping_gstin_standard(self):
-        """Test error handling for cancelled shipping GSTIN (error 3029)"""
+        """Test error handling for cancelled shipping GSTIN - Standard API (error 3029)"""
 
         test_data = self.e_invoice_test_data.get("gstin_error_3029_cancelled")
         si = create_sales_invoice(
@@ -285,7 +287,9 @@ class TestEInvoice(IntegrationTestCase):
             frappe.flags.bypass_auth = True
             generate_e_invoice(si.name)
 
-        self.assertIn("GSTIN 29ABCDE1234F1Z5 status is not Active", str(cm.exception))
+        self.assertIn(
+            "GSTIN -29ABCDE1234F1Z5 is inactive or cancelled", str(cm.exception)
+        )
 
     @responses.activate
     def test_generate_e_invoice_with_goods_item(self):

--- a/india_compliance/gst_india/utils/test_e_invoice.py
+++ b/india_compliance/gst_india/utils/test_e_invoice.py
@@ -217,6 +217,76 @@ class TestEInvoice(IntegrationTestCase):
         )
 
     @responses.activate
+    @change_settings("GST Settings", {"use_fallback_for_nic": 1})
+    def test_generate_e_invoice_with_cancelled_shipping_gstin_enriched(self):
+        """Test error handling for cancelled shipping GSTIN (error 3029)"""
+
+        test_data = self.e_invoice_test_data.get("gstin_error_3029_cancelled")
+        si = create_sales_invoice(
+            **test_data.get("kwargs"),
+            qty=1000,
+            is_in_state=True,
+        )
+
+        error_response = test_data.get("error_response_enriched")
+
+        responses.add(
+            responses.POST,
+            BASE_URL + "/test/ei/api/invoice",
+            json=error_response,
+            status=200,
+        )
+
+        sync_gstin_response = test_data.get("sync_gstin_response_inactive")
+
+        responses.add(
+            responses.GET,
+            BASE_URL + "/test/ei/api/master/syncgstin",
+            json=sync_gstin_response,
+            status=200,
+        )
+
+        with self.assertRaises(frappe.exceptions.ValidationError) as cm:
+            generate_e_invoice(si.name)
+
+        self.assertIn("GSTIN 29ABCDE1234F1Z5 status is not Active", str(cm.exception))
+
+    @responses.activate
+    @change_settings("GST Settings", {"use_fallback_for_nic": 0, "sandbox_mode": 0})
+    def test_generate_e_invoice_with_cancelled_shipping_gstin_standard(self):
+        """Test error handling for cancelled shipping GSTIN (error 3029)"""
+
+        test_data = self.e_invoice_test_data.get("gstin_error_3029_cancelled")
+        si = create_sales_invoice(
+            **test_data.get("kwargs"),
+            qty=1000,
+            is_in_state=True,
+        )
+
+        error_response = test_data.get("error_response_standard")
+
+        responses.add(
+            responses.POST,
+            BASE_URL + "/standard/ei/api/invoice",
+            json=error_response,
+            status=200,
+        )
+
+        sync_gstin_response = test_data.get("sync_gstin_response_inactive")
+
+        responses.add(
+            responses.GET,
+            BASE_URL + "/standard/ei/api/master/syncgstin",
+            json=sync_gstin_response,
+            status=200,
+        )
+
+        with self.assertRaises(frappe.exceptions.ValidationError) as cm:
+            generate_e_invoice(si.name)
+
+        self.assertIn("GSTIN 29ABCDE1234F1Z5 status is not Active", str(cm.exception))
+
+    @responses.activate
     def test_generate_e_invoice_with_goods_item(self):
         """Generate test e-Invoice for goods item"""
         test_data = self.e_invoice_test_data.get("goods_item_with_ewaybill")

--- a/india_compliance/gst_india/utils/test_e_waybill.py
+++ b/india_compliance/gst_india/utils/test_e_waybill.py
@@ -970,6 +970,7 @@ class TestEWaybill(IntegrationTestCase):
         responses.add(
             responses.GET,
             BASE_URL + "/test/ei/api/master/syncgstin",
+            match=[matchers.query_param_matcher({"gstin": "29ABCDE1234F1Z5"})],
             json=sync_gstin_response,
             status=200,
         )
@@ -1014,6 +1015,7 @@ class TestEWaybill(IntegrationTestCase):
         responses.add(
             responses.GET,
             BASE_URL + "/standard/ei/api/master/syncgstin",
+            match=[matchers.query_param_matcher({"gstin": "29ABCDE1234F1Z5"})],
             json=sync_gstin_response,
             status=200,
         )

--- a/india_compliance/gst_india/utils/test_e_waybill.py
+++ b/india_compliance/gst_india/utils/test_e_waybill.py
@@ -21,6 +21,7 @@ from india_compliance.gst_india.utils.e_invoice import (
 )
 from india_compliance.gst_india.utils.e_waybill import (
     EWaybillData,
+    _generate_e_waybill,
     cancel_e_waybill,
     fetch_e_waybill_data,
     generate_e_waybill,
@@ -940,6 +941,87 @@ class TestEWaybill(IntegrationTestCase):
             frappe.get_doc("e-Waybill Log", {"reference_name": si.name}),
         )
 
+    @responses.activate
+    @change_settings("GST Settings", {"use_fallback_for_nic": 1, "enable_e_invoice": 1})
+    def test_generate_e_waybill_with_irn_with_cancelled_gstin_error_3029_enriched(self):
+        """Test error handling for cancelled GSTIN in e-waybill generation with Irn - Enriched API(error 3029)"""
+
+        test_data = self.e_waybill_test_data.get("ewaybill_gstin_error_3029")
+        si = create_sales_invoice(
+            **test_data.get("kwargs"),
+            qty=1000,
+            transporter="_Test Common Supplier",
+            distance=10,
+            mode_of_transport="Road",
+            irn="12345678901234567",
+        )
+
+        error_response = test_data.get("error_response_enriched")
+
+        responses.add(
+            responses.POST,
+            BASE_URL + "/test/ei/api/ewaybill",
+            json=error_response,
+            status=200,
+        )
+
+        sync_gstin_response = test_data.get("sync_gstin_response_inactive")
+
+        responses.add(
+            responses.GET,
+            BASE_URL + "/test/ei/api/master/syncgstin",
+            json=sync_gstin_response,
+            status=200,
+        )
+
+        with self.assertRaises(frappe.exceptions.ValidationError) as cm:
+            doc = load_doc("Sales Invoice", si.name, "submit")
+            _generate_e_waybill(doc)
+
+        self.assertIn("GSTIN 29ABCDE1234F1Z5 status is not Active", str(cm.exception))
+
+    @responses.activate
+    @change_settings(
+        "GST Settings",
+        {"use_fallback_for_nic": 0, "sandbox_mode": 0, "enable_e_invoice": 1},
+    )
+    def test_generate_e_waybill_with_cancelled_gstin_error_3029_standard(self):
+        """Test error handling for cancelled GSTIN in e-waybill generation with Irn - Standard API(error 3029)"""
+
+        test_data = self.e_waybill_test_data.get("ewaybill_gstin_error_3029")
+        si = create_sales_invoice(
+            **test_data.get("kwargs"),
+            qty=1000,
+            transporter="_Test Common Supplier",
+            distance=10,
+            mode_of_transport="Road",
+            irn="12345678901234567",
+        )
+
+        error_response = test_data.get("error_response_standard")
+
+        responses.add(
+            responses.POST,
+            BASE_URL + "/standard/ei/api/ewaybill",
+            json=error_response,
+            status=200,
+        )
+
+        sync_gstin_response = test_data.get("sync_gstin_response_inactive")
+
+        responses.add(
+            responses.GET,
+            BASE_URL + "/standard/ei/api/master/syncgstin",
+            json=sync_gstin_response,
+            status=200,
+        )
+
+        with self.assertRaises(frappe.exceptions.ValidationError) as cm:
+            doc = load_doc("Sales Invoice", si.name, "submit")
+            _generate_e_waybill(doc)
+
+        self.assertIn("GSTIN 29ABCDE1234F1Z5 status is not Active", str(cm.exception))
+
     # helper functions
     def _generate_e_waybill(
         self, docname=None, doctype="Sales Invoice", test_data=None, force=False
@@ -1124,7 +1206,7 @@ def update_dates_for_test_data(test_data):
             continue
 
         response_request = value.get("request_data")
-        response_result = value.get("response_data").get("result", {})
+        response_result = value.get("response_data", {}).get("result", {})
 
         for k, v in response_result.items():
             if k == "ewayBillDate":

--- a/india_compliance/gst_india/utils/test_e_waybill.py
+++ b/india_compliance/gst_india/utils/test_e_waybill.py
@@ -1018,6 +1018,8 @@ class TestEWaybill(IntegrationTestCase):
 
         with self.assertRaises(frappe.exceptions.ValidationError) as cm:
             doc = load_doc("Sales Invoice", si.name, "submit")
+
+            frappe.flags.bypass_auth = True
             _generate_e_waybill(doc)
 
         self.assertIn("GSTIN 29ABCDE1234F1Z5 status is not Active", str(cm.exception))

--- a/india_compliance/gst_india/utils/test_e_waybill.py
+++ b/india_compliance/gst_india/utils/test_e_waybill.py
@@ -1025,6 +1025,7 @@ class TestEWaybill(IntegrationTestCase):
 
             frappe.flags.bypass_auth = True
             _generate_e_waybill(doc)
+            frappe.flags.bypass_auth = False
 
         self.assertIn(
             "GSTIN -29ABCDE1234F1Z5 is inactive or cancelled", str(cm.exception)

--- a/india_compliance/gst_india/utils/test_e_waybill.py
+++ b/india_compliance/gst_india/utils/test_e_waybill.py
@@ -978,7 +978,9 @@ class TestEWaybill(IntegrationTestCase):
             doc = load_doc("Sales Invoice", si.name, "submit")
             _generate_e_waybill(doc)
 
-        self.assertIn("GSTIN 29ABCDE1234F1Z5 status is not Active", str(cm.exception))
+        self.assertIn(
+            "GSTIN -29ABCDE1234F1Z5 is inactive or cancelled", str(cm.exception)
+        )
 
     @responses.activate
     @change_settings(
@@ -1022,7 +1024,9 @@ class TestEWaybill(IntegrationTestCase):
             frappe.flags.bypass_auth = True
             _generate_e_waybill(doc)
 
-        self.assertIn("GSTIN 29ABCDE1234F1Z5 status is not Active", str(cm.exception))
+        self.assertIn(
+            "GSTIN -29ABCDE1234F1Z5 is inactive or cancelled", str(cm.exception)
+        )
 
     # helper functions
     def _generate_e_waybill(


### PR DESCRIPTION
Fixes: #3617

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added GSTIN regex validation and extraction to better detect GSTINs in error messages.
  - NIC integrations now respect an auth-bypass flag to skip credential/header/auth steps when enabled.

- **Bug Fixes**
  - Ignored error responses now include both error codes and descriptive messages.
  - e-Invoice/e-Waybill flows validate GSTIN status after certain errors and stop/retry appropriately; added safeguard when generation numbers are missing.

- **Tests**
  - Added tests for cancelled/inactive GSTIN scenarios and exposed a helper for e-waybill generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->