### PR TITLE
fix: do not adjust taxes in payment entry if there are not taxes charged

### DIFF
--- a/india_compliance/gst_india/overrides/payment_entry.py
+++ b/india_compliance/gst_india/overrides/payment_entry.py
@@ -444,6 +444,10 @@ def get_taxes_summary(company, payment_entries):
         .where(gl_entry.voucher_no.isin(references))
         .where(gl_entry.account.isin(gst_accounts))
         .where(gl_entry.company == company)
+        # This is temporary fix.
+        # It will still cause issues where
+        # other taxes are charged like TDS and GST Account are specified in deduction table.
+        .where(pe.total_taxes_and_charges != 0)
         .groupby(gl_entry.voucher_no)
         .run(as_dict=True)
     )

--- a/india_compliance/gst_india/overrides/test_advance_payment_entry.py
+++ b/india_compliance/gst_india/overrides/test_advance_payment_entry.py
@@ -478,6 +478,50 @@ class TestRegionalOverrides(TestAdvancePaymentEntry):
         payment_entry_amount = payment_entry[0].get("amount")
         self.assertNotEqual(400, payment_entry_amount)
 
+    def test_get_advance_payment_entries_for_regional_with_gst_accounts_in_deduction_table(
+        self,
+    ):
+        payment_doc = self._create_payment_entry(do_not_submit=True)
+        payment_doc.taxes = []
+        payment_doc.append(
+            "deductions",
+            {
+                "account": "Output Tax CGST - _TIRC",
+                "cost_center": "Main - _TIRC",
+                "amount": 45,
+            },
+        )
+        payment_doc.append(
+            "deductions",
+            {
+                "account": "Output Tax SGST - _TIRC",
+                "cost_center": "Main - _TIRC",
+                "amount": 45,
+            },
+        )
+        payment_doc.submit()
+        self.assertEqual(payment_doc.total_taxes_and_charges, 0)
+        invoice_doc = self._create_sales_invoice(payment_doc)
+
+        conditions = frappe._dict(
+            {"company": invoice_doc.get("company"), "name": payment_doc.name}
+        )
+
+        payment_entry = get_advance_payment_entries_for_regional(
+            party_type="Customer",
+            party=invoice_doc.customer,
+            party_account=[invoice_doc.debit_to],
+            order_list=[],
+            order_doctype="Sales Order",
+            include_unallocated=True,
+            condition=conditions,
+        )
+
+        payment_entry_amount = payment_entry[0].get("amount")
+        # Total Unallocated = 500+90 =>590
+        # Remaining Unallocated = 590 - 100 (sales invoice amount)
+        self.assertEqual(490, payment_entry_amount)
+
     def test_adjust_allocations_for_taxes(self):
         payment_doc = self._create_payment_entry()
         invoice_doc = self._create_sales_invoice()


### PR DESCRIPTION
Issue: If GST Accounts are used in the deduction table, they are also treated as Advance GST adjustment causing incorrect entries in payment reconciliation.


Closes: #3637 
Frappe Support Issue: https://support.frappe.io/app/hd-ticket/46775

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Exclude payment entries with zero total taxes from GST tax summaries to prevent inflated or misleading totals.
  * Ensure advance payment allocation correctly accounts for GST amounts recorded in deduction lines, producing accurate unallocated balances and allocations against invoices.

* **Tests**
  * Added test coverage for advance payment scenarios involving GST deductions to validate allocation and reporting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->