### PR TITLE
fix: set default value to `false` for force_update

### DIFF
--- a/india_compliance/public/js/utils.js
+++ b/india_compliance/public/js/utils.js
@@ -135,7 +135,7 @@ Object.assign(india_compliance, {
         return message;
     },
 
-    async set_pan_status(field, force_update = null) {
+    async set_pan_status(field, force_update = false) {
         const pan = field.value;
         field.set_description("");
         if (!pan || pan.length !== 10) return;

--- a/india_compliance/public/js/utils.js
+++ b/india_compliance/public/js/utils.js
@@ -110,7 +110,7 @@ Object.assign(india_compliance, {
         return in_list(frappe.boot.sales_doctypes, doctype) ? "Customer" : "Supplier";
     },
 
-    async set_gstin_status(field, doc, force_update) {
+    async set_gstin_status(field, doc, force_update = false) {
         const gstin = field.value;
         if (!gstin || gstin.length !== 15) return field.set_description("");
 


### PR DESCRIPTION
**Issue:** default value `null` converting to empty string and `Typehint` throwing the error.

<details>

<summary>Error Traceback</summary>

```
Traceback (most recent call last):
  File "apps/frappe/frappe/utils/typing_validations.py", line 160, in transform_parameter_types
    current_arg_value_after = TypeAdapter(current_arg_type).validate_python(current_arg_value)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "env/lib/python3.11/site-packages/pydantic/type_adapter.py", line 421, in validate_python
    return self.validator.validate_python(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pydantic_core._pydantic_core.ValidationError: 3 validation errors for union[int,bool,float]
int
  Input should be a valid integer, unable to parse string as an integer [type=int_parsing, input_value='', input_type=str]
    For further information visit https://errors.pydantic.dev/2.11/v/int_parsing
bool
  Input should be a valid boolean, unable to interpret input [type=bool_parsing, input_value='', input_type=str]
    For further information visit https://errors.pydantic.dev/2.11/v/bool_parsing
float
  Input should be a valid number, unable to parse string as a number [type=float_parsing, input_value='', input_type=str]
    For further information visit https://errors.pydantic.dev/2.11/v/float_parsing

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 121, in application
    response = frappe.api.handle(request)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/api/__init__.py", line 60, in handle
    data = endpoint(**arguments)
           ^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/api/v1.py", line 36, in handle_rpc_call
    return frappe.handler.handle()
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/handler.py", line 52, in handle
    data = execute_cmd(cmd)
           ^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/handler.py", line 85, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/__init__.py", line 1127, in call
    return fn(*args, **newargs)
           ^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/utils/typing_validations.py", line 34, in wrapper
    args, kwargs = transform_parameter_types(func, args, kwargs)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/utils/typing_validations.py", line 162, in transform_parameter_types
    raise_type_error(func, current_arg, current_arg_type, current_arg_value, current_exception=e)
  File "apps/frappe/frappe/utils/typing_validations.py", line 73, in raise_type_error
    raise FrappeTypeError(
frappe.exceptions.FrappeTypeError: Argument 'force_update' in 'india_compliance.gst_india.doctype.pan.pan.get_pan_status' should be of type 'typing.Union[int, bool, float]' but got 'str' instead.
request.js:478:14

```

</details> 

> [!NOTE]
> Backport to V-15

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * PAN status check: default behavior now avoids forcing a refresh when no preference is specified, reducing unnecessary network calls and preventing unintended overwrites; explicit refresh still works.
  * GSTIN status check: default behavior now supplies a clear false value when no refresh is requested, ensuring more consistent backend calls and UI status handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->