### PR TITLE
fix: add default invoice sub categories based on selected sub section in Purchase Register Beta

### DIFF
--- a/india_compliance/gst_india/report/gst_purchase_register/gst_purchase_register.py
+++ b/india_compliance/gst_india/report/gst_purchase_register/gst_purchase_register.py
@@ -286,6 +286,10 @@ def get_data(filters):
     is_grouped_by_invoice = filters.summary_by != "Summary by Item"
     sub_section = filters.sub_section
 
+    # Set default invoice sub categories if only sub_section is selected
+    if not filters.invoice_sub_category:
+        filters.invoice_sub_category = get_invoice_sub_categories(sub_section)
+
     doctypes = ["Purchase Invoice"]
     if sub_section == "4":
         doctypes.extend(["Bill of Entry", "Journal Entry"])
@@ -302,6 +306,14 @@ def get_data(filters):
     )
 
     return data
+
+
+def get_invoice_sub_categories(sub_section):
+    section = SECTION_MAPPING.get(sub_section) or {}
+
+    return [
+        category for sub_categories in section.values() for category in sub_categories
+    ]
 
 
 def get_summary_view(data, sub_section):


### PR DESCRIPTION
Issue: Data was not filtered in the Purchase Register Beta if only the section is selected but not sub_category.

Closes: https://github.com/resilient-tech/india-compliance/issues/3639

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - GST Purchase Register now auto-populates the Invoice Sub-category filter when left blank, deriving values from the selected sub-section for comprehensive coverage across ITC groups.
  - Enhances usability and speeds up report setup with sensible defaults while preserving existing data flow and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->