### PR TITLE
fix: move set_gst_tax_type from `before_validate` to `validate`

### DIFF
--- a/india_compliance/gst_india/doctype/bill_of_entry/bill_of_entry.py
+++ b/india_compliance/gst_india/doctype/bill_of_entry/bill_of_entry.py
@@ -55,12 +55,12 @@ class BillofEntry(Document):
 
     def before_validate(self):
         self.set_taxes_and_totals()
-        set_gst_tax_type(self)
 
     def before_submit(self):
         self.validate_qty()
 
     def validate(self):
+        set_gst_tax_type(self)
         self.validate_purchase_invoice()
         self.validate_taxes()
         self.reconciliation_status = "Unreconciled"

--- a/india_compliance/gst_india/overrides/journal_entry.py
+++ b/india_compliance/gst_india/overrides/journal_entry.py
@@ -7,7 +7,7 @@ from india_compliance.gst_india.overrides.transaction import (
 from india_compliance.gst_india.utils import get_gst_account_gst_tax_type_map
 
 
-def before_validate(doc, method=None):
+def set_gst_tax_type(doc, method=None):
     if not doc.accounts:
         return
 
@@ -23,6 +23,8 @@ def before_validate(doc, method=None):
 def validate(doc, method=None):
     if doc.company_gstin or not is_indian_registered_company(doc):
         return
+
+    set_gst_tax_type(doc)
 
     # validate company_gstin
     contains_gst_account = False

--- a/india_compliance/gst_india/overrides/payment_entry.py
+++ b/india_compliance/gst_india/overrides/payment_entry.py
@@ -10,6 +10,7 @@ from erpnext.controllers.accounts_controller import get_advance_payment_entries
 from india_compliance.gst_india.constants import TAX_TYPES
 from india_compliance.gst_india.overrides.transaction import (
     get_gst_details,
+    set_gst_tax_type,
 )
 from india_compliance.gst_india.overrides.transaction import (
     validate_backdated_transaction as _validate_backdated_transaction,
@@ -90,6 +91,7 @@ def validate(doc, method=None):
         validate_transaction_for_advance_payment(doc, method)
 
     else:
+        set_gst_tax_type(doc)
         for row in doc.taxes:
             if row.gst_tax_type in TAX_TYPES and row.tax_amount != 0:
                 frappe.throw(

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -1662,6 +1662,7 @@ def validate_transaction(doc, method=None):
     if ignore_gst_validations(doc):
         return False
 
+    set_gst_tax_type(doc)
     validate_items(doc)
 
     if doc.place_of_supply:

--- a/india_compliance/hooks.py
+++ b/india_compliance/hooks.py
@@ -148,7 +148,6 @@ doc_events = {
         "before_save": "india_compliance.gst_india.overrides.transaction.update_gst_details",
         "before_submit": "india_compliance.gst_india.overrides.transaction.update_gst_details",
         "before_cancel": "india_compliance.gst_india.utils.e_waybill.before_cancel",
-        "before_validate": "india_compliance.gst_india.overrides.transaction.set_gst_tax_type",
         "validate": (
             "india_compliance.gst_india.overrides.transaction.validate_transaction"
         ),
@@ -166,11 +165,9 @@ doc_events = {
     },
     "Journal Entry": {
         "validate": "india_compliance.gst_india.overrides.journal_entry.validate",
-        "before_validate": "india_compliance.gst_india.overrides.journal_entry.before_validate",
     },
     "Payment Entry": {
         "onload": "india_compliance.gst_india.overrides.payment_entry.onload",
-        "before_validate": "india_compliance.gst_india.overrides.transaction.set_gst_tax_type",
         "validate": "india_compliance.gst_india.overrides.payment_entry.validate",
         "on_submit": "india_compliance.gst_india.overrides.payment_entry.on_submit",
         "on_update_after_submit": "india_compliance.gst_india.overrides.payment_entry.on_update_after_submit",
@@ -184,7 +181,6 @@ doc_events = {
         "before_print": "india_compliance.gst_india.overrides.transaction.before_print",
         "before_validate": [
             "india_compliance.gst_india.overrides.transaction.before_validate_transaction",
-            "india_compliance.gst_india.overrides.transaction.set_gst_tax_type",
         ],
         "validate": "india_compliance.gst_india.overrides.purchase_invoice.validate",
         "before_save": "india_compliance.gst_india.overrides.transaction.update_gst_details",
@@ -200,7 +196,6 @@ doc_events = {
         "before_print": "india_compliance.gst_india.overrides.transaction.before_print",
         "before_validate": [
             "india_compliance.gst_india.overrides.transaction.before_validate_transaction",
-            "india_compliance.gst_india.overrides.transaction.set_gst_tax_type",
         ],
         "validate": (
             "india_compliance.gst_india.overrides.transaction.validate_transaction"
@@ -220,7 +215,6 @@ doc_events = {
         "before_print": "india_compliance.gst_india.overrides.transaction.before_print",
         "before_validate": [
             "india_compliance.gst_india.overrides.transaction.before_validate_transaction",
-            "india_compliance.gst_india.overrides.transaction.set_gst_tax_type",
         ],
         "validate": "india_compliance.gst_india.overrides.purchase_receipt.validate",
         "before_save": "india_compliance.gst_india.overrides.transaction.update_gst_details",
@@ -235,9 +229,6 @@ doc_events = {
             "india_compliance.gst_india.overrides.transaction.onload",
         ],
         "before_print": "india_compliance.gst_india.overrides.transaction.before_print",
-        "before_validate": [
-            "india_compliance.gst_india.overrides.transaction.set_gst_tax_type"
-        ],
         "validate": "india_compliance.gst_india.overrides.sales_invoice.validate",
         "before_save": "india_compliance.gst_india.overrides.transaction.update_gst_details",
         "before_submit": "india_compliance.gst_india.overrides.transaction.update_gst_details",
@@ -253,7 +244,6 @@ doc_events = {
     "Sales Order": {
         "onload": "india_compliance.gst_india.overrides.transaction.onload",
         "before_print": "india_compliance.gst_india.overrides.transaction.before_print",
-        "before_validate": "india_compliance.gst_india.overrides.transaction.set_gst_tax_type",
         "validate": (
             "india_compliance.gst_india.overrides.transaction.validate_transaction"
         ),
@@ -308,7 +298,6 @@ doc_events = {
     "POS Invoice": {
         "onload": "india_compliance.gst_india.overrides.transaction.onload",
         "before_print": "india_compliance.gst_india.overrides.transaction.before_print",
-        "before_validate": "india_compliance.gst_india.overrides.transaction.set_gst_tax_type",
         "validate": (
             "india_compliance.gst_india.overrides.transaction.validate_transaction"
         ),
@@ -318,7 +307,6 @@ doc_events = {
     "Quotation": {
         "onload": "india_compliance.gst_india.overrides.transaction.onload",
         "before_print": "india_compliance.gst_india.overrides.transaction.before_print",
-        "before_validate": "india_compliance.gst_india.overrides.transaction.set_gst_tax_type",
         "validate": (
             "india_compliance.gst_india.overrides.transaction.validate_transaction"
         ),
@@ -330,7 +318,6 @@ doc_events = {
         "before_print": "india_compliance.gst_india.overrides.transaction.before_print",
         "before_validate": [
             "india_compliance.gst_india.overrides.transaction.before_validate_transaction",
-            "india_compliance.gst_india.overrides.transaction.set_gst_tax_type",
         ],
         "validate": (
             "india_compliance.gst_india.overrides.transaction.validate_transaction"


### PR DESCRIPTION
Issue: In ERPNext, taxes are set in the validate hook before gst_tax_type is set, causing the taxable value to be computed incorrectly.

Frappe Support Issue: https://support.frappe.io/app/hd-ticket/46877

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * GST tax type is now assigned during validation for key documents (e.g., Sales/Purchase Invoices and Orders, Receipts, Delivery Notes, Payment and Journal Entries, Quotations, POS Invoice), leading to more accurate GST checks and fewer incorrect errors (e.g., missing GSTIN or non-zero tax amounts).

* **Refactor**
  * Streamlined and reduced pre-validation hooks, consolidating GST handling within validation for more consistent behavior across transactions.
  * No changes to public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->