### PR TITLE
fix: use string instead of object for description

### DIFF
--- a/india_compliance/public/js/utils.js
+++ b/india_compliance/public/js/utils.js
@@ -169,16 +169,18 @@ Object.assign(india_compliance, {
             "pan-last-synced"
         );
 
+        field.set_description(pan_desc);
+
         const refresh_btn = this.get_status_refresh_button(
             "refresh-pan",
-            pan_desc.find(".pan-last-synced")
+            field.$wrapper.find(".pan-last-synced")
         );
 
         refresh_btn.on("click", async function () {
             await india_compliance.set_pan_status(field, true);
         });
 
-        return field.set_description(pan_desc);
+        return;
     },
 
     validate_gst_transporter_id(transporter_id, doc) {
@@ -239,7 +241,7 @@ Object.assign(india_compliance, {
         const user_date = frappe.datetime.str_to_user(datetime);
         const pretty_date = frappe.datetime.prettyDate(datetime);
 
-        return $(`<div class="d-flex indicator ${indicator}" style="font-size: 12px">
+        return `<div class="d-flex indicator ${indicator}" style="font-size: 12px">
                     <strong>${status}</strong>
                     <span class="d-flex justify-content-between align-items-center ${classes}"
                         title="${user_date}" style="margin-left: auto;gap: 2px">
@@ -247,7 +249,7 @@ Object.assign(india_compliance, {
                            datetime ? "Synced " + pretty_date : ""
                        }</span>
                     </span>
-                </div>`);
+                </div>`;
     },
 
     get_status_refresh_button(classes, append_to = null, style = null) {


### PR DESCRIPTION
Issue: If the description is passed as an object, an error is raised.
regression: https://github.com/frappe/frappe/pull/33791

Traceback
```
Uncaught (in promise) TypeError: description2.includes is not a function
    set_description base_input.js:212
    set_gstin_status utils.js:126
    _set_gstin_status transaction.js:271
    refresh transaction.js:232
    _handler script_manager.js:30
    runner script_manager.js:109
    trigger script_manager.js:127
    promise callback*frappe.run_serially/< dom.js:276
    run_serially dom.js:274
    trigger script_manager.js:141
    render_form form.js:622
    promise callback*frappe.run_serially/< dom.js:276
    run_serially dom.js:274
    render_form form.js:612
    initialize_new_doc form.js:581
    promise callback*initialize_new_doc form.js:578
    trigger_onload form.js:559
    refresh form.js:448
    render formview.js:107
    fetch_and_render formview.js:91
    callback model.js:283
    callback request.js:87
    200 request.js:135
    call request.js:310
    jQuery 6
    call request.js:284
    call request.js:111
    with_doc model.js:275
    with_doc model.js:265
    fetch_and_render formview.js:80
base_input.js:212:19




```
Related PR: https://github.com/resilient-tech/india-compliance/pull/2762
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Streamlined how status indicators are rendered for PAN/GST fields to use plain HTML.
  - Updated refresh control attachment to ensure it targets the correct element.
  - Improves consistency of status descriptions and refresh behavior with no visible UI changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->