### PR TITLE
fix: do not fetch gstin info if it is in data import

### DIFF
--- a/india_compliance/gst_india/doctype/gstin/gstin.py
+++ b/india_compliance/gst_india/doctype/gstin/gstin.py
@@ -63,6 +63,9 @@ def create_or_update_gstin_status(
     is_transporter_id=False,
     throw=False,
 ):
+    if frappe.flags.in_import:
+        return
+
     doctype = "GSTIN"
 
     if not response:

--- a/india_compliance/gst_india/overrides/party.py
+++ b/india_compliance/gst_india/overrides/party.py
@@ -49,7 +49,7 @@ def fetch_or_guess_gst_category(doc):
     if doc.gstin and doc.gst_category == "Deemed Export":
         return doc.gst_category
 
-    if doc.gstin and is_autofill_party_info_enabled():
+    if doc.gstin and is_autofill_party_info_enabled() and not frappe.flags.in_import:
         gstin_info = _get_gstin_info(doc.gstin, doc=doc, throw_error=False) or {}
 
         if gstin_info.get("gst_category"):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Stops GSTIN autofill lookups during data imports, reducing errors/timeouts and improving import reliability and speed.
  - During imports, GST category is now inferred rather than fetched from GSTIN; manual entry still uses autofill.
  - Skips GSTIN status processing and external API calls during import flows, minimizing unintended external requests in bulk operations.
  - No changes to Overseas or Deemed Export handling; existing behavior remains intact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->