### PR TITLE
perf: optimize tax updates for items with HSN code using bulk operations

### DIFF
--- a/india_compliance/gst_india/doctype/gst_hsn_code/gst_hsn_code.py
+++ b/india_compliance/gst_india/doctype/gst_hsn_code/gst_hsn_code.py
@@ -74,7 +74,7 @@ def _update_item_modified_timestamp(item_names, timestamp=None):
         frappe.qb.update(item)
         .set(item.modified, timestamp or frappe.utils.now())
         .set(item.modified_by, frappe.session.user)
-        .where(frappe.qb.DocType("Item").name.isin(item_names))
+        .where(item.name.isin(item_names))
     ).run()
 
 

--- a/india_compliance/gst_india/doctype/gst_hsn_code/gst_hsn_code.py
+++ b/india_compliance/gst_india/doctype/gst_hsn_code/gst_hsn_code.py
@@ -24,7 +24,6 @@ def update_taxes_in_item_master(taxes, hsn_code):
 
 
 def update_item_document(taxes, hsn_code):
-    """Update taxes for all items with the given HSN code using bulk operations for performance."""
     taxes = frappe.parse_json(taxes)
     items = frappe.get_list("Item", filters={"gst_hsn_code": hsn_code}, pluck="name")
 
@@ -79,13 +78,10 @@ def _update_item_modified_timestamp(item_names, timestamp=None):
 
 
 def _add_comment_to_items(item_names, hsn_code, timestamp=None):
-    """Add a comment to each Item document about the tax update from HSN code."""
     if not item_names:
         return
 
-    comment_text = (
-        f"Item tax was changed because of change from GST HSN Code {hsn_code}"
-    )
+    comment_text = f"changed item tax from GST HSN Code {hsn_code}"
 
     comment_docs = []
     current_time = timestamp or frappe.utils.now()

--- a/india_compliance/gst_india/doctype/gst_hsn_code/gst_hsn_code.py
+++ b/india_compliance/gst_india/doctype/gst_hsn_code/gst_hsn_code.py
@@ -101,9 +101,13 @@ def _bulk_insert_item_taxes(item_names, taxes):
 
 
 def _update_item_modified_timestamp(item_names):
-    frappe.qb.update(frappe.qb.DocType("Item")).set("modified", frappe.utils.now()).set(
-        "modified_by", frappe.session.user
-    ).where(frappe.qb.DocType("Item").name.isin(item_names)).run()
+    item = frappe.qb.DocType("Item")
+    (
+        frappe.qb.update(item)
+        .set(item.modified, frappe.utils.now())
+        .set(item.modified_by, frappe.session.user)
+        .where(frappe.qb.DocType("Item").name.isin(item_names))
+    ).run()
 
 
 def validate_hsn_code(hsn_code):

--- a/india_compliance/gst_india/doctype/gst_hsn_code/gst_hsn_code.py
+++ b/india_compliance/gst_india/doctype/gst_hsn_code/gst_hsn_code.py
@@ -4,9 +4,9 @@
 import frappe
 from frappe import _
 from frappe.model.document import Document
+from frappe.utils import now, random_string
 
 from india_compliance.gst_india.utils import (
-    enable_autocommit,
     get_hsn_settings,
     join_list_with_custom_separators,
 )
@@ -23,28 +23,87 @@ def update_taxes_in_item_master(taxes, hsn_code):
     return 1
 
 
-@enable_autocommit
-def update_item_document(taxes, hsn_code):
-    taxes = frappe.parse_json(taxes)
-    items = frappe.get_list("Item", filters={"gst_hsn_code": hsn_code})
+BATCH_SIZE = 100
 
-    for index, item in enumerate(items):
-        item_to_be_updated = frappe.get_doc("Item", item.name)
-        item_to_be_updated.taxes = []
-        for tax in taxes:
+
+def update_item_document(taxes, hsn_code):
+    """Update taxes for all items with the given HSN code using bulk operations for performance."""
+    taxes = frappe.parse_json(taxes)
+    items = frappe.get_list("Item", filters={"gst_hsn_code": hsn_code}, pluck="name")
+
+    if not items:
+        return
+
+    for i in range(0, len(items), BATCH_SIZE):
+        batch_items = items[i : i + BATCH_SIZE]
+        _process_item_batch(batch_items, taxes)
+
+
+def _process_item_batch(batch_items, taxes):
+    frappe.db.delete("Item Tax", {"parent": ["in", batch_items]})
+
+    if taxes:
+        _bulk_insert_item_taxes(batch_items, taxes)
+
+    _update_item_modified_timestamp(batch_items)
+
+    # TODO: Add Versioning?
+
+    frappe.db.commit()
+
+
+def _bulk_insert_item_taxes(item_names, taxes):
+    fields = [
+        "name",
+        "parent",
+        "parenttype",
+        "parentfield",
+        "item_tax_template",
+        "tax_category",
+        "valid_from",
+        "minimum_net_rate",
+        "maximum_net_rate",
+        "creation",
+        "modified",
+        "modified_by",
+        "owner",
+        "idx",
+    ]
+
+    current_time = now()
+    current_user = frappe.session.user
+
+    values = []
+    for item_name in item_names:
+        for index, tax in enumerate(taxes):
             tax = frappe._dict(tax)
-            item_to_be_updated.append(
-                "taxes",
-                {
-                    "item_tax_template": tax.item_tax_template,
-                    "tax_category": tax.tax_category,
-                    "valid_from": tax.valid_from,
-                    "minimum_net_rate": tax.minimum_net_rate,
-                    "maximum_net_rate": tax.maximum_net_rate,
-                },
+            values.append(
+                (
+                    random_string(10),  # name
+                    item_name,  # parent
+                    "Item",  # parenttype
+                    "taxes",  # parentfield
+                    tax.item_tax_template,
+                    tax.tax_category,
+                    tax.valid_from,
+                    tax.minimum_net_rate,
+                    tax.maximum_net_rate,
+                    current_time,  # creation
+                    current_time,  # modified
+                    current_user,  # modified_by
+                    current_user,  # owner
+                    index + 1,  # idx
+                )
             )
 
-        item_to_be_updated.save()
+    if values:
+        frappe.db.bulk_insert("Item Tax", fields, values)
+
+
+def _update_item_modified_timestamp(item_names):
+    frappe.qb.update(frappe.qb.DocType("Item")).set("modified", frappe.utils.now()).set(
+        "modified_by", frappe.session.user
+    ).where(frappe.qb.DocType("Item").name.isin(item_names)).run()
 
 
 def validate_hsn_code(hsn_code):

--- a/india_compliance/gst_india/doctype/gst_hsn_code/gst_hsn_code.py
+++ b/india_compliance/gst_india/doctype/gst_hsn_code/gst_hsn_code.py
@@ -36,7 +36,10 @@ def update_item_document(taxes, hsn_code):
     if taxes:
         _bulk_insert_item_taxes(items, taxes)
 
-    _update_item_modified_timestamp(items)
+    timestamp = frappe.utils.now()
+
+    _update_item_modified_timestamp(items, timestamp)
+    _add_comment_to_items(items, hsn_code, timestamp)
 
 
 def _bulk_insert_item_taxes(item_names, taxes):
@@ -65,14 +68,50 @@ def _bulk_insert_item_taxes(item_names, taxes):
         bulk_insert("Item Tax", documents)
 
 
-def _update_item_modified_timestamp(item_names):
+def _update_item_modified_timestamp(item_names, timestamp=None):
     item = frappe.qb.DocType("Item")
     (
         frappe.qb.update(item)
-        .set(item.modified, frappe.utils.now())
+        .set(item.modified, timestamp or frappe.utils.now())
         .set(item.modified_by, frappe.session.user)
         .where(frappe.qb.DocType("Item").name.isin(item_names))
     ).run()
+
+
+def _add_comment_to_items(item_names, hsn_code, timestamp=None):
+    """Add a comment to each Item document about the tax update from HSN code."""
+    if not item_names:
+        return
+
+    comment_text = (
+        f"Item tax was changed because of change from GST HSN Code {hsn_code}"
+    )
+
+    comment_docs = []
+    current_time = timestamp or frappe.utils.now()
+    current_user = frappe.session.user
+
+    for item_name in item_names:
+        comment_doc = frappe.new_doc("Comment")
+        comment_doc.update(
+            {
+                "name": random_string(10),
+                "comment_type": "Info",
+                "comment_email": current_user,
+                "comment_by": current_user,
+                "creation": current_time,
+                "modified": current_time,
+                "modified_by": current_user,
+                "owner": current_user,
+                "reference_doctype": "Item",
+                "reference_name": item_name,
+                "content": comment_text,
+            }
+        )
+        comment_docs.append(comment_doc)
+
+    if comment_docs:
+        bulk_insert("Comment", comment_docs)
 
 
 def validate_hsn_code(hsn_code):

--- a/india_compliance/gst_india/doctype/gst_hsn_code/gst_hsn_code.py
+++ b/india_compliance/gst_india/doctype/gst_hsn_code/gst_hsn_code.py
@@ -3,8 +3,8 @@
 
 import frappe
 from frappe import _
-from frappe.model.document import Document
-from frappe.utils import now, random_string
+from frappe.model.document import Document, bulk_insert
+from frappe.utils import random_string
 
 from india_compliance.gst_india.utils import (
     get_hsn_settings,
@@ -23,9 +23,6 @@ def update_taxes_in_item_master(taxes, hsn_code):
     return 1
 
 
-BATCH_SIZE = 100
-
-
 def update_item_document(taxes, hsn_code):
     """Update taxes for all items with the given HSN code using bulk operations for performance."""
     taxes = frappe.parse_json(taxes)
@@ -34,70 +31,38 @@ def update_item_document(taxes, hsn_code):
     if not items:
         return
 
-    for i in range(0, len(items), BATCH_SIZE):
-        batch_items = items[i : i + BATCH_SIZE]
-        _process_item_batch(batch_items, taxes)
-
-
-def _process_item_batch(batch_items, taxes):
-    frappe.db.delete("Item Tax", {"parent": ["in", batch_items]})
+    frappe.db.delete("Item Tax", {"parent": ["in", items]})
 
     if taxes:
-        _bulk_insert_item_taxes(batch_items, taxes)
+        _bulk_insert_item_taxes(items, taxes)
 
-    _update_item_modified_timestamp(batch_items)
-
-    # TODO: Add Versioning?
-
-    frappe.db.commit()  # nosemgrep
+    _update_item_modified_timestamp(items)
 
 
 def _bulk_insert_item_taxes(item_names, taxes):
-    fields = [
-        "name",
-        "parent",
-        "parenttype",
-        "parentfield",
-        "item_tax_template",
-        "tax_category",
-        "valid_from",
-        "minimum_net_rate",
-        "maximum_net_rate",
-        "creation",
-        "modified",
-        "modified_by",
-        "owner",
-        "idx",
-    ]
-
-    current_time = now()
-    current_user = frappe.session.user
-
-    values = []
+    documents = []
     for item_name in item_names:
-        for index, tax in enumerate(taxes):
+        for tax in taxes:
             tax = frappe._dict(tax)
-            values.append(
-                (
-                    random_string(10),  # name
-                    item_name,  # parent
-                    "Item",  # parenttype
-                    "taxes",  # parentfield
-                    tax.get("item_tax_template"),
-                    tax.get("tax_category"),
-                    tax.get("valid_from"),
-                    tax.get("minimum_net_rate", 0),
-                    tax.get("maximum_net_rate", 0),
-                    current_time,  # creation
-                    current_time,  # modified
-                    current_user,  # modified_by
-                    current_user,  # owner
-                    index + 1,  # idx
-                )
+            doc = frappe.new_doc("Item Tax")
+            doc.update(
+                {
+                    "name": random_string(10),
+                    "parent": item_name,
+                    "parenttype": "Item",
+                    "parentfield": "taxes",
+                    "item_tax_template": tax.get("item_tax_template"),
+                    "tax_category": tax.get("tax_category"),
+                    "valid_from": tax.get("valid_from"),
+                    "minimum_net_rate": tax.get("minimum_net_rate", 0),
+                    "maximum_net_rate": tax.get("maximum_net_rate", 0),
+                    "idx": tax.get("idx"),
+                }
             )
+            documents.append(doc)
 
-    if values:
-        frappe.db.bulk_insert("Item Tax", fields, values)
+    if documents:
+        bulk_insert("Item Tax", documents)
 
 
 def _update_item_modified_timestamp(item_names):

--- a/india_compliance/gst_india/doctype/gst_hsn_code/gst_hsn_code.py
+++ b/india_compliance/gst_india/doctype/gst_hsn_code/gst_hsn_code.py
@@ -42,7 +42,7 @@ def update_item_document(taxes, hsn_code):
 def _bulk_insert_item_taxes(item_names, taxes):
     documents = []
     for item_name in item_names:
-        for tax in taxes:
+        for index, tax in enumerate(taxes):
             tax = frappe._dict(tax)
             doc = frappe.new_doc("Item Tax")
             doc.update(
@@ -56,7 +56,7 @@ def _bulk_insert_item_taxes(item_names, taxes):
                     "valid_from": tax.get("valid_from"),
                     "minimum_net_rate": tax.get("minimum_net_rate", 0),
                     "maximum_net_rate": tax.get("maximum_net_rate", 0),
-                    "idx": tax.get("idx"),
+                    "idx": tax.get("idx", index + 1),
                 }
             )
             documents.append(doc)

--- a/india_compliance/gst_india/doctype/gst_hsn_code/gst_hsn_code.py
+++ b/india_compliance/gst_india/doctype/gst_hsn_code/gst_hsn_code.py
@@ -83,11 +83,11 @@ def _bulk_insert_item_taxes(item_names, taxes):
                     item_name,  # parent
                     "Item",  # parenttype
                     "taxes",  # parentfield
-                    tax.item_tax_template,
-                    tax.tax_category,
-                    tax.valid_from,
-                    tax.minimum_net_rate,
-                    tax.maximum_net_rate,
+                    tax.get("item_tax_template"),
+                    tax.get("tax_category"),
+                    tax.get("valid_from"),
+                    tax.get("minimum_net_rate", 0),
+                    tax.get("maximum_net_rate", 0),
                     current_time,  # creation
                     current_time,  # modified
                     current_user,  # modified_by

--- a/india_compliance/gst_india/doctype/gst_hsn_code/gst_hsn_code.py
+++ b/india_compliance/gst_india/doctype/gst_hsn_code/gst_hsn_code.py
@@ -49,7 +49,7 @@ def _process_item_batch(batch_items, taxes):
 
     # TODO: Add Versioning?
 
-    frappe.db.commit()
+    frappe.db.commit()  # nosemgrep
 
 
 def _bulk_insert_item_taxes(item_names, taxes):


### PR DESCRIPTION
Fixes: #3672 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Adds per-item comments when HSN-driven tax updates run, improving traceability.

- **Refactor**
  - Tax updates now run as batched bulk operations for better performance and scalability on large item sets.
  - Existing item tax rows are removed and new item tax entries are created in bulk with complete metadata and ordering.

- **Chores**
  - Bulk persistence applies unified timestamps and user attribution for consistent audit records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->