### PR TITLE
fix: exclude specific document types from count in summary of Document Issued

### DIFF
--- a/india_compliance/gst_india/doctype/gst_return_log/generate_gstr_1.py
+++ b/india_compliance/gst_india/doctype/gst_return_log/generate_gstr_1.py
@@ -238,6 +238,13 @@ class SummarizeGSTR1:
 
     @staticmethod
     def count_doc_issue_summary(summary_row, data_row):
+        if data_row.get(inv_f.DOC_TYPE) in (
+            "Excluded from Report (Invalid Invoice Number)",
+            "Excluded from Report (Same GSTIN Billing)",
+            "Excluded from Report (Is Opening Entry)",
+        ):
+            return
+
         summary_row["no_of_records"] += (
             data_row.get(inv_f.TOTAL_COUNT, 0)
             - data_row.get(inv_f.CANCELLED_COUNT, 0)


### PR DESCRIPTION
Fixes: #3660 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * GSTR-1 summaries now correctly exclude records marked as “Excluded from Report” (e.g., invalid invoice numbers, same GSTIN billing, opening entries), ensuring accurate document counts and preventing inflated totals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->