### PR TITLE
fix: add 40% GST tax rate and execute Patch for custom fields update

### DIFF
--- a/india_compliance/gst_india/constants/__init__.py
+++ b/india_compliance/gst_india/constants/__init__.py
@@ -1404,6 +1404,7 @@ GST_TAX_RATES = {
     12.000,
     18.000,
     28.000,
+    40.000,
 }
 
 # REGEX PATTERNS (https://developer.gst.gov.in/apiportal/taxpayer/returns)

--- a/india_compliance/patches.txt
+++ b/india_compliance/patches.txt
@@ -4,7 +4,7 @@ india_compliance.patches.v15.remove_duplicate_web_template
 
 [post_model_sync]
 india_compliance.patches.v14.set_default_for_overridden_accounts_setting
-execute:from india_compliance.gst_india.setup import create_custom_fields; create_custom_fields() #64
+execute:from india_compliance.gst_india.setup import create_custom_fields; create_custom_fields() #65
 execute:from india_compliance.gst_india.setup import create_property_setters; create_property_setters() #11
 execute:from india_compliance.income_tax_india.setup import create_custom_fields; create_custom_fields() #4
 india_compliance.patches.post_install.remove_old_fields #2

--- a/india_compliance/public/js/setup_wizard.js
+++ b/india_compliance/public/js/setup_wizard.js
@@ -88,6 +88,7 @@ function update_erpnext_slides_settings() {
             "12.0",
             "18.0",
             "28.0",
+            "40.0",
         ],
         default: "18.0",
     });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a 40% GST rate, including availability in the Setup Wizard’s Default GST Rate options and recognition across tax calculations.
* **Chores**
  * Updated internal patch reference annotations with no user-facing impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->