### PR TITLE
fix: do not generate e-waybill using IRN if  invoice has non-taxable items

### DIFF
--- a/india_compliance/gst_india/data/test_e_invoice.json
+++ b/india_compliance/gst_india/data/test_e_invoice.json
@@ -908,10 +908,10 @@
         "request_data": {
             "BuyerDtls": {
                 "Addr1": "Test Address - 3",
-                "Gstin": "29ABCDE1234F1Z5",
+                "Gstin": "29AAACI1195H2ZH",
                 "LglNm": "_Test Registered Customer",
                 "Loc": "Test City",
-                "Pin": 500055,
+                "Pin": 560001,
                 "Pos": "29",
                 "Stcd": "29",
                 "TrdNm": "_Test Registered Customer"
@@ -974,14 +974,14 @@
             "ErrorDetails": [
                 {
                     "ErrorCode": "3029",
-                    "ErrorMessage": "GSTIN -29ABCDE1234F1Z5 is inactive or cancelled"
+                    "ErrorMessage": "GSTIN -29AAACI1195H2ZH is inactive or cancelled"
                 }
             ],
             "Status": 0,
             "error_code": "3029"
         },
         "error_response_enriched": {
-            "message": "3029: GSTIN -29ABCDE1234F1Z5 is inactive or cancelled",
+            "message": "3029: GSTIN -29AAACI1195H2ZH is inactive or cancelled",
             "success": false
         },
         "sync_gstin_response_inactive": {
@@ -995,7 +995,7 @@
                     "Bnm": "Test Building",
                     "St": "Test Street",
                     "Loc": "Test Location",
-                    "Pncd": "500055",
+                    "Pncd": "560001",
                     "Stcd": "29"
                 }
             },

--- a/india_compliance/gst_india/data/test_e_waybill.json
+++ b/india_compliance/gst_india/data/test_e_waybill.json
@@ -1278,7 +1278,9 @@
             "company_address": "_Test Indian Registered Company-Billing",
             "customer": "_Test Registered Customer",
             "currency": "INR",
-            "is_in_state": false
+            "is_in_state": false,
+            "is_out_state": true,
+            "customer_address": "_Test Registered Customer-Billing-3"
         },
         "request_data": {
             "userGstin": "05AAACG2115R1ZN",
@@ -1296,10 +1298,10 @@
             "fromStateCode": 5,
             "actFromStateCode": 5,
             "toTrdName": "_Test Registered Customer",
-            "toGstin": "29ABCDE1234F1Z5",
+            "toGstin": "29AAACI1195H2ZH",
             "toAddr1": "Test Address - 3",
             "toPlace": "Test City",
-            "toPincode": 500055,
+            "toPincode": 560001,
             "toStateCode": 29,
             "actToStateCode": 29,
             "totalValue": 100000.0,
@@ -1337,14 +1339,14 @@
             "ErrorDetails": [
                 {
                     "ErrorCode": "3029",
-                    "ErrorMessage": "GSTIN -29ABCDE1234F1Z5 is inactive or cancelled"
+                    "ErrorMessage": "GSTIN -29AAACI1195H2ZH is inactive or cancelled"
                 }
             ],
             "Status": 0,
             "error_code": "3029"
         },
         "error_response_enriched": {
-            "message": "3029: GSTIN -29ABCDE1234F1Z5 is inactive or cancelled",
+            "message": "3029: GSTIN -29AAACI1195H2ZH is inactive or cancelled",
             "success": false
         },
         "sync_gstin_response_inactive": {

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -157,10 +157,14 @@ def _generate_e_waybill(doc, throw=True, force=False):
             raise GSPServerError
 
         # Via e-Invoice API if not Return or Debit Note
+        # Via e-Waybill API if has Non-Taxable items
         # Handles following error when generating e-Waybill using IRN:
         # 4010: E-way Bill cannot generated for Debit Note, Credit Note and Services
-        with_irn = doc.get("irn") and not (
-            doc.is_return or doc.get("is_debit_note") or is_foreign_doc(doc)
+
+        with_irn = (
+            doc.get("irn")
+            and all(item.gst_treatment in TAXABLE_GST_TREATMENTS for item in doc.items)
+            and not (doc.is_return or doc.get("is_debit_note") or is_foreign_doc(doc))
         )
 
         data = EWaybillData(doc).get_data(with_irn=with_irn)

--- a/india_compliance/gst_india/utils/test_e_invoice.py
+++ b/india_compliance/gst_india/utils/test_e_invoice.py
@@ -242,7 +242,7 @@ class TestEInvoice(IntegrationTestCase):
         responses.add(
             responses.GET,
             BASE_URL + "/test/ei/api/master/syncgstin",
-            match=[matchers.query_param_matcher({"gstin": "29ABCDE1234F1Z5"})],
+            match=[matchers.query_param_matcher({"gstin": "29AAACI1195H2ZH"})],
             json=sync_gstin_response,
             status=200,
         )
@@ -251,7 +251,7 @@ class TestEInvoice(IntegrationTestCase):
             generate_e_invoice(si.name)
 
         self.assertIn(
-            "GSTIN -29ABCDE1234F1Z5 is inactive or cancelled", str(cm.exception)
+            "GSTIN -29AAACI1195H2ZH is inactive or cancelled", str(cm.exception)
         )
 
     @responses.activate
@@ -280,7 +280,7 @@ class TestEInvoice(IntegrationTestCase):
         responses.add(
             responses.GET,
             BASE_URL + "/standard/ei/api/master/syncgstin",
-            match=[matchers.query_param_matcher({"gstin": "29ABCDE1234F1Z5"})],
+            match=[matchers.query_param_matcher({"gstin": "29AAACI1195H2ZH"})],
             json=sync_gstin_response,
             status=200,
         )
@@ -290,7 +290,7 @@ class TestEInvoice(IntegrationTestCase):
             generate_e_invoice(si.name)
 
         self.assertIn(
-            "GSTIN -29ABCDE1234F1Z5 is inactive or cancelled", str(cm.exception)
+            "GSTIN -29AAACI1195H2ZH is inactive or cancelled", str(cm.exception)
         )
 
     @responses.activate

--- a/india_compliance/gst_india/utils/test_e_waybill.py
+++ b/india_compliance/gst_india/utils/test_e_waybill.py
@@ -1249,7 +1249,7 @@ class TestEWaybill(IntegrationTestCase):
         responses.add(
             responses.GET,
             BASE_URL + "/test/ei/api/master/syncgstin",
-            match=[matchers.query_param_matcher({"gstin": "29ABCDE1234F1Z5"})],
+            match=[matchers.query_param_matcher({"gstin": "29AAACI1195H2ZH"})],
             json=sync_gstin_response,
             status=200,
         )
@@ -1259,7 +1259,7 @@ class TestEWaybill(IntegrationTestCase):
             _generate_e_waybill(doc)
 
         self.assertIn(
-            "GSTIN -29ABCDE1234F1Z5 is inactive or cancelled", str(cm.exception)
+            "GSTIN -29AAACI1195H2ZH is inactive or cancelled", str(cm.exception)
         )
 
     @responses.activate
@@ -1294,7 +1294,7 @@ class TestEWaybill(IntegrationTestCase):
         responses.add(
             responses.GET,
             BASE_URL + "/standard/ei/api/master/syncgstin",
-            match=[matchers.query_param_matcher({"gstin": "29ABCDE1234F1Z5"})],
+            match=[matchers.query_param_matcher({"gstin": "29AAACI1195H2ZH"})],
             json=sync_gstin_response,
             status=200,
         )
@@ -1307,7 +1307,7 @@ class TestEWaybill(IntegrationTestCase):
             frappe.flags.bypass_auth = False
 
         self.assertIn(
-            "GSTIN -29ABCDE1234F1Z5 is inactive or cancelled", str(cm.exception)
+            "GSTIN -29AAACI1195H2ZH is inactive or cancelled", str(cm.exception)
         )
 
     # helper functions

--- a/india_compliance/tests/test_records.json
+++ b/india_compliance/tests/test_records.json
@@ -361,6 +361,23 @@
             ]
         },
         {
+            "name": "_Test Registered Customer-Billing-3",
+            "address_type": "Billing",
+            "address_line1": "Test Address - 3",
+            "city": "Test City",
+            "state": "Karnataka",
+            "pincode": "560001",
+            "country": "India",
+            "gstin": "29AAACI1195H2ZH",
+            "gst_category": "Registered Regular",
+            "links": [
+                {
+                    "link_doctype": "Customer",
+                    "link_name": "_Test Registered Customer"
+                }
+            ]
+        },
+        {
             "name": "_Test Registered Composition Customer-Billing",
             "address_type": "Billing",
             "address_line1": "Test Address - 6",


### PR DESCRIPTION
Issue: If the invoice contains non-taxable items( Nil-rated, Non-GST, Exempted), then generating e-waybill using IRN raises error because e-Invoice do not have details about nil-rated goods.

Stes to replicate:
- Create an Invoice with:
    - 1 taxable service item
    - 1 nil-rated good (or Exempt/Non-GST item)
- Generate e-Invoice (IRN should be generated since there’s a taxable item).
- Attempt to generate the e-Waybill Error will be raised.

<img width="775" height="300" alt="image" src="https://github.com/user-attachments/assets/bf79cad8-5768-4421-9e86-db57cb5341dd" />

Solution: Do not use the e-Invoice API if the invoice has non-taxable goods.

Frappe Support Issue: https://support.frappe.io/app/hd-ticket/47625

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * e-Waybill selection now respects item-level taxability; invoices with any non-taxable items use the e-Waybill path while preserving exclusions for Returns, Debit Notes, and foreign documents.

* **Tests**
  * Updated test expectations to reflect the refined e-Waybill/e-Invoice behavior.

* **Chores**
  * Updated test data and a sample address entry to use a new GSTIN and corresponding postal code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->