### PR TITLE
fix: allow e-waybill for different GSTIN from Material Transfer Stock Entry

### DIFF
--- a/india_compliance/gst_india/client_scripts/e_waybill_actions.js
+++ b/india_compliance/gst_india/client_scripts/e_waybill_actions.js
@@ -560,6 +560,10 @@ function get_sub_suppy_type_options(frm) {
                     "Others",
                 ];
             }
+            else {
+                supply_type = "Outward";
+                sub_supply_type = ["Job Work", "SKD/CKD", "Others"];
+            }
         }
     } else {
         const key = `${frm.doctype}_${frm.doc.is_return || 0}`;

--- a/india_compliance/gst_india/client_scripts/e_waybill_applicability.js
+++ b/india_compliance/gst_india/client_scripts/e_waybill_applicability.js
@@ -277,11 +277,6 @@ class StockEntryEwaybill extends EwaybillApplicability {
             message_list.push("Bill From GSTIN and Bill To GSTIN are same.");
         }
 
-        if (!same_gstin && applicable_for_same_gstin) {
-            is_ewb_applicable = false;
-            message_list.push("Bill From GSTIN and Bill To GSTIN are different.");
-        }
-
         if (this.frm.doc.is_opening === "Yes") {
             is_ewb_applicable = false;
             message_list.push(

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -1055,7 +1055,7 @@ def update_transaction(doc, values):
 
     if doc.doctype in ("Delivery Note", "Stock Entry", "Subcontracting Receipt"):
         doc._sub_supply_type = SUB_SUPPLY_TYPES[values.sub_supply_type]
-    if doc.doctype == "Delivery Note":
+    if doc.doctype in ("Delivery Note", "Stock Entry"):
         doc._sub_supply_desc = values.sub_supply_desc
 
 
@@ -1318,19 +1318,8 @@ class EWaybillData(GSTTransactionData):
         if not self.doc.gst_transporter_id:
             self.validate_mode_of_transport()
 
-        if is_outward_stock_entry(self.doc):
-            self.validate_different_gstin()
-        else:
+        if not is_outward_stock_entry(self.doc):
             self.validate_same_gstin()
-
-    def validate_different_gstin(self):
-        if self.doc.company_gstin != self.doc.get("supplier_gstin"):
-            frappe.throw(
-                _(
-                    "e-Waybill cannot be generated because party GSTIN and company GSTIN are different"
-                ),
-                title=_("Invalid Data"),
-            )
 
     def validate_same_gstin(self):
         if self.doc.doctype == "Delivery Note":
@@ -1555,6 +1544,7 @@ class EWaybillData(GSTTransactionData):
             ("Stock Entry", 0): {
                 "supply_type": "O",
                 "sub_supply_type": doc.get("_sub_supply_type", ""),
+                "sub_supply_desc": doc.get("_sub_supply_desc", ""),
                 "document_type": "CHL",
             },
             ("Stock Entry", 1): {


### PR DESCRIPTION
Allow different GSTIN e-Waybill Generation from Stock Entry.

Frappe Support Issue: 
- https://support.frappe.io/app/hd-ticket/48790
- https://support.frappe.io/app/hd-ticket/48480


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * e-Waybill now supports Stock Entry when Bill From and Bill To GSTIN differ (where applicable).
  * Sub-supply description is captured and included for Stock Entry e-Waybills.

* Bug Fixes
  * For Stock Entry (Material Transfer/Issue) with different GSTINs, default supply type and sub-supply options are preset (Outward with Job Work/SKD/CKD/Others), avoiding undefined states.
  * Streamlined outward Stock Entry validation to reduce unnecessary e-Waybill rejections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->