### PR TITLE
fix: set default company value on onload

### DIFF
--- a/india_compliance/gst_india/doctype/gst_invoice_management_system/gst_invoice_management_system.js
+++ b/india_compliance/gst_india/doctype/gst_invoice_management_system/gst_invoice_management_system.js
@@ -29,7 +29,8 @@ frappe.ui.form.on(DOCTYPE, {
             "invoice_html"
         );
 
-        frm.set_value("company", frappe.defaults.get_user_default("Company"));
+        frm.doc.company = frappe.defaults.get_user_default("Company");
+        frm.trigger("company");
         // Setup Listeners
 
         // Download Queued

--- a/india_compliance/gst_india/doctype/gst_invoice_management_system/gst_invoice_management_system.js
+++ b/india_compliance/gst_india/doctype/gst_invoice_management_system/gst_invoice_management_system.js
@@ -29,8 +29,7 @@ frappe.ui.form.on(DOCTYPE, {
             "invoice_html"
         );
 
-        frm.trigger("company");
-
+        frm.set_value("company", frappe.defaults.get_user_default("Company"));
         // Setup Listeners
 
         // Download Queued

--- a/india_compliance/gst_india/doctype/gstr_1/gstr_1.js
+++ b/india_compliance/gst_india/doctype/gstr_1/gstr_1.js
@@ -105,13 +105,12 @@ const GSTR1_DataField = {
 
 frappe.ui.form.on(DOCTYPE, {
     async setup(frm) {
-        frappe.require("gstr1.bundle.js").then(() => {
+        await frappe.require("gstr1.bundle.js").then(() => {
             frm.gstr1 = new GSTR1(frm);
-            frm.trigger("company");
         });
 
         // Set Default Values
-        set_default_company_gstin(frm);
+        frm.set_value("company", frappe.defaults.get_user_default("Company"));
         set_options_for_year(frm);
         set_options_for_month_or_quarter(frm);
 
@@ -198,7 +197,6 @@ frappe.ui.form.on(DOCTYPE, {
 
     async company(frm) {
         render_empty_state(frm);
-
         if (!frm.doc.company) return;
         const options = await india_compliance.set_gstin_options(frm, false, true);
 
@@ -3105,21 +3103,6 @@ function patch_set_indicator(frm) {
     frm.toolbar.set_indicator = function () {};
 }
 
-async function set_default_company_gstin(frm) {
-    frm.set_value("company_gstin", "");
-
-    const company = frm.doc.company;
-    if (!company) return;
-
-    const { message: gstin_list } = await frappe.call(
-        "india_compliance.gst_india.utils.get_gstin_list",
-        { party: company, exclude_isd: true }
-    );
-
-    if (gstin_list && gstin_list.length) {
-        frm.set_value("company_gstin", gstin_list[0]);
-    }
-}
 
 function update_filing_preference(frm) {
     const { month_or_quarter, year, company_gstin } = frm.doc;

--- a/india_compliance/gst_india/doctype/gstr_1/gstr_1.js
+++ b/india_compliance/gst_india/doctype/gstr_1/gstr_1.js
@@ -105,12 +105,12 @@ const GSTR1_DataField = {
 
 frappe.ui.form.on(DOCTYPE, {
     async setup(frm) {
-        await frappe.require("gstr1.bundle.js").then(() => {
-            frm.gstr1 = new GSTR1(frm);
-        });
+        await frappe.require("gstr1.bundle.js");
+        frm.gstr1 = new GSTR1(frm);
 
         // Set Default Values
-        frm.set_value("company", frappe.defaults.get_user_default("Company"));
+        frm.doc.company = frappe.defaults.get_user_default("Company");
+        frm.trigger("company");
         set_options_for_year(frm);
         set_options_for_month_or_quarter(frm);
 
@@ -3102,7 +3102,6 @@ function is_gstr1_api_enabled() {
 function patch_set_indicator(frm) {
     frm.toolbar.set_indicator = function () {};
 }
-
 
 function update_filing_preference(frm) {
     const { month_or_quarter, year, company_gstin } = frm.doc;

--- a/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.js
+++ b/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.js
@@ -68,7 +68,10 @@ frappe.ui.form.on(DOCTYPE, {
         new india_compliance.quick_info_popover(frm, tooltip_info);
 
         await frappe.require("purchase_reconciliation_tool.bundle.js");
-        frm.set_value("company", frappe.defaults.get_user_default("Company"));
+
+        frm.doc.company = frappe.defaults.get_user_default("Company");
+        frm.trigger("company");
+
         frm.reconciliation_tabs = new PurchaseReconciliationTool(
             frm,
             ["invoice", "supplier", "summary"],

--- a/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.js
+++ b/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.js
@@ -68,10 +68,7 @@ frappe.ui.form.on(DOCTYPE, {
         new india_compliance.quick_info_popover(frm, tooltip_info);
 
         await frappe.require("purchase_reconciliation_tool.bundle.js");
-         if (!frm.doc.company) {
-            frm.doc.company = frappe.defaults.get_user_default("Company");
-        }
-        frm.trigger("company");
+        frm.set_value("company", frappe.defaults.get_user_default("Company"));
         frm.reconciliation_tabs = new PurchaseReconciliationTool(
             frm,
             ["invoice", "supplier", "summary"],

--- a/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.js
+++ b/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.js
@@ -68,6 +68,9 @@ frappe.ui.form.on(DOCTYPE, {
         new india_compliance.quick_info_popover(frm, tooltip_info);
 
         await frappe.require("purchase_reconciliation_tool.bundle.js");
+         if (!frm.doc.company) {
+            frm.doc.company = frappe.defaults.get_user_default("Company");
+        }
         frm.trigger("company");
         frm.reconciliation_tabs = new PurchaseReconciliationTool(
             frm,


### PR DESCRIPTION
Automatically set the session default company on setup.



closes: https://github.com/resilient-tech/india-compliance/issues/3389

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Purchase Reconciliation Tool now auto-fills your default Company immediately on open to avoid a blank Company.
  * GST Invoice Management System now ensures a default Company is set during setup to stabilize company-dependent fields.

* **Changes**
  * GSTR-1 now sets the default Company earlier and triggers company-related logic immediately.
  * Automatic remote GSTIN lookup/auto-fill has been removed, so GSTIN may no longer populate automatically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->