### PR TITLE
fix: allow sub supply type as export for Sales Invoice in e-Waybill generation

### DIFF
--- a/india_compliance/gst_india/client_scripts/e_waybill_actions.js
+++ b/india_compliance/gst_india/client_scripts/e_waybill_actions.js
@@ -566,7 +566,7 @@ function get_sub_suppy_type_options(frm) {
         const default_supply_types = {
             "Sales Invoice_0": {
                 supply_type: "Outward",
-                sub_supply_type: ["Supply"],
+                sub_supply_type: ["Supply", "Export"],
                 document_type: "Tax Invoice",
             },
             "Sales Invoice_1": {

--- a/india_compliance/gst_india/client_scripts/e_waybill_actions.js
+++ b/india_compliance/gst_india/client_scripts/e_waybill_actions.js
@@ -339,7 +339,11 @@ function show_generate_e_waybill_dialog(frm) {
 
 function get_generate_e_waybill_dialog(opts, frm) {
     if (!frm) frm = { doc: {} };
-    const ewaybill_defaults = get_sub_suppy_type_options(frm);
+    const is_foreign_transaction =
+        frm.doc.gst_category === "Overseas" &&
+        frm.doc.place_of_supply === "96-Other Countries";
+
+    const ewaybill_defaults = get_sub_suppy_type_options(frm, is_foreign_transaction);
 
     const fields = [
         {
@@ -476,10 +480,6 @@ function get_generate_e_waybill_dialog(opts, frm) {
         },
     ];
 
-    const is_foreign_transaction =
-        frm.doc.gst_category === "Overseas" &&
-        frm.doc.place_of_supply === "96-Other Countries";
-
     if (frm.doctype === "Sales Invoice" && is_foreign_transaction) {
         fields.splice(5, 0, {
             label: "Origin Port / Border Checkpost Address",
@@ -509,7 +509,7 @@ function get_generate_e_waybill_dialog(opts, frm) {
     return d;
 }
 
-function get_sub_suppy_type_options(frm) {
+function get_sub_suppy_type_options(frm, is_foreign_transaction) {
     let supply_type, sub_supply_type, sub_supply_desc, document_type;
 
     if (frm.doctype === "Delivery Note") {
@@ -561,12 +561,20 @@ function get_sub_suppy_type_options(frm) {
                 ];
             }
         }
+    } else if (
+        frm.doctype === "Sales Invoice" &&
+        frm.doc.is_return === 0 &&
+        is_foreign_transaction
+    ) {
+        supply_type = "Outward";
+        sub_supply_type = ["Export"];
+        document_type = "Tax Invoice";
     } else {
         const key = `${frm.doctype}_${frm.doc.is_return || 0}`;
         const default_supply_types = {
             "Sales Invoice_0": {
                 supply_type: "Outward",
-                sub_supply_type: ["Supply", "Export"],
+                sub_supply_type: ["Supply"],
                 document_type: "Tax Invoice",
             },
             "Sales Invoice_1": {

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -1057,7 +1057,12 @@ def update_transaction(doc, values):
 
     doc.db_set(data)
 
-    if doc.doctype in ("Delivery Note", "Stock Entry", "Subcontracting Receipt"):
+    if doc.doctype in (
+        "Delivery Note",
+        "Stock Entry",
+        "Subcontracting Receipt",
+        "Sales Invoice",
+    ):
         doc._sub_supply_type = SUB_SUPPLY_TYPES[values.sub_supply_type]
     if doc.doctype == "Delivery Note":
         doc._sub_supply_desc = values.sub_supply_desc
@@ -1514,7 +1519,7 @@ class EWaybillData(GSTTransactionData):
             # Key: (doctype, is_return)
             ("Sales Invoice", 0): {
                 "supply_type": "O",
-                "sub_supply_type": 1,  # Supply
+                "sub_supply_type": doc.get("_sub_supply_type", ""),
                 "document_type": "INV",
             },
             ("Sales Invoice", 1): {

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -1057,12 +1057,7 @@ def update_transaction(doc, values):
 
     doc.db_set(data)
 
-    if doc.doctype in (
-        "Delivery Note",
-        "Stock Entry",
-        "Subcontracting Receipt",
-        "Sales Invoice",
-    ):
+    if doc.doctype in ("Delivery Note", "Stock Entry", "Subcontracting Receipt"):
         doc._sub_supply_type = SUB_SUPPLY_TYPES[values.sub_supply_type]
     if doc.doctype == "Delivery Note":
         doc._sub_supply_desc = values.sub_supply_desc
@@ -1519,7 +1514,7 @@ class EWaybillData(GSTTransactionData):
             # Key: (doctype, is_return)
             ("Sales Invoice", 0): {
                 "supply_type": "O",
-                "sub_supply_type": doc.get("_sub_supply_type", ""),
+                "sub_supply_type": 1,  # Supply
                 "document_type": "INV",
             },
             ("Sales Invoice", 1): {


### PR DESCRIPTION
- [x] Improve ux => auto suggest when export
- [x] Manual Test
- [x] Fix Test cases

Already works as expected in backend
https://github.com/resilient-tech/india-compliance/blob/db4aa99537260a270ce8dd04c37508d4bdd29f5c/india_compliance/gst_india/utils/e_waybill.py#L1591


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - e-Waybill flow now recognizes foreign transactions and applies export-appropriate default values.
  - For Sales Invoices identified as foreign transactions, an Origin Port field is shown to capture export details.
  - Sub-supply type options are dynamically tailored based on whether the transaction is domestic or foreign, reducing manual selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->