### PR TITLE
fix: show documents even if document reference is missing in GST Job Work Report

### DIFF
--- a/india_compliance/gst_india/report/gst_job_work_stock_movement/gst_job_work_stock_movement.js
+++ b/india_compliance/gst_india/report/gst_job_work_stock_movement/gst_job_work_stock_movement.js
@@ -58,15 +58,26 @@ frappe.query_reports["GST Job Work Stock Movement"] = {
         },
     ],
     onload: function (query_report) {
+        const handle_download = (response) => {
+            india_compliance.trigger_file_download(
+                JSON.stringify(response.data),
+                response.filename
+            );
+        };
+
         query_report.page.add_inner_button(__("Export JSON"), function () {
             frappe.call({
                 method: "india_compliance.gst_india.utils.itc_04.itc_04_export.download_itc_04_json",
                 args: { filters: query_report.get_values() },
                 callback: r => {
-                    india_compliance.trigger_file_download(
-                        JSON.stringify(r.message.data),
-                        r.message.filename
-                    );
+                    if (r.message && r.message.has_invalid_data) {
+                        frappe.confirm(
+                            __("Some entries are skipped in Table 5A because <strong>Original Challan No</strong> is missing.<br><br>Do you want to continue with the download?"),
+                            () => handle_download(r.message),
+                        );
+                    } else {
+                        handle_download(r.message);
+                    }
                 },
             });
         });

--- a/india_compliance/gst_india/report/gst_job_work_stock_movement/gst_job_work_stock_movement.js
+++ b/india_compliance/gst_india/report/gst_job_work_stock_movement/gst_job_work_stock_movement.js
@@ -57,6 +57,22 @@ frappe.query_reports["GST Job Work Stock Movement"] = {
             reqd: 1,
         },
     ],
+
+    formatter: (value, row, column, data, default_formatter) => {
+        value = default_formatter(value, row, column, data);
+        // replace href with link to original return doc
+        if (data && column.fieldname === "invoice_no" && data.invoice_no && data.original_invoice_no) {
+            value = frappe.utils.get_form_link(
+                data.invoice_type,
+                data.original_invoice_no,
+                true,
+                data.invoice_no
+            );
+        }
+
+        return value;
+    },
+
     onload: function (query_report) {
         const handle_download = (response) => {
             india_compliance.trigger_file_download(

--- a/india_compliance/gst_india/utils/itc_04/itc_04_data.py
+++ b/india_compliance/gst_india/utils/itc_04/itc_04_data.py
@@ -140,7 +140,7 @@ class ITC04Query:
             frappe.qb.from_(doc)
             .inner_join(doc_item)
             .on(doc.name == doc_item.parent)
-            .inner_join(ref_doc)
+            .left_join(ref_doc)
             .on(ref_doc.parent == doc.name)
             .select(
                 IfNull(doc_item.item_code, doc_item.item_name).as_("item_code"),

--- a/india_compliance/gst_india/utils/itc_04/itc_04_data.py
+++ b/india_compliance/gst_india/utils/itc_04/itc_04_data.py
@@ -200,6 +200,7 @@ class ITC04Query:
             self.get_base_query_table_5A(self.sr, self.sr_item, self.ref_doc)
             .select(
                 IfNull(self.sr.supplier_delivery_note, "").as_("invoice_no"),
+                self.sr.name.as_("original_invoice_no"),
                 self.sr_item.stock_uom.as_("uom"),
                 self.sr.company_gstin,
                 self.sr.supplier_gstin,

--- a/india_compliance/gst_india/utils/itc_04/itc_04_export.py
+++ b/india_compliance/gst_india/utils/itc_04/itc_04_export.py
@@ -37,10 +37,8 @@ def download_itc_04_json(filters):
             **convert_to_gov_data_format(data, company_gstin),
         },
         "filename": f"ITC-04-Gov-{company_gstin}-{ret_period}.json",
+        "has_invalid_data": has_invalid_data,
     }
-
-    if has_invalid_data:
-        response["has_invalid_data"] = True
 
     return response
 
@@ -93,15 +91,14 @@ def get_data(filters):
     ) + itc04.get_query_table_5A_sr().run(as_dict=True)
 
     fg_received_data = process_table_5a_data(table_5a_data)
-    has_invalid_data = fg_received_data.pop("has_invalid_data", False)
 
     data = {
         ITC04JsonKey.FG_RECEIVED.value: fg_received_data,
         ITC04JsonKey.RM_SENT.value: process_table_4_data(table_4_data),
+        "has_invalid_data": any(
+            not invoice.original_challan_no for invoice in table_5a_data
+        ),
     }
-
-    if has_invalid_data:
-        data["has_invalid_data"] = True
 
     return data
 
@@ -155,11 +152,9 @@ def process_table_5a_data(invoice_data):
         }
 
     res = {}
-    has_invalid_data = False
 
     for invoice in invoice_data:
         if not invoice.original_challan_no:
-            has_invalid_data = True
             continue
 
         key = f"{invoice.original_challan_no} - {invoice.invoice_no}"
@@ -185,8 +180,5 @@ def process_table_5a_data(invoice_data):
             res[key][ITC04_DataField.ITEMS.value].append(
                 create_item(invoice, uom, jw_challan_date, challan_date)
             )
-
-    if has_invalid_data:
-        res["has_invalid_data"] = True
 
     return res

--- a/india_compliance/gst_india/utils/itc_04/itc_04_export.py
+++ b/india_compliance/gst_india/utils/itc_04/itc_04_export.py
@@ -26,10 +26,11 @@ def download_itc_04_json(filters):
     ret_period = get_return_period(filters)
 
     data = get_data(filters)
+    has_invalid_data = data.pop("has_invalid_data", False)
 
     GenerateGSTR1().normalize_data(data)
 
-    return {
+    response = {
         "data": {
             "gstin": company_gstin,
             "fp": ret_period,
@@ -37,6 +38,11 @@ def download_itc_04_json(filters):
         },
         "filename": f"ITC-04-Gov-{company_gstin}-{ret_period}.json",
     }
+
+    if has_invalid_data:
+        response["has_invalid_data"] = True
+
+    return response
 
 
 def get_return_period(filters):
@@ -86,10 +92,18 @@ def get_data(filters):
         as_dict=True
     ) + itc04.get_query_table_5A_sr().run(as_dict=True)
 
-    return {
-        ITC04JsonKey.FG_RECEIVED.value: process_table_5a_data(table_5a_data),
+    fg_received_data = process_table_5a_data(table_5a_data)
+    has_invalid_data = fg_received_data.pop("has_invalid_data", False)
+
+    data = {
+        ITC04JsonKey.FG_RECEIVED.value: fg_received_data,
         ITC04JsonKey.RM_SENT.value: process_table_4_data(table_4_data),
     }
+
+    if has_invalid_data:
+        data["has_invalid_data"] = True
+
+    return data
 
 
 def process_table_4_data(invoice_data):
@@ -141,8 +155,13 @@ def process_table_5a_data(invoice_data):
         }
 
     res = {}
+    has_invalid_data = False
 
     for invoice in invoice_data:
+        if not invoice.original_challan_no:
+            has_invalid_data = True
+            continue
+
         key = f"{invoice.original_challan_no} - {invoice.invoice_no}"
         uom = invoice.uom.upper()
 
@@ -166,5 +185,8 @@ def process_table_5a_data(invoice_data):
             res[key][ITC04_DataField.ITEMS.value].append(
                 create_item(invoice, uom, jw_challan_date, challan_date)
             )
+
+    if has_invalid_data:
+        res["has_invalid_data"] = True
 
     return res

--- a/india_compliance/gst_india/utils/itc_04/test_itc_04_export.py
+++ b/india_compliance/gst_india/utils/itc_04/test_itc_04_export.py
@@ -70,6 +70,7 @@ response = {
         ],
     },
     "filename": "ITC-04-Gov-24AAQCA8719H1ZC-182024.json",
+    "has_invalid_data": False,
 }
 
 


### PR DESCRIPTION
<img width="689" height="270" alt="image" src="https://github.com/user-attachments/assets/d6d64d84-1ecc-4c24-a04a-7631a6c699c3" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Confirmation dialog when exporting ITC‑04 JSON if some entries lack Original Challan No, with option to proceed.

* **Enhancements**
  * Export now flags files with invalid data when entries are skipped and omits those entries.
  * Added an "Original Invoice No" column to the ITC‑04 report.

* **Bug Fixes**
  * Includes records that previously lacked a matching reference document, improving completeness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->