### PR TITLE
chore: remove ignore_version flag when enabling audit trail

### DIFF
--- a/india_compliance/audit_trail/utils.py
+++ b/india_compliance/audit_trail/utils.py
@@ -27,5 +27,4 @@ def disable_audit_trail_notification():
 def enable_audit_trail():
     accounts_settings = frappe.get_doc("Accounts Settings")
     accounts_settings.enable_audit_trail = 1
-    accounts_settings.flags.ignore_version = True
     accounts_settings.save()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enabling the Audit Trail no longer alters version-check behavior. Standard version handling is preserved when saving settings.
  * No changes to how you enable the Audit Trail; configuration flows remain the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->