### PR TITLE
fix: do not include `place of supply` in CDNUR if it is export document

### DIFF
--- a/india_compliance/gst_india/doctype/gstr_1/gstr_1_export.py
+++ b/india_compliance/gst_india/doctype/gstr_1/gstr_1_export.py
@@ -283,7 +283,7 @@ class GovExcel(DataProcessor):
                 "fieldname": inv_f.DOC_DATE,
                 "data_format": {"number_format": self.DATE_FORMAT},
                 "header_format": {"width": ExcelWidth.XS.value},
-                "transform": lambda x: x.strftime("%d-%b-%y") if x else None,
+                "transform": lambda x, *args: x.strftime("%d-%b-%y") if x else None,
             },
             {
                 "label": _(gov_xl.INVOICE_VALUE),
@@ -305,7 +305,7 @@ class GovExcel(DataProcessor):
                 "fieldname": inv_f.DIFF_PERCENTAGE,
                 "data_format": {"number_format": self.PERCENT_FORMAT},
                 "header_format": {"width": ExcelWidth.XS.value},
-                "transform": lambda x: x if x else None,
+                "transform": lambda x, *args: x if x else None,
             },
             {
                 "label": _(gov_xl.INVOICE_TYPE),
@@ -346,7 +346,7 @@ class GovExcel(DataProcessor):
                 "fieldname": inv_f.DOC_DATE,
                 "data_format": {"number_format": self.DATE_FORMAT},
                 "header_format": {"width": ExcelWidth.XS.value},
-                "transform": lambda x: x.strftime("%d-%b-%y") if x else None,
+                "transform": lambda x, *args: x.strftime("%d-%b-%y") if x else None,
             },
             {
                 "label": _(gov_xl.INVOICE_VALUE),
@@ -362,7 +362,7 @@ class GovExcel(DataProcessor):
                 "fieldname": inv_f.DIFF_PERCENTAGE,
                 "data_format": {"number_format": self.PERCENT_FORMAT},
                 "header_format": {"width": ExcelWidth.XS.value},
-                "transform": lambda x: x if x else None,
+                "transform": lambda x, *args: x if x else None,
             },
             {
                 "label": _(gov_xl.TAX_RATE),
@@ -402,7 +402,7 @@ class GovExcel(DataProcessor):
                 "fieldname": inv_f.DIFF_PERCENTAGE,
                 "data_format": {"number_format": self.PERCENT_FORMAT},
                 "header_format": {"width": ExcelWidth.XS.value},
-                "transform": lambda x: x if x else None,
+                "transform": lambda x, *args: x if x else None,
             },
             {
                 "label": _(gov_xl.TAX_RATE),
@@ -449,12 +449,12 @@ class GovExcel(DataProcessor):
                 "fieldname": inv_f.DOC_DATE,
                 "data_format": {"number_format": self.DATE_FORMAT},
                 "header_format": {"width": ExcelWidth.XS.value},
-                "transform": lambda x: x.strftime("%d-%b-%y") if x else None,
+                "transform": lambda x, *args: x.strftime("%d-%b-%y") if x else None,
             },
             {
                 "label": _(gov_xl.NOTE_TYPE),
                 "fieldname": inv_f.TRANSACTION_TYPE,
-                "transform": lambda x: x[0],
+                "transform": lambda x, *args: x[0],
             },
             {
                 "label": _(gov_xl.POS),
@@ -480,7 +480,7 @@ class GovExcel(DataProcessor):
                 "fieldname": inv_f.DIFF_PERCENTAGE,
                 "data_format": {"number_format": self.PERCENT_FORMAT},
                 "header_format": {"width": ExcelWidth.XS.value},
-                "transform": lambda x: x if x else None,
+                "transform": lambda x, *args: x if x else None,
             },
             {
                 "label": _(gov_xl.TAX_RATE),
@@ -516,7 +516,7 @@ class GovExcel(DataProcessor):
                 "fieldname": inv_f.DOC_DATE,
                 "data_format": {"number_format": self.DATE_FORMAT},
                 "header_format": {"width": ExcelWidth.XS.value},
-                "transform": lambda x: x.strftime("%d-%b-%y") if x else None,
+                "transform": lambda x, *args: x.strftime("%d-%b-%y") if x else None,
             },
             {
                 "label": _(gov_xl.NOTE_TYPE),
@@ -536,7 +536,7 @@ class GovExcel(DataProcessor):
                 "fieldname": inv_f.DIFF_PERCENTAGE,
                 "data_format": {"number_format": self.PERCENT_FORMAT},
                 "header_format": {"width": ExcelWidth.XS.value},
-                "transform": lambda x: x if x else None,
+                "transform": lambda x, *args: x if x else None,
             },
             {
                 "label": _(gov_xl.TAX_RATE),
@@ -572,7 +572,7 @@ class GovExcel(DataProcessor):
                 "fieldname": inv_f.DOC_DATE,
                 "data_format": {"number_format": self.DATE_FORMAT},
                 "header_format": {"width": ExcelWidth.XS.value},
-                "transform": lambda x: x.strftime("%d-%b-%y") if x else None,
+                "transform": lambda x, *args: x.strftime("%d-%b-%y") if x else None,
             },
             {
                 "label": _(gov_xl.INVOICE_VALUE),
@@ -593,7 +593,7 @@ class GovExcel(DataProcessor):
                 "fieldname": inv_f.SHIPPING_BILL_DATE,
                 "data_format": {"number_format": self.DATE_FORMAT},
                 "header_format": {"width": ExcelWidth.XS.value},
-                "transform": lambda x: x.strftime("%d-%b-%y") if x else None,
+                "transform": lambda x, *args: x.strftime("%d-%b-%y") if x else None,
             },
             {
                 "label": _(gov_xl.TAX_RATE),
@@ -626,7 +626,7 @@ class GovExcel(DataProcessor):
                     "number_format": self.PERCENT_FORMAT,
                 },
                 "header_format": {"width": ExcelWidth.XS.value},
-                "transform": lambda x: x if x else None,
+                "transform": lambda x, *args: x if x else None,
             },
             {
                 "label": _(gov_xl.TAX_RATE),
@@ -657,7 +657,7 @@ class GovExcel(DataProcessor):
                 "fieldname": inv_f.DIFF_PERCENTAGE,
                 "data_format": {"number_format": self.PERCENT_FORMAT},
                 "header_format": {"width": ExcelWidth.XS.value},
-                "transform": lambda x: x if x else None,
+                "transform": lambda x, *args: x if x else None,
             },
             {
                 "label": _(gov_xl.TAX_RATE),

--- a/india_compliance/gst_india/doctype/gstr_1/gstr_1_export.py
+++ b/india_compliance/gst_india/doctype/gstr_1/gstr_1_export.py
@@ -501,6 +501,10 @@ class GovExcel(DataProcessor):
         ]
 
     def get_cdnur_headers(self):
+        def ignore_if_export(value, row):
+            if row.get(inv_f.DOC_TYPE) not in ("EXPWP", "EXPWOP"):
+                return value
+
         return [
             {
                 "label": _("UR Type"),
@@ -525,6 +529,7 @@ class GovExcel(DataProcessor):
             {
                 "label": _(gov_xl.POS),
                 "fieldname": inv_f.POS,
+                "transform": ignore_if_export,
             },
             {
                 "label": _(gov_xl.NOTE_VALUE),

--- a/india_compliance/gst_india/utils/exporter.py
+++ b/india_compliance/gst_india/utils/exporter.py
@@ -171,7 +171,7 @@ class Worksheet:
                 value = row.get(fieldname)
 
                 if transform:
-                    value = transform(value)
+                    value = transform(value, row)
 
                 sheet.cell(row=i, column=j, value=value or "")
 

--- a/india_compliance/gst_india/utils/gstr_1/gstr_1_json_map.py
+++ b/india_compliance/gst_india/utils/gstr_1/gstr_1_json_map.py
@@ -1098,7 +1098,7 @@ class CDNUR(GSTR1DataMapper):
     def format_doc_value(self, value, data):
         return value * -1 if data[gov_f.NOTE_TYPE] == "C" else value
 
-    def ignore_pos_if_export(self, pos, *args):
+    def ignore_pos_if_export(self, _, *args):
         if (
             args
             and isinstance(args[0], dict)

--- a/india_compliance/gst_india/utils/gstr_1/gstr_1_json_map.py
+++ b/india_compliance/gst_india/utils/gstr_1/gstr_1_json_map.py
@@ -1044,6 +1044,10 @@ class CDNUR(GSTR1DataMapper):
             inv_f.DOC_DATE: self.format_date_for_gov,
         }
 
+        self.ignore_key_for_gov = {
+            inv_f.POS: self.ignore_pos_if_export,
+        }
+
     def convert_to_internal_data_format(self, input_data):
         output = {}
 
@@ -1093,6 +1097,16 @@ class CDNUR(GSTR1DataMapper):
 
     def format_doc_value(self, value, data):
         return value * -1 if data[gov_f.NOTE_TYPE] == "C" else value
+
+    def ignore_pos_if_export(self, pos, *args):
+        if (
+            args
+            and isinstance(args[0], dict)
+            and args[0].get(inv_f.DOC_TYPE) in ("EXPWP", "EXPWOP")
+        ):
+            return True
+
+        return False
 
 
 class HSNSUM(GSTR1DataMapper):
@@ -1998,7 +2012,6 @@ def summarize_retsum_data(input_data):
 
 
 class BooksDataMapper:
-
     def get_transaction_type(self, invoice):
         if invoice.is_debit_note:
             return "Debit Note"
@@ -2218,7 +2231,6 @@ class BooksDataMapper:
                 invoice_list.append(invoice)
 
                 for key, field in self.DATA_TO_INVOICE_FIELD_MAPPING.items():
-
                     for item in items:
                         invoice[key] += item.get(field, 0)
 

--- a/india_compliance/gst_india/utils/gstr_mapper_utils.py
+++ b/india_compliance/gst_india/utils/gstr_mapper_utils.py
@@ -16,6 +16,9 @@ class GovDataMapper:
         self.value_formatters_for_internal = {}
         self.value_formatters_for_gov = {}
 
+        self.ignore_key_for_internal = {}
+        self.ignore_key_for_gov = {}
+
         # value formatting constants
         self.STATE_NUMBERS = self.reverse_dict(STATE_NUMBERS)
 
@@ -57,8 +60,19 @@ class GovDataMapper:
             else self.value_formatters_for_internal
         )
 
+        ignore_key = (
+            self.ignore_key_for_gov if for_gov else self.ignore_key_for_internal
+        )
+
         for old_key, new_key in key_mapping.items():
             invoice_data_value = data.get(old_key, "")
+
+            if (
+                old_key in ignore_key
+                and callable(ignore_key[old_key])
+                and ignore_key[old_key](invoice_data_value, data)
+            ):
+                continue
 
             if not for_gov and old_key == "flag":
                 continue


### PR DESCRIPTION
Fixes: #3670 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Place of Supply is now automatically omitted for export document types (EXPWP/EXPWOP), reducing filing validation errors and improving data accuracy.

* **New Features**
  * Mapping and export transforms now receive row context and can conditionally skip fields, enabling more robust and flexible Excel exports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->