### PR TITLE
fix: use load_doc for onload trigger in get_source_destination_address function

### DIFF
--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -1105,7 +1105,8 @@ def get_address_map(doc):
 
 @frappe.whitelist()
 def get_source_destination_address(doctype, docname, address_type):
-    doc = frappe.get_doc(doctype, docname)
+    # using load_doc for onload trigger required for stock entry.
+    doc = load_doc(doctype, docname)
     address_map = get_billing_shipping_address_map(doc)
 
     if address_type == "source_address":

--- a/india_compliance/gst_india/utils/test_e_waybill.py
+++ b/india_compliance/gst_india/utils/test_e_waybill.py
@@ -27,6 +27,7 @@ from india_compliance.gst_india.utils.e_waybill import (
     fetch_e_waybill_data,
     generate_e_waybill,
     get_e_waybills_to_extend,
+    get_source_destination_address,
     schedule_ewaybill_for_extension,
     update_transporter,
     update_vehicle_info,
@@ -599,6 +600,30 @@ class TestEWaybill(IntegrationTestCase):
 
         se.reload()
         self.assertEqual(se.ewaybill, "")
+
+    def test_get_source_destination_address_for_stock_entry(self):
+        """Test get_source_destination_address function with Stock Entry doctype"""
+
+        # Create a Stock Entry for testing
+        se = self._create_stock_entry("stock_entry")
+
+        # Test source address
+        source_address = get_source_destination_address(
+            doctype="Stock Entry", docname=se.name, address_type="source_address"
+        )
+
+        # Verify that the function returns an Address document
+        self.assertEqual(source_address.doctype, "Address")
+        self.assertIsNotNone(source_address.name)
+
+        # Test destination address
+        destination_address = get_source_destination_address(
+            doctype="Stock Entry", docname=se.name, address_type="destination_address"
+        )
+
+        # Verify that the function returns an Address document
+        self.assertEqual(destination_address.doctype, "Address")
+        self.assertIsNotNone(destination_address.name)
 
     def test_get_all_item_details(self):
         """Tests:


### PR DESCRIPTION
Issue: In the Stock entry,gst fields required for e-waybill and utilities are being set on onload.

### Traceback
```
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 121, in application
    response = frappe.api.handle(request)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/api/__init__.py", line 60, in handle
    data = endpoint(**arguments)
           ^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/api/v1.py", line 36, in handle_rpc_call
    return frappe.handler.handle()
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/handler.py", line 52, in handle
    data = execute_cmd(cmd)
           ^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/handler.py", line 85, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/__init__.py", line 1127, in call
    return fn(*args, **newargs)
           ^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/utils/typing_validations.py", line 36, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "apps/india_compliance/india_compliance/gst_india/utils/e_waybill.py", line 1109, in get_source_destination_address
    address_map = get_billing_shipping_address_map(doc)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/india_compliance/india_compliance/gst_india/utils/e_waybill.py", line 1131, in get_billing_shipping_address_map
    if (is_foreign_doc(doc) and doc.port_address)
        ^^^^^^^^^^^^^^^^^^^
  File "apps/india_compliance/india_compliance/gst_india/utils/__init__.py", line 373, in is_foreign_doc
    return is_foreign_transaction(doc.gst_category, doc.place_of_supply)
                                  ^^^^^^^^^^^^^^^^
AttributeError: 'StockEntry' object has no attribute 'gst_category'

```
### Request Data
```
{
	"type": "POST",
	"args": {
		"doctype": "Stock Entry",
		"docname": "MAT-STE-00001",
		"address_type": "source_address"
	},
	"headers": {},
	"error_handlers": {},
	"url": "/api/method/india_compliance.gst_india.utils.e_waybill.get_source_destination_address",
	"request_id": null
}
```

Frappe Support Issue: https://support.frappe.io/app/hd-ticket/48931

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured e-Waybill source/destination addresses resolve correctly for Stock Entry workflows by running required preload logic before address mapping, reducing incorrect or incomplete addresses during e-Waybill generation.
* **Tests**
  * Added automated tests verifying source and destination address resolution for Stock Entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->