### PR TITLE
fix: update references from gross_purchase_amount to net_purchase_amount

### DIFF
--- a/india_compliance/gst_india/overrides/ineligible_itc.py
+++ b/india_compliance/gst_india/overrides/ineligible_itc.py
@@ -321,7 +321,7 @@ class IneligibleITC:
                 frappe.scrub(self.doc.doctype): self.doc.name,
             },
             {
-                "gross_purchase_amount": flt(item.valuation_rate),
+                "net_purchase_amount": flt(item.valuation_rate),
                 "purchase_amount": flt(item.valuation_rate),
             },
         )

--- a/india_compliance/gst_india/overrides/test_ineligible_itc.py
+++ b/india_compliance/gst_india/overrides/test_ineligible_itc.py
@@ -881,7 +881,7 @@ class TestIneligibleITC(IntegrationTestCase):
             asset_purchase_value = frappe.db.get_value(
                 "Asset",
                 {f"{frappe.scrub(doctype)}": docname, "item_code": asset},
-                "gross_purchase_amount",
+                "net_purchase_amount",
             )
             self.assertEqual(asset_purchase_value, value)
 

--- a/india_compliance/income_tax_india/overrides/asset_depreciation_schedule.py
+++ b/india_compliance/income_tax_india/overrides/asset_depreciation_schedule.py
@@ -77,7 +77,7 @@ def get_wdv_or_dd_depr_amount(asset_depreciation_schedule, row_idx):
     if asset_depreciation_schedule.fb_row.frequency_of_depreciation == 12:
         if schedule_date < start_date_of_next_fiscal_year:
             depreciation_amount = flt(
-                asset_depreciation_schedule.asset_doc.gross_purchase_amount
+                asset_depreciation_schedule.asset_doc.net_purchase_amount
             ) * (flt(rate_of_depreciation) / 100)
         else:
             depreciation_amount = flt(
@@ -111,7 +111,7 @@ def get_wdv_or_dd_depr_amount(asset_depreciation_schedule, row_idx):
 
         if schedule_date < start_date_of_next_fiscal_year:
             depreciation_amount = (
-                flt(asset_depreciation_schedule.asset_doc.gross_purchase_amount)
+                flt(asset_depreciation_schedule.asset_doc.net_purchase_amount)
                 * (flt(rate_of_depreciation) / 100)
                 * fraction
             )


### PR DESCRIPTION
In erpnext field, gross_purchase_amount is renamed to net_purchase_amount.

Reference PR: https://github.com/frappe/erpnext/pull/49084

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Asset valuation now uses net purchase amount, ensuring correct asset capitalization.
  - Depreciation schedules (monthly/yearly) now calculate using net purchase amount for more accurate depreciation and written-down values.
  - Applies across relevant GST and Income Tax India workflows.

- **Tests**
  - Updated test assertions to reflect net-based asset valuation and depreciation calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->