### PR TITLE
fix: correct condition to check for included documents for quarterly filing

### DIFF
--- a/india_compliance/gst_india/utils/gstr_1/gstr_1_json_map.py
+++ b/india_compliance/gst_india/utils/gstr_1/gstr_1_json_map.py
@@ -2595,7 +2595,7 @@ class GSTR1BooksData(BooksDataMapper):
 
         for category in categories_to_process:
             for key, row in data[category].copy().items():
-                if key not in included_docs:
+                if key in included_docs:
                     continue
 
                 row["sub_category"] = category


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected quarterly GSTR-1 document selection. The workflow now skips documents already marked as included and processes the remaining ones, ensuring the correct set is considered during quarterly generation. This prevents missing or duplicated documents and leads to more accurate summaries and exports for quarterly filings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->