### PR TITLE
fix: add validation for item GST details to ensure accuracy of tax amounts

### DIFF
--- a/india_compliance/gst_india/overrides/test_transaction.py
+++ b/india_compliance/gst_india/overrides/test_transaction.py
@@ -755,6 +755,19 @@ class TestTransaction(IntegrationTestCase):
             doc.items[0],
         )
 
+    def test_invalid_item_gst_details(self):
+        doc = create_transaction(
+            **self.transaction_details, rate=200, is_out_state=True, do_not_save=True
+        )
+        row = frappe.copy_doc(doc.taxes[0])
+        doc.append("taxes", row)
+        doc.place_of_supply = "27-Maharashtra"
+        self.assertRaisesRegex(
+            frappe.exceptions.ValidationError,
+            re.compile(r"^(.*GST amounts do not match the calculated values.*)$"),
+            doc.insert,
+        )
+
     def test_rounding_gst_details(self):
         doc = create_transaction(
             **self.transaction_details, rate=62.51, is_in_state=True, do_not_save=True

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -1203,6 +1203,8 @@ class ItemGSTDetails:
         else:
             self.set_item_name_wise_tax_details()
 
+        self.validate_item_gst_details()
+
     def get_item_defaults(self):
         item_defaults = frappe._dict(count=0)
 
@@ -1398,6 +1400,40 @@ class ItemGSTDetails:
             response.update({tax_amount_field: tax_amount})
 
         return response
+
+    def validate_item_gst_details(self):
+        invalid_rows = defaultdict(list)
+
+        for item in self.doc.get("items"):
+            for tax in GST_TAX_TYPES:
+                amount_field = f"{tax}_amount"
+                precision = self.precision.get(amount_field)
+                actual_amt = flt(item.get(amount_field), precision)
+                expected_amt = self.get_item_tax_amount(
+                    item, item.get(f"{tax}_rate"), tax
+                )
+
+                if actual_amt != expected_amt:
+                    invalid_rows[item.idx].append(tax.upper())
+
+        if invalid_rows:
+            msg = (
+                _(
+                    "GST amounts do not match the calculated values based on tax rates for the following Item rows:<br><br>"
+                )
+                + "<ul>"
+            )
+            for idx, fields in invalid_rows.items():
+                msg += _(
+                    "<li><strong>Row #{0}</strong>: {1} amount mismatch</li>"
+                ).format(idx, ", ".join(fields))
+
+            msg += "</ul>"
+
+            frappe.throw(
+                msg,
+                title=_("Incorrect Item GST Details"),
+            )
 
     def set_tax_amount_precisions(self, doctype):
         item_doctype = frappe.get_meta(doctype).get_field("items").options

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -1408,9 +1408,9 @@ class ItemGSTDetails:
             for tax in GST_TAX_TYPES:
                 amount_field = f"{tax}_amount"
                 precision = self.precision.get(amount_field)
-                actual_amt = flt(item.get(amount_field), precision)
-                expected_amt = self.get_item_tax_amount(
-                    item, item.get(f"{tax}_rate"), tax
+                actual_amt = round(flt(item.get(amount_field), precision), 0)
+                expected_amt = round(
+                    self.get_item_tax_amount(item, item.get(f"{tax}_rate"), tax), 0
                 )
 
                 if actual_amt != expected_amt:

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -1221,13 +1221,13 @@ class ItemGSTDetails:
         - Item count added to handle rounding errors
         """
 
-        tax_differences = frappe._dict(
-            {
-                tax_row.gst_tax_type: tax_row.get(self.tax_amount_field(), 0)
-                for tax_row in self.doc.taxes
-                if self.is_gst_tax_row(tax_row)
-            }
-        )
+        tax_differences = defaultdict(float)
+        for tax_row in self.doc.taxes:
+            if not self.is_gst_tax_row(tax_row):
+                continue
+            tax_type = tax_row.gst_tax_type
+            tax_differences[tax_type] += tax_row.get(self.tax_amount_field(), 0)
+
         last_item_with_tax = None
         last_item_defaults = None
 

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -53,6 +53,8 @@ DOCTYPES_WITH_GST_DETAIL = {
     "POS Invoice",
 }
 
+ALLOWED_TAX_DIFFERENCE = 1  # Allowable difference in tax amount due to rounding off
+
 
 def set_gst_breakup(doc):
     gst_breakup_html = frappe.render_template(
@@ -180,7 +182,7 @@ def validate_item_wise_tax_detail(doc):
             )
             tax_difference = abs(multiplier * tax_rate - tax_amount)
 
-            if tax_difference > 1:
+            if tax_difference > ALLOWED_TAX_DIFFERENCE:
                 correct_charge_type = (
                     "On Item Quantity" if is_cess_non_advol else "On Net Total"
                 )
@@ -1413,7 +1415,9 @@ class ItemGSTDetails:
                     self.get_item_tax_amount(item, item.get(f"{tax}_rate"), tax), 0
                 )
 
-                if actual_amt != expected_amt:
+                diff = abs(actual_amt - expected_amt)
+
+                if diff > ALLOWED_TAX_DIFFERENCE:
                     invalid_rows[item.idx].append(tax.upper())
 
         if invalid_rows:

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -1408,14 +1408,11 @@ class ItemGSTDetails:
 
         for item in self.doc.get("items"):
             for tax in GST_TAX_TYPES:
-                amount_field = f"{tax}_amount"
-                precision = self.precision.get(amount_field)
-                actual_amt = round(flt(item.get(amount_field), precision), 0)
-                expected_amt = round(
-                    self.get_item_tax_amount(item, item.get(f"{tax}_rate"), tax), 0
+                expected_amt = self.get_item_tax_amount(
+                    item, item.get(f"{tax}_rate"), tax
                 )
 
-                diff = abs(actual_amt - expected_amt)
+                diff = abs(item.get(f"{tax}_amount") - expected_amt)
 
                 if diff > ALLOWED_TAX_DIFFERENCE:
                     invalid_rows[item.idx].append(tax.upper())


### PR DESCRIPTION
Issue: If gst accounts are added twice in a transaction, then the Item GST details are incorrect.

Steps to replicate:

- Create a sales invoice
- Add the tax row twice.

The tax will be added twice, but in the Item GST details amount will be added for a single row.


Solution: validating gst amount with taxable and gst rate before saving.

Note:
- ERPNext sets only one tax rate per item and per account.

Frappe Support Issue: https://support.frappe.io/app/hd-ticket/50848


<img width="634" height="213" alt="image" src="https://github.com/user-attachments/assets/0b55e4d9-c72e-4d53-9ee5-fcb428c054a9" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Added item-level GST validation that flags discrepancies with clearer, descriptive error messages.
  * Introduced a small rounding tolerance to reduce false positives in GST checks.

* **Bug Fixes**
  * Fixed item-wise GST difference handling so totals align correctly across tax types.

* **Tests**
  * Added tests covering detection of mismatched GST amounts at the item level.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->