### PR TITLE
fix: always set correct gst treatment

### DIFF
--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -1529,34 +1529,24 @@ class ItemGSTTreatment:
 
     def update_gst_treatment_map(self):
         item_templates = set()
-        gst_treatments = set()
-        gst_treatment_map = {}
 
         for item in self.doc.items:
             item_templates.add(item.item_tax_template)
-            gst_treatments.add(item.gst_treatment)
 
-        if any(
-            gst_treatment in gst_treatments
-            for gst_treatment in ["Zero-Rated", "Nil-Rated"]
-        ):
-            # doc changed from overseas to local sale post
-            # taxes added after save
-            _gst_treatments = frappe.get_all(
+        self.gst_treatment_map = frappe._dict(
+            frappe.get_all(
                 "Item Tax Template",
                 filters={"name": ("in", item_templates)},
                 fields=["name", "gst_treatment"],
+                as_list=True,
             )
-            gst_treatment_map = {row.name: row.gst_treatment for row in _gst_treatments}
-
-        self.gst_treatment_map = gst_treatment_map
+        )
 
     def set_default_treatment(self):
         default_treatment = self.get_default_treatment()
 
         for item in self.doc.items:
-            if item.gst_treatment in ("Zero-Rated", "Nil-Rated"):
-                item.gst_treatment = self.gst_treatment_map.get(item.item_tax_template)
+            item.gst_treatment = self.gst_treatment_map.get(item.item_tax_template)
 
             if not item.gst_treatment or not item.item_tax_template:
                 item.gst_treatment = default_treatment


### PR DESCRIPTION
Issue: incorrect gst treatment if the item tax template is changed from the backend or the item tax template is updated from exempted to taxable.

Steps to replicate:
- Set the item tax template in the item as `18%`.
- Create a Sales Invoice and save it.
- Item tax template will be 18% and gst treatment will be taxable.
- Change the item tax template in Item to `Exempted`
- Again, save the invoice.

GST treatment will be Taxable, but the Item Tax Template will be `Exempted` because erpnext changed it.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized GST treatment mapping logic for improved transaction processing efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->