### PR TITLE
fix: absolute item total value for rcm invoice

### DIFF
--- a/india_compliance/gst_india/utils/e_invoice.py
+++ b/india_compliance/gst_india/utils/e_invoice.py
@@ -685,7 +685,7 @@ class EInvoiceData(GSTTransactionData):
         )
 
         if self.doc.is_reverse_charge:
-            item_details["total_value"] = item.taxable_value
+            item_details["total_value"] = abs(self.rounded(item.taxable_value, 3))
 
         if batch_no := self.sanitize_value(
             item.batch_no, max_length=20, truncate=False

--- a/india_compliance/gst_india/utils/e_invoice.py
+++ b/india_compliance/gst_india/utils/e_invoice.py
@@ -685,7 +685,7 @@ class EInvoiceData(GSTTransactionData):
         )
 
         if self.doc.is_reverse_charge:
-            item_details["total_value"] = abs(self.rounded(item.taxable_value, 3))
+            item_details["total_value"] = abs(self.rounded(item.taxable_value, 2))
 
         if batch_no := self.sanitize_value(
             item.batch_no, max_length=20, truncate=False


### PR DESCRIPTION
Issue: Error on Sales RCM Credit Note e-invoice generation.

<img width="1365" height="639" alt="image" src="https://github.com/user-attachments/assets/5fe1338e-2702-45fa-a015-bd5e79ae5224" />

Frappe Support Issue: https://support.frappe.io/helpdesk/tickets/51639?view=VIEW-HD+Ticket-771

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected e-invoice total value for reverse-charge transactions to use the absolute value of the taxable amount and apply rounding to two decimals, ensuring accurate and consistent invoice totals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->