### PR TITLE
fix: remove upload error JSON when filing status is ready

### DIFF
--- a/india_compliance/gst_india/doctype/gstr_1/gstr_1.js
+++ b/india_compliance/gst_india/doctype/gstr_1/gstr_1.js
@@ -2966,7 +2966,7 @@ class GSTR1Action extends FileGSTR1Dialog {
         // summary matched
         if (filing_status == "Ready to File") {
             // only show filed tab
-            ["books", "unfiled", "reconcile"].map(tab =>
+            ["books", "unfiled", "reconcile", "errors"].map(tab =>
                 this.frm.gstr1.tabs[`${tab}_tab`].hide()
             );
             this.frm.gstr1.tabs.filed_tab.set_active();


### PR DESCRIPTION
Fixes: #3732 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * When a return reaches the "Ready to File" state, the Errors tab is now hidden along with other non-relevant tabs. This streamlines the filing workflow by reducing distractions and ensuring the Filed view becomes the active focus for users preparing and completing submissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->