### PR TITLE
fix: arrange GSTIN fields in setup Wizard

### DIFF
--- a/india_compliance/public/js/setup_wizard.js
+++ b/india_compliance/public/js/setup_wizard.js
@@ -31,8 +31,8 @@ function complete_setup_wizard() {
         method: "india_compliance.setup_wizard.enable_setup_wizard_complete",
         callback: function (r) {
             frappe.ui.toolbar.clear_cache();
-        }
-    })
+        },
+    });
 }
 
 function toggle_india_specific_fields(country) {
@@ -61,15 +61,13 @@ function update_erpnext_slides_settings() {
         erpnext.setup?.slides_settings && erpnext.setup.slides_settings.slice(-1)[0];
     if (!slide) return;
 
-    company_gstin_field = {
+    const _index = can_fetch_gstin_info() ? 0 : 3;
+
+    slide.fields.splice(_index, 0, {
         fieldname: "company_gstin",
         fieldtype: "Data",
         label: __("Company GSTIN"),
-    };
-
-    const _index = can_fetch_gstin_info() ? 0 : 1;
-
-    slide.fields.splice(_index, 0, company_gstin_field);
+    });
 
     slide.fields.splice(4, 0, {
         fieldname: "default_gst_rate",


### PR DESCRIPTION
- related to: https://github.com/frappe/erpnext/issues/49135


**If company details can be fetch from GSTIN:**

<img width="602" height="849" alt="image_2025-11-05_16-03-18" src="https://github.com/user-attachments/assets/95c95237-d8c2-46ca-8a2f-c5789c24c95c" />



**If company details can't be fetch from GSTIN:**

<img width="593" height="857" alt="image_2025-11-05_16-02-44" src="https://github.com/user-attachments/assets/a6df76bd-875b-46fa-9f4a-1e2456dd308c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed setup wizard function syntax and execution flow.
  * Improved Company GSTIN field placement logic in the setup workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->