### PR TITLE
fix: update taxable value calculation using `transfer_qty`

### DIFF
--- a/india_compliance/public/js/taxes_controller.js
+++ b/india_compliance/public/js/taxes_controller.js
@@ -132,14 +132,17 @@ india_compliance.taxes_controller = class TaxesController {
         let amount;
 
         // Function to calculate amount
-        const calculateAmount = (qty, rate, precisionType) => {
-            return flt(flt(qty) * flt(rate), precision(precisionType, row));
+        const calculateAmount = (rate, precisionType) => {
+            return flt(
+                flt(row.transfer_qty) * flt(rate),
+                precision(precisionType, row)
+            );
         };
 
         if (this.frm.doc.doctype === "Subcontracting Receipt") {
-            amount = calculateAmount(row.qty, row.rate, "amount");
+            amount = calculateAmount(row.rate, "amount");
         } else if (this.frm.doc.doctype === "Stock Entry") {
-            amount = calculateAmount(row.qty, row.basic_rate, "basic_amount");
+            amount = calculateAmount(row.basic_rate, "basic_amount");
         }
 
         row.taxable_value = amount;

--- a/india_compliance/public/js/taxes_controller.js
+++ b/india_compliance/public/js/taxes_controller.js
@@ -146,6 +146,7 @@ india_compliance.taxes_controller = class TaxesController {
         }
 
         row.taxable_value = amount;
+        this.frm.refresh_field("items");
     }
 
     async update_tax_amount() {

--- a/india_compliance/public/js/taxes_controller.js
+++ b/india_compliance/public/js/taxes_controller.js
@@ -132,17 +132,14 @@ india_compliance.taxes_controller = class TaxesController {
         let amount;
 
         // Function to calculate amount
-        const calculateAmount = (rate, precisionType) => {
-            return flt(
-                flt(row.transfer_qty) * flt(rate),
-                precision(precisionType, row)
-            );
+        const calculateAmount = (qty, rate, precisionType) => {
+            return flt(flt(qty) * flt(rate), precision(precisionType, row));
         };
 
         if (this.frm.doc.doctype === "Subcontracting Receipt") {
-            amount = calculateAmount(row.rate, "amount");
+            amount = calculateAmount(row.qty, row.rate, "amount");
         } else if (this.frm.doc.doctype === "Stock Entry") {
-            amount = calculateAmount(row.basic_rate, "basic_amount");
+            amount = calculateAmount(row.transfer_qty, row.basic_rate, "basic_amount");
         }
 
         row.taxable_value = amount;


### PR DESCRIPTION
Support Ticket: https://support.frappe.io/helpdesk/tickets/51112

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Use transfer quantity for tax and amount calculations on Stock Entry and related receipt lines, yielding accurate taxable values.
  * Refresh item lines after recalculation so amount fields respect precision and updated taxable totals display immediately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->