### PR TITLE
fix: set taxes and totals before validating subcontracting transaction

### DIFF
--- a/india_compliance/gst_india/overrides/subcontracting_transaction.py
+++ b/india_compliance/gst_india/overrides/subcontracting_transaction.py
@@ -178,6 +178,13 @@ def onload(doc, method=None):
 
 
 def validate(doc, method=None):
+    field_map = (
+        STOCK_ENTRY_FIELD_MAP
+        if doc.doctype == "Stock Entry"
+        else SUBCONTRACTING_ORDER_RECEIPT_FIELD_MAP
+    )
+    CustomTaxController(doc, field_map).set_taxes_and_totals()
+
     if ignore_gst_validations_for_subcontracting(doc):
         return
 
@@ -186,13 +193,6 @@ def validate(doc, method=None):
 
     if doc.doctype in ("Stock Entry", "Subcontracting Receipt"):
         validate_transaction_name(doc)
-
-    field_map = (
-        STOCK_ENTRY_FIELD_MAP
-        if doc.doctype == "Stock Entry"
-        else SUBCONTRACTING_ORDER_RECEIPT_FIELD_MAP
-    )
-    CustomTaxController(doc, field_map).set_taxes_and_totals()
 
     set_gst_tax_type(doc)
     validate_taxes(doc)

--- a/india_compliance/gst_india/overrides/test_subcontracting_transaction.py
+++ b/india_compliance/gst_india/overrides/test_subcontracting_transaction.py
@@ -251,7 +251,7 @@ class TestSubcontractingTransaction(IntegrationTestCase):
         )
 
         sco = create_subcontracting_order(po_name=po.name)
-        self.assertEqual(sco.total_taxes, None)
+        self.assertEqual(sco.total_taxes, 0.0)
 
         rm_items = get_rm_items(sco.supplied_items)
         args = {
@@ -271,7 +271,7 @@ class TestSubcontractingTransaction(IntegrationTestCase):
         se = make_stock_entry()
         se.save()
 
-        self.assertEqual(se.total_taxes, None)
+        self.assertEqual(se.total_taxes, 0.0)
 
     def test_subcontracting_validations(self):
         po = create_purchase_order(

--- a/india_compliance/gst_india/utils/itc_04/test_itc_04_export.py
+++ b/india_compliance/gst_india/utils/itc_04/test_itc_04_export.py
@@ -55,7 +55,7 @@ response = {
                         "uqc": "NOS",
                         "qty": 10.0,
                         "desc": "Subcontracted SRM Item 1",
-                        "txval": 0.0,
+                        "txval": 200.0,
                         "goods_ty": "8b",
                         "tx_i": 0.0,
                         "tx_c": 0.0,


### PR DESCRIPTION
Fixes: #3777

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Tax initialization now runs earlier and only once, preventing duplicate calculations.

* **Bug Fixes / Tests**
  * total_taxes now shows 0.0 (not blank) for subcontracting orders with unregistered entities and for material receipt stock entries.

* **Tests**
  * Updated ITC-04 export expectations: adjusted an item's reported value from 0.0 to 200.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->