### PR TITLE
Revert "fix: set taxes and totals before validating subcontracting transaction"

### DIFF
--- a/india_compliance/gst_india/overrides/subcontracting_transaction.py
+++ b/india_compliance/gst_india/overrides/subcontracting_transaction.py
@@ -178,13 +178,6 @@ def onload(doc, method=None):
 
 
 def validate(doc, method=None):
-    field_map = (
-        STOCK_ENTRY_FIELD_MAP
-        if doc.doctype == "Stock Entry"
-        else SUBCONTRACTING_ORDER_RECEIPT_FIELD_MAP
-    )
-    CustomTaxController(doc, field_map).set_taxes_and_totals()
-
     if ignore_gst_validations_for_subcontracting(doc):
         return
 
@@ -193,6 +186,13 @@ def validate(doc, method=None):
 
     if doc.doctype in ("Stock Entry", "Subcontracting Receipt"):
         validate_transaction_name(doc)
+
+    field_map = (
+        STOCK_ENTRY_FIELD_MAP
+        if doc.doctype == "Stock Entry"
+        else SUBCONTRACTING_ORDER_RECEIPT_FIELD_MAP
+    )
+    CustomTaxController(doc, field_map).set_taxes_and_totals()
 
     set_gst_tax_type(doc)
     validate_taxes(doc)

--- a/india_compliance/gst_india/overrides/test_subcontracting_transaction.py
+++ b/india_compliance/gst_india/overrides/test_subcontracting_transaction.py
@@ -251,7 +251,7 @@ class TestSubcontractingTransaction(IntegrationTestCase):
         )
 
         sco = create_subcontracting_order(po_name=po.name)
-        self.assertEqual(sco.total_taxes, 0.0)
+        self.assertEqual(sco.total_taxes, None)
 
         rm_items = get_rm_items(sco.supplied_items)
         args = {
@@ -271,7 +271,7 @@ class TestSubcontractingTransaction(IntegrationTestCase):
         se = make_stock_entry()
         se.save()
 
-        self.assertEqual(se.total_taxes, 0.0)
+        self.assertEqual(se.total_taxes, None)
 
     def test_subcontracting_validations(self):
         po = create_purchase_order(

--- a/india_compliance/gst_india/utils/itc_04/test_itc_04_export.py
+++ b/india_compliance/gst_india/utils/itc_04/test_itc_04_export.py
@@ -55,7 +55,7 @@ response = {
                         "uqc": "NOS",
                         "qty": 10.0,
                         "desc": "Subcontracted SRM Item 1",
-                        "txval": 200.0,
+                        "txval": 0.0,
                         "goods_ty": "8b",
                         "tx_i": 0.0,
                         "tx_c": 0.0,


### PR DESCRIPTION
Reverts resilient-tech/india-compliance#3782

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed GST tax calculation initialization for subcontracting transactions to ensure tax data is properly updated during validation.
  * Corrected tax value handling for unregistered company subcontracting scenarios in GST compliance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->