### PR TITLE
fix: add company and is_group filter to "default_gst_expense_account" search query

### DIFF
--- a/india_compliance/gst_india/client_scripts/company.js
+++ b/india_compliance/gst_india/client_scripts/company.js
@@ -22,6 +22,10 @@ frappe.ui.form.on(DOCTYPE, {
             "default_customs_payable_account",
             { root_type: "Liability" },
         ]);
+        erpnext.company.set_custom_query(frm, [
+            "default_gst_expense_account",
+            {},
+        ]);
 
         frm.set_query("print_label", "bank_details_for_printing", (_, cdt, cdn) => {
             return  {


### PR DESCRIPTION
<img width="1156" height="404" alt="image" src="https://github.com/user-attachments/assets/bc4f75e5-ec3e-4136-b477-17c25a0e4d7f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended accounting setup to support default GST expense account configuration alongside existing expense account options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->