### PR TITLE
fix: first and last name field in party quick entry form

### DIFF
--- a/india_compliance/public/js/quick_entry.js
+++ b/india_compliance/public/js/quick_entry.js
@@ -172,7 +172,7 @@ class PartyQuickEntryForm extends GSTQuickEntryForm {
 				label: __("First Name"),
 				fieldname: "map_to_first_name",
 				fieldtype: "Data",
-				depends_on: "eval:doc.customer_type=='Company'",
+				depends_on: "eval:doc.customer_type=='Company' || doc.supplier_type=='Company'",
 			},
              {
                 fieldtype: "Column Break",
@@ -181,7 +181,7 @@ class PartyQuickEntryForm extends GSTQuickEntryForm {
 				label: __("Last Name"),
 				fieldname: "map_to_last_name",
 				fieldtype: "Data",
-				depends_on: "eval:doc.customer_type=='Company'",
+				depends_on: "eval:doc.customer_type=='Company' || doc.supplier_type=='Company'",
 			},
              {
                 fieldname: "primary_contact_section_2",

--- a/india_compliance/public/js/quick_entry.js
+++ b/india_compliance/public/js/quick_entry.js
@@ -169,6 +169,27 @@ class PartyQuickEntryForm extends GSTQuickEntryForm {
                 collapsible: 0,
             },
             {
+				label: __("First Name"),
+				fieldname: "map_to_first_name",
+				fieldtype: "Data",
+				depends_on: "eval:doc.customer_type=='Company'",
+			},
+             {
+                fieldtype: "Column Break",
+            },
+			{
+				label: __("Last Name"),
+				fieldname: "map_to_last_name",
+				fieldtype: "Data",
+				depends_on: "eval:doc.customer_type=='Company'",
+			},
+             {
+                fieldname: "primary_contact_section_2",
+                fieldtype: "Section Break",
+                collapsible: 0,
+                hide_border: 1,
+            },
+            {
                 label: __("Email ID"),
                 fieldname: "_email_id",
                 fieldtype: "Data",
@@ -195,6 +216,8 @@ class PartyQuickEntryForm extends GSTQuickEntryForm {
         // these fields were suffixed with _ to prevent them from being read only
         doc.email_id = doc._email_id;
         doc.mobile_no = doc._mobile_no;
+        doc.first_name = doc.map_to_first_name;
+        doc.last_name = doc.map_to_last_name;
 
         return doc;
     }


### PR DESCRIPTION
Issue: The User did not have the option to enter the contact's first and last name.
depends on: https://github.com/frappe/erpnext/pull/46281


<img width="575" height="864" alt="image" src="https://github.com/user-attachments/assets/03ca8e8e-15cb-49af-adb0-507f3d103f3c" />


Frappe Support Issue: https://support.frappe.io/app/hd-ticket/53105

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added first and last name fields for the primary contact in the quick entry form when creating company-type parties; these fields are shown only for companies and are visually separated for clarity.
  * Entered names now automatically populate the primary contact name in the party record, streamlining contact setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->