### PR TITLE
feat: ability to specify Origin Port / Border Checkpost Address for the purpose of e-Waybill in delivery note

### DIFF
--- a/india_compliance/gst_india/client_scripts/delivery_note.js
+++ b/india_compliance/gst_india/client_scripts/delivery_note.js
@@ -2,6 +2,13 @@ const DOCTYPE = "Delivery Note";
 setup_e_waybill_actions(DOCTYPE);
 
 frappe.ui.form.on(DOCTYPE, {
+    setup(frm) {
+        frm.set_query("port_address", {
+            filters: {
+                country: "India",
+            },
+        });
+    },
     refresh(frm) {
         if (!gst_settings.enable_e_waybill || !gst_settings.enable_e_waybill_from_dn)
             return;

--- a/india_compliance/gst_india/client_scripts/e_waybill_actions.js
+++ b/india_compliance/gst_india/client_scripts/e_waybill_actions.js
@@ -480,7 +480,7 @@ function get_generate_e_waybill_dialog(opts, frm) {
         },
     ];
 
-    if (frm.doctype === "Sales Invoice" && is_foreign_transaction) {
+    if (["Sales Invoice","Delivery Note"].includes(frm.doctype) && is_foreign_transaction) {
         fields.splice(5, 0, {
             label: "Origin Port / Border Checkpost Address",
             fieldname: "port_address",

--- a/india_compliance/gst_india/constants/custom_fields.py
+++ b/india_compliance/gst_india/constants/custom_fields.py
@@ -633,6 +633,22 @@ CUSTOM_FIELDS = {
     # Sales Shipping Fields
     ("Delivery Note", "Sales Invoice"): [
         {
+            "fieldname": "port_address",
+            "label": "Origin Port / Border Checkpost Address Name",
+            "fieldtype": "Link",
+            "options": "Address",
+            "print_hide": 1,
+            "description": (
+                "Address of the place / port in India from where goods are being"
+                " exported <br>(for generating e-Waybill against export of goods)"
+            ),
+            "insert_after": "shipping_address",
+            "depends_on": (
+                "eval:doc.company_gstin && doc.gst_category === 'Overseas' &&"
+                " doc.place_of_supply == '96-Other Countries' && gst_settings.enable_e_waybill"
+            ),
+        },
+        {
             "fieldname": "port_code",
             "label": "Port Code",
             "fieldtype": "Autocomplete",
@@ -937,22 +953,6 @@ CUSTOM_FIELDS = {
         },
     ],
     "Sales Invoice": [
-        {
-            "fieldname": "port_address",
-            "label": "Origin Port / Border Checkpost Address Name",
-            "fieldtype": "Link",
-            "options": "Address",
-            "print_hide": 1,
-            "description": (
-                "Address of the place / port in India from where goods are being"
-                " exported <br>(for generating e-Waybill against export of goods)"
-            ),
-            "insert_after": "shipping_address",
-            "depends_on": (
-                "eval:doc.company_gstin && doc.gst_category === 'Overseas' &&"
-                " doc.place_of_supply == '96-Other Countries' && gst_settings.enable_e_waybill"
-            ),
-        },
         {
             "fieldname": "invoice_copy",
             "label": "Invoice Copy",

--- a/india_compliance/gst_india/overrides/delivery_note.py
+++ b/india_compliance/gst_india/overrides/delivery_note.py
@@ -1,7 +1,13 @@
 import frappe
 
 from india_compliance.gst_india.overrides.sales_invoice import (
+    is_e_waybill_applicable,
+    is_shipping_address_in_india,
     update_dashboard_with_gst_logs,
+    validate_port_address,
+)
+from india_compliance.gst_india.overrides.transaction import (
+    validate_transaction,
 )
 from india_compliance.gst_india.utils import is_api_enabled
 from india_compliance.gst_india.utils.e_waybill import get_e_waybill_info
@@ -9,6 +15,11 @@ from india_compliance.gst_india.utils.e_waybill import get_e_waybill_info
 
 def onload(doc, method=None):
     if not doc.get("ewaybill"):
+        if doc.gst_category == "Overseas" and is_e_waybill_applicable(doc):
+
+            doc.set_onload(
+                "shipping_address_in_india", is_shipping_address_in_india(doc)
+            )
         return
 
     gst_settings = frappe.get_cached_doc("GST Settings")
@@ -22,6 +33,13 @@ def onload(doc, method=None):
         and (e_waybill_info := get_e_waybill_info(doc))
     ):
         doc.set_onload("e_waybill_info", e_waybill_info)
+
+
+def validate(doc, method=None):
+    if validate_transaction(doc) is False:
+        return
+
+    validate_port_address(doc)
 
 
 def get_dashboard_data(data):

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -1052,7 +1052,7 @@ def update_transaction(doc, values):
         "gst_vehicle_type": values.gst_vehicle_type,
     }
 
-    if doc.doctype == "Sales Invoice":
+    if doc.doctype in ["Sales Invoice", "Delivery Note"]:
         data["port_address"] = values.port_address
 
     doc.db_set(data)

--- a/india_compliance/hooks.py
+++ b/india_compliance/hooks.py
@@ -148,9 +148,7 @@ doc_events = {
         "before_save": "india_compliance.gst_india.overrides.transaction.update_gst_details",
         "before_submit": "india_compliance.gst_india.overrides.transaction.update_gst_details",
         "before_cancel": "india_compliance.gst_india.utils.e_waybill.before_cancel",
-        "validate": (
-            "india_compliance.gst_india.overrides.transaction.validate_transaction"
-        ),
+        "validate": "india_compliance.gst_india.overrides.delivery_note.validate",
     },
     "Email Template": {
         "after_rename": "india_compliance.gst_india.overrides.email_template.after_rename",

--- a/india_compliance/patches.txt
+++ b/india_compliance/patches.txt
@@ -4,7 +4,7 @@ india_compliance.patches.v15.remove_duplicate_web_template
 
 [post_model_sync]
 india_compliance.patches.v14.set_default_for_overridden_accounts_setting
-execute:from india_compliance.gst_india.setup import create_custom_fields; create_custom_fields() #65
+execute:from india_compliance.gst_india.setup import create_custom_fields; create_custom_fields() #66
 execute:from india_compliance.gst_india.setup import create_property_setters; create_property_setters() #11
 execute:from india_compliance.income_tax_india.setup import create_custom_fields; create_custom_fields() #4
 india_compliance.patches.post_install.remove_old_fields #2


### PR DESCRIPTION
closes: https://github.com/resilient-tech/india-compliance/issues/3665

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Origin Port / Border Checkpost Address field to Delivery Notes for foreign transactions and e-waybill generation, extending this capability beyond Sales Invoices.

* **Improvements**
  * Implemented validation for port address entries in Delivery Notes to ensure data consistency.
  * Enhanced form filtering to automatically restrict port address lookups to Indian locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->