### PR TITLE
fix(ims): also fetch original_bill_date and original_bill_no fields in Inward Supply

### DIFF
--- a/india_compliance/gst_india/doctype/gst_invoice_management_system/__init__.py
+++ b/india_compliance/gst_india/doctype/gst_invoice_management_system/__init__.py
@@ -131,6 +131,8 @@ class InwardSupply:
             "is_pending_action_allowed",
             "supplier_return_form",
             "is_supplier_return_filed",
+            "original_bill_date",
+            "original_bill_no",
         ]
 
         if additional_fields:


### PR DESCRIPTION
Fixes: https://support.frappe.io/helpdesk/tickets/53643
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added capture of original bill date and original bill number in the GST Invoice Management System, allowing users to record and track additional invoice reference details for inward supplies.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->