### PR TITLE
refactor: use Frappe utils for dynamic URL generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,16 +50,16 @@ Simplified invoice actions to ensure accurate and efficient GSTR-3B submissions
 
 ### Other Features
 
-- **Advanced Purchase Reconciliation**  
+- **Advanced Purchase Reconciliation**
  Maximize ITC claims with automated reconciliation based on GSTR-2B and GSTR-2A
 
-- **E-Invoice & E-Waybill Integration**  
+- **E-Invoice & E-Waybill Integration**
   Seamless integration with NIC portal (IRP)
 
-- **Real-time Validation**  
+- **Real-time Validation**
   Instant GSTIN verification and document validation against government APIs
 
-- **Intelligent Reporting**  
+- **Intelligent Reporting**
   Pre-built reports for GSTR-1, GSTR-2A/2B reconciliation, and tax liability
 
 ## Quick Start
@@ -70,7 +70,7 @@ For detailed instructions, please [refer to the documentation](https://docs.indi
 
 ### In-app Purchases
 
-Some of the automation features available in India Compliance require access to [GST APIs](https://discuss.erpnext.com/t/introducing-india-compliance/86335#a-note-on-gst-apis-3). Since there are some costs associated with these APIs, they can be accessed by signing up for an India Compliance Account after installing this app.
+Some of the automation features available in India Compliance require access to [GST APIs](https://discuss.frappe.io/t/introducing-india-compliance/86335#a-note-on-gst-apis-3). Since there are some costs associated with these APIs, they can be accessed by signing up for an India Compliance Account after installing this app.
 
 ## Contributing
 

--- a/india_compliance/gst_india/client_scripts/e_waybill_actions.js
+++ b/india_compliance/gst_india/client_scripts/e_waybill_actions.js
@@ -1427,7 +1427,7 @@ function show_sandbox_mode_indicator() {
                 <p><label class="indicator-pill no-indicator-dot yellow" title="${__(
                     "Your site has enabled Sandbox Mode in GST Settings."
                 )}">${__("Sandbox Mode")}</label></p>
-                <p><a class="small text-muted" href="/app/gst-settings" target="_blank">${__(
+                <p><a class="small text-muted" href="${frappe.utils.get_form_link("GST Settings", "GST Settings")}" target="_blank">${__(
                     "Sandbox Mode is enabled for GST APIs."
                 )}</a></p>
             </div>

--- a/india_compliance/gst_india/client_scripts/sales_invoice.js
+++ b/india_compliance/gst_india/client_scripts/sales_invoice.js
@@ -62,8 +62,8 @@ async function gst_invoice_warning(frm) {
     if (is_gst_invoice(frm) && !contains_gst_account) {
         frm.dashboard.add_comment(
             __(
-                `GST is applicable for this invoice but no tax accounts specified in <a href="/app/gst-settings">
-                GST Settings</a> are charged.`
+                "GST is applicable for this invoice but no tax accounts specified in {0} are charged.",
+                [frappe.utils.get_form_link("GST Settings", "GST Settings", true)]
             ),
             "red",
             true

--- a/india_compliance/gst_india/doctype/gst_settings/gst_settings.js
+++ b/india_compliance/gst_india/doctype/gst_settings/gst_settings.js
@@ -59,7 +59,7 @@ function show_ic_api_promo(frm) {
     if (!frm.doc.__onload?.can_show_promo) return;
     const alert_message = `
     Looking for API Features?
-    <a href="/app/india-compliance-account" class="alert-link">
+    <a href="${frappe.utils.generate_route({type: 'Page', name: 'india-compliance-account'})}" class="alert-link">
         Get started with the India Compliance API!
     </a>`;
 

--- a/india_compliance/gst_india/doctype/gstr_1/gstr_1.js
+++ b/india_compliance/gst_india/doctype/gstr_1/gstr_1.js
@@ -174,9 +174,9 @@ frappe.ui.form.on(DOCTYPE, {
             if (error_log) {
                 frappe.msgprint({
                     message: __(
-                        "Error while preparing GSTR-1 data, please check {0} for more deatils.",
+                        "Error while preparing GSTR-1 data, please {0} for more details.",
                         [
-                            `<a href='/app/error-log/${error_log}' class='variant-click'>error log</a>`,
+                            frappe.utils.get_form_link("Error Log", error_log, true, "check the error log"),
                         ]
                     ),
                     title: "GSTR-1 Download Failed",

--- a/india_compliance/hooks.py
+++ b/india_compliance/hooks.py
@@ -7,7 +7,7 @@ app_color = "grey"
 app_email = "hello@indiacompliance.app"
 app_license = "GNU General Public License (v3)"
 required_apps = ["frappe/erpnext"]
-app_home = "/app/gst-india"
+app_home = "/desk/gst-india"
 
 add_to_apps_screen = [
     {

--- a/india_compliance/public/js/india_compliance_account/india_compliance_account.bundle.js
+++ b/india_compliance/public/js/india_compliance_account/india_compliance_account.bundle.js
@@ -18,7 +18,7 @@ class IndiaComplianceAccountPage {
     }
 
     createRouter() {
-        const history = createWebHistory("/app/india-compliance-account");
+        const history = createWebHistory(frappe.utils.generate_route({type: 'Page', name: 'india-compliance-account'}));
 
         history.listen(to => {
             if (frappe.get_route_str().startsWith(this.pageName)) return;

--- a/india_compliance/public/js/india_compliance_account/pages/AccountPage.vue
+++ b/india_compliance/public/js/india_compliance_account/pages/AccountPage.vue
@@ -39,8 +39,8 @@
             <a @click.prevent="showUsage"><li>Review API Usage</li></a>
             <!-- <a href="#"><li>Check API Status</li></a> -->
             <a @click.prevent="openInvoiceDialog"><li>Invoice History</li></a>
-            <a href="https://discuss.erpnext.com/c/erpnext/india-compliance/65"><li>Community Forum</li></a>
-            <a href="https://github.com/resilient-tech/india-compliance/issues/new"><li>Report a Bug</li></a>
+            <a href="https://discuss.frappe.io/c/erpnext/india-compliance/65"><li>Community Forum</li></a>
+            <a href="https://github.com/resilient-tech/india-compliance/issues/new?template=bug_report.yaml"><li>Report a Bug</li></a>
             <a href="mailto:api-support@indiacompliance.app"><li>Email Support</li></a>
             <a @click.prevent="logout"><li>Logout</li></a>
           </ul>


### PR DESCRIPTION
Replace hardcoded URLs with Frappe utility functions for flexibility when routing changes

- Use `frappe.utils.get_form_link()` for DocType form links
- Use `frappe.utils.generate_route()` for page routes
- Fix typo in GSTR-1 error message
- Update community forum and bug report links

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a typo in an error message for clearer guidance.

* **Documentation**
  * Updated Community Forum and Report a Bug links.
  * Updated GST API reference URL.

* **Enhancements**
  * Links to GST Settings, error logs, and account pages now open the correct, localized destinations.
  * App home now routes to the Desk view for a consistent entry point.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->