### PR TITLE
chore: use set_single_value

### DIFF
--- a/india_compliance/gst_india/overrides/test_transaction.py
+++ b/india_compliance/gst_india/overrides/test_transaction.py
@@ -1394,19 +1394,19 @@ class TestPlaceOfSupply(IntegrationTestCase):
             "shipping_address_name": "_Test Indian Registered Company-Billing",
         }
 
-        settings = ["Accounts Settings", None, "determine_address_tax_category_from"]
+        settings = ["Accounts Settings", "determine_address_tax_category_from"]
 
         # Shipping Address
-        frappe.db.set_value(*settings, "Shipping Address")
+        frappe.db.set_single_value(*settings, "Shipping Address")
         doc = create_transaction(**doc_args)
         self.assertEqual(doc.place_of_supply, "24-Gujarat")
 
         # Billing Address
-        frappe.db.set_value(*settings, "Billing Address")
+        frappe.db.set_single_value(*settings, "Billing Address")
         doc = create_transaction(**doc_args)
         self.assertEqual(doc.place_of_supply, "29-Karnataka")
 
-        frappe.db.set_value(*settings, "Shipping Address")
+        frappe.db.set_single_value(*settings, "Shipping Address")
 
         # Sales Invoice with only Billing Address
         doc_args = {

--- a/india_compliance/patches.txt
+++ b/india_compliance/patches.txt
@@ -27,8 +27,8 @@ execute:from india_compliance.gst_india.setup import map_default_uoms; map_defau
 india_compliance.patches.v14.rename_reverse_charge_to_purchase_reverse_charge
 india_compliance.patches.v14.set_correct_root_account_for_rcm
 india_compliance.patches.v14.set_autogenerate_e_waybill_with_e_invoice
-execute:import frappe; frappe.db.set_value("GST Settings", None, "archive_party_info_days", 7)
-execute:import frappe; frappe.db.set_value("GST Settings", None, "enable_retry_e_invoice_generation", 1)
+execute:import frappe; frappe.db.set_single_value("GST Settings", "archive_party_info_days", 7)
+execute:import frappe; frappe.db.set_single_value("GST Settings", "enable_retry_e_invoice_generation", 1)
 india_compliance.patches.v14.set_enable_retry_einv_ewb_generation
 india_compliance.patches.v14.set_reverse_charge_applicability_in_supplier
 india_compliance.patches.post_install.update_e_waybill_status

--- a/india_compliance/patches.txt
+++ b/india_compliance/patches.txt
@@ -27,8 +27,6 @@ execute:from india_compliance.gst_india.setup import map_default_uoms; map_defau
 india_compliance.patches.v14.rename_reverse_charge_to_purchase_reverse_charge
 india_compliance.patches.v14.set_correct_root_account_for_rcm
 india_compliance.patches.v14.set_autogenerate_e_waybill_with_e_invoice
-execute:import frappe; frappe.db.set_single_value("GST Settings", "archive_party_info_days", 7)
-execute:import frappe; frappe.db.set_single_value("GST Settings", "enable_retry_e_invoice_generation", 1)
 india_compliance.patches.v14.set_enable_retry_einv_ewb_generation
 india_compliance.patches.v14.set_reverse_charge_applicability_in_supplier
 india_compliance.patches.post_install.update_e_waybill_status


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified how address tax-category configuration is applied during invoice processing, consolidating multi-step updates into a single-step operation for billing and shipping addresses.
* **Chores**
  * Removed two outdated GST settings update entries to streamline configuration patches.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->