### PR TITLE
fix: add duplicate GSTIN and PAN message checks in party and address

### DIFF
--- a/india_compliance/gst_india/client_scripts/party.js
+++ b/india_compliance/gst_india/client_scripts/party.js
@@ -89,14 +89,10 @@ function check_duplicate_gstin(doc) {
         party: doc.name,
     };
 
-    // For Address, get party info from the links (Dynamic Link) table
-    // Only validate if there is exactly one link
     if (doc.doctype === "Address") {
         if (!doc.links || doc.links.length !== 1) return;
 
         const link = doc.links[0];
-        if (!frappe.boot.gst_party_types.includes(link.link_doctype)) return;
-
         args = {
             gstin: doc.gstin,
             party_type: link.link_doctype,
@@ -104,6 +100,8 @@ function check_duplicate_gstin(doc) {
             address_name: doc.name,
         };
     }
+
+    if (!frappe.boot.gst_party_types.includes(args.party_type)) return;
 
     frappe.call({
         method: "india_compliance.gst_india.utils.check_duplicate_gstin",
@@ -129,9 +127,18 @@ function validate_pan(doctype) {
 
 function check_duplicate_pan(doc) {
     if (!doc.pan) return;
+
+    let args = {
+        pan: doc.pan,
+        party_type: doc.doctype,
+        party: doc.name,
+    };
+
+    if (!frappe.boot.gst_party_types.includes(args.party_type)) return;
+
     frappe.call({
         method: "india_compliance.gst_india.utils.check_duplicate_pan",
-        args: { pan: doc.pan, party_type: doc.doctype, party: doc.name },
+        args: { ...args },
     });
 }
 

--- a/india_compliance/gst_india/client_scripts/party.js
+++ b/india_compliance/gst_india/client_scripts/party.js
@@ -58,9 +58,9 @@ function validate_gstin(doctype) {
             }
 
             gstin = india_compliance.validate_gstin(gstin);
-            check_duplicate_gstin(frm.doc);
 
             frm.doc.gstin = gstin;
+            check_duplicate_gstin(frm.doc);
             frm.refresh_field("gstin");
 
             if (!frm.fields_dict.pan) return;
@@ -81,15 +81,16 @@ function validate_gstin(doctype) {
 }
 
 function check_duplicate_gstin(doc) {
-    // For Address, get party info from the links (Dynamic Link) table
-    // Only validate if there is exactly one link
+    if (!doc.gstin) return;
 
     let args = {
         gstin: doc.gstin,
         party_type: doc.doctype,
         party: doc.name,
-    }
+    };
 
+    // For Address, get party info from the links (Dynamic Link) table
+    // Only validate if there is exactly one link
     if (doc.doctype === "Address") {
         if (!doc.links || doc.links.length !== 1) return;
 
@@ -110,7 +111,6 @@ function check_duplicate_gstin(doc) {
     });
 }
 
-
 function validate_pan(doctype) {
     frappe.ui.form.on(doctype, {
         pan(frm) {
@@ -118,9 +118,9 @@ function validate_pan(doctype) {
             if (!pan || pan.length < 10) return;
 
             pan = india_compliance.validate_pan(pan);
-            check_duplicate_pan(frm.doc);
 
             frm.doc.pan = pan;
+            check_duplicate_pan(frm.doc);
             frm.refresh_field("pan");
             set_party_type(frm);
         },
@@ -128,6 +128,7 @@ function validate_pan(doctype) {
 }
 
 function check_duplicate_pan(doc) {
+    if (!doc.pan) return;
     frappe.call({
         method: "india_compliance.gst_india.utils.check_duplicate_pan",
         args: { pan: doc.pan, party_type: doc.doctype, party: doc.name },

--- a/india_compliance/gst_india/client_scripts/party.js
+++ b/india_compliance/gst_india/client_scripts/party.js
@@ -60,8 +60,9 @@ function validate_gstin(doctype) {
             gstin = india_compliance.validate_gstin(gstin);
 
             frm.doc.gstin = gstin;
-            check_duplicate_gstin(frm.doc);
             frm.refresh_field("gstin");
+
+            india_compliance.check_duplicate_gstin(gstin, frm.doctype, frm.docname);
 
             if (!frm.fields_dict.pan) return;
 
@@ -80,35 +81,6 @@ function validate_gstin(doctype) {
     });
 }
 
-function check_duplicate_gstin(doc) {
-    if (!doc.gstin) return;
-
-    let args = {
-        gstin: doc.gstin,
-        party_type: doc.doctype,
-        party: doc.__islocal ? null : doc.name,
-    };
-
-    if (doc.doctype === "Address") {
-        if (!doc.links || doc.links.length !== 1) return;
-
-        const link = doc.links[0];
-        args = {
-            gstin: doc.gstin,
-            party_type: link.link_doctype,
-            party: link.link_name,
-            address_name: doc.__islocal ? null : doc.name,
-        };
-    }
-
-    if (!frappe.boot.gst_party_types.includes(args.party_type)) return;
-
-    frappe.call({
-        method: "india_compliance.gst_india.utils.check_duplicate_gstin",
-        args: { ...args },
-    });
-}
-
 function validate_pan(doctype) {
     frappe.ui.form.on(doctype, {
         pan(frm) {
@@ -118,27 +90,11 @@ function validate_pan(doctype) {
             pan = india_compliance.validate_pan(pan);
 
             frm.doc.pan = pan;
-            check_duplicate_pan(frm.doc);
             frm.refresh_field("pan");
+
+            india_compliance.check_duplicate_pan(pan, frm.doctype, frm.docname);
             set_party_type(frm);
         },
-    });
-}
-
-function check_duplicate_pan(doc) {
-    if (!doc.pan) return;
-
-    let args = {
-        pan: doc.pan,
-        party_type: doc.doctype,
-        party: doc.__islocal ? null : doc.name,
-    };
-
-    if (!frappe.boot.gst_party_types.includes(args.party_type)) return;
-
-    frappe.call({
-        method: "india_compliance.gst_india.utils.check_duplicate_pan",
-        args: { ...args },
     });
 }
 

--- a/india_compliance/gst_india/client_scripts/party.js
+++ b/india_compliance/gst_india/client_scripts/party.js
@@ -58,6 +58,7 @@ function validate_gstin(doctype) {
             }
 
             gstin = india_compliance.validate_gstin(gstin);
+            check_duplicate_gstin(frm.doc);
 
             frm.doc.gstin = gstin;
             frm.refresh_field("gstin");
@@ -79,6 +80,37 @@ function validate_gstin(doctype) {
     });
 }
 
+function check_duplicate_gstin(doc) {
+    // For Address, get party info from the links (Dynamic Link) table
+    // Only validate if there is exactly one link
+
+    let args = {
+        gstin: doc.gstin,
+        party_type: doc.doctype,
+        party: doc.name,
+    }
+
+    if (doc.doctype === "Address") {
+        if (!doc.links || doc.links.length !== 1) return;
+
+        const link = doc.links[0];
+        if (!frappe.boot.gst_party_types.includes(link.link_doctype)) return;
+
+        args = {
+            gstin: doc.gstin,
+            party_type: link.link_doctype,
+            party: link.link_name,
+            address_name: doc.name,
+        };
+    }
+
+    frappe.call({
+        method: "india_compliance.gst_india.utils.check_duplicate_gstin",
+        args: { ...args },
+    });
+}
+
+
 function validate_pan(doctype) {
     frappe.ui.form.on(doctype, {
         pan(frm) {
@@ -86,11 +118,19 @@ function validate_pan(doctype) {
             if (!pan || pan.length < 10) return;
 
             pan = india_compliance.validate_pan(pan);
+            check_duplicate_pan(frm.doc);
 
             frm.doc.pan = pan;
             frm.refresh_field("pan");
             set_party_type(frm);
         },
+    });
+}
+
+function check_duplicate_pan(doc) {
+    frappe.call({
+        method: "india_compliance.gst_india.utils.check_duplicate_pan",
+        args: { pan: doc.pan, party_type: doc.doctype, party: doc.name },
     });
 }
 

--- a/india_compliance/gst_india/client_scripts/party.js
+++ b/india_compliance/gst_india/client_scripts/party.js
@@ -86,7 +86,7 @@ function check_duplicate_gstin(doc) {
     let args = {
         gstin: doc.gstin,
         party_type: doc.doctype,
-        party: doc.name,
+        party: doc.__islocal ? null : doc.name,
     };
 
     if (doc.doctype === "Address") {
@@ -97,7 +97,7 @@ function check_duplicate_gstin(doc) {
             gstin: doc.gstin,
             party_type: link.link_doctype,
             party: link.link_name,
-            address_name: doc.name,
+            address_name: doc.__islocal ? null : doc.name,
         };
     }
 
@@ -131,7 +131,7 @@ function check_duplicate_pan(doc) {
     let args = {
         pan: doc.pan,
         party_type: doc.doctype,
-        party: doc.name,
+        party: doc.__islocal ? null : doc.name,
     };
 
     if (!frappe.boot.gst_party_types.includes(args.party_type)) return;

--- a/india_compliance/gst_india/utils/__init__.py
+++ b/india_compliance/gst_india/utils/__init__.py
@@ -1161,7 +1161,6 @@ def _check_duplicate_pan(pan, party_type, party):
     msg = _(
         "PAN {0} is already registered with the following {1}(s):<br><br>"
         "<ul>{2}</ul><br>"
-        "Please verify if you want to create a duplicate entry."
     ).format(
         frappe.bold(pan),
         party_type,
@@ -1184,12 +1183,6 @@ def check_duplicate_gstin(gstin, party_type, party, address_name=None):
 def _check_duplicate_gstin(gstin, party_type, party, address_name=None):
     """
     Check if GSTIN already exists for another party of the same doctype.
-    Shows a single alert with all duplicates found.
-
-    :param gstin: GSTIN to check for duplicates
-    :param party_type: Type of party (Customer, Supplier, Company)
-    :param party_name: Current party name (to exclude from check during updates)
-    :param address_name: Current address name (to exclude when checking from Address)
     """
     if not gstin:
         return
@@ -1242,21 +1235,20 @@ def _check_duplicate_gstin(gstin, party_type, party, address_name=None):
 
     # Build combined message
     duplicate_links = []
-    for dup in duplicates:
-        party_link = get_link_to_form(party_type, dup["name"])
-        if dup["via_address"]:
-            address_link = get_link_to_form("Address", dup["address"])
-            duplicate_links.append(
-                f"<li>{party_link} (via Address: {address_link})</li>"
-            )
-        else:
-            duplicate_links.append(f"<li>{party_link}</li>")
+    for row in duplicates:
+        party_link = get_link_to_form(party_type, row["name"])
+        msg = f"{party_link}"
+        if row["via_address"]:
+            address_link = get_link_to_form("Address", row["address"])
+            msg += f" (via Address {address_link})"
+
+        msg = _("{}").format(msg)
+        duplicate_links.append(f"<li>{msg}</li>")
 
     msg = _(
-        "{0} {1} is already registered with the following {2}(s):<br><br>"
-        "<ul>{3}</ul><br>"
+        "GSTIN {0} is already registered with the following {1}(s):<br><br>"
+        "<ul>{2}</ul>"
     ).format(
-        "GSTIN",
         frappe.bold(gstin),
         party_type,
         "".join(duplicate_links),

--- a/india_compliance/gst_india/utils/__init__.py
+++ b/india_compliance/gst_india/utils/__init__.py
@@ -1158,17 +1158,15 @@ def _check_duplicate_pan(pan, party_type, party):
     if not existing_parties:
         return
 
-    msg = _(
-        "PAN {0} is already registered with the following {1}(s):<br><br>"
-        "<ul>{2}</ul><br>"
-    ).format(
+    duplicate_links = "".join(
+        f"<li>{get_link_to_form(party_type, name)}</li>" for name in existing_parties
+    )
+
+    msg = _("PAN {0} is already registered with the following {1}(s):").format(
         frappe.bold(pan),
         party_type,
-        "".join(
-            f"<li>{get_link_to_form(party_type, party)}</li>"
-            for party in existing_parties
-        ),
     )
+    msg += f"<br><br><ul>{duplicate_links}</ul>"
 
     frappe.msgprint(msg=msg, indicator="orange")
 
@@ -1237,21 +1235,18 @@ def _check_duplicate_gstin(gstin, party_type, party, address_name=None):
     duplicate_links = []
     for row in duplicates:
         party_link = get_link_to_form(party_type, row["name"])
-        msg = f"{party_link}"
         if row["via_address"]:
             address_link = get_link_to_form("Address", row["address"])
-            msg += f" (via Address {address_link})"
+            link_msg = _("{0} (via Address {1})").format(party_link, address_link)
+        else:
+            link_msg = party_link
 
-        msg = _("{}").format(msg)
-        duplicate_links.append(f"<li>{msg}</li>")
+        duplicate_links.append(f"<li>{link_msg}</li>")
 
-    msg = _(
-        "GSTIN {0} is already registered with the following {1}(s):<br><br>"
-        "<ul>{2}</ul>"
-    ).format(
+    msg = _("GSTIN {0} is already registered with the following {1}(s):").format(
         frappe.bold(gstin),
         party_type,
-        "".join(duplicate_links),
     )
+    msg += f"<br><br><ul>{''.join(duplicate_links)}</ul>"
 
     frappe.msgprint(msg=msg, indicator="orange")

--- a/india_compliance/gst_india/utils/__init__.py
+++ b/india_compliance/gst_india/utils/__init__.py
@@ -33,6 +33,7 @@ from india_compliance.gst_india.constants import (
     E_INVOICE_MASTER_CODES_URL,
     GST_ACCOUNT_FIELDS,
     GST_INVOICE_NUMBER_FORMAT,
+    GST_PARTY_TYPES,
     GSTIN_FORMATS,
     PAN_NUMBER,
     PINCODE_FORMAT,
@@ -1133,105 +1134,71 @@ def has_permission_of_page(page_name, throw=False):
     return True
 
 
+def _show_duplicate_alert(field_label, value, party_type, duplicate_links):
+    msg = _("{0} {1} is already registered with the following {2}(s):").format(
+        field_label,
+        frappe.bold(value),
+        party_type,
+    )
+    msg += f"<br><br><ul>{''.join(duplicate_links)}</ul>"
+
+    frappe.msgprint(msg=msg, indicator="orange")
+
+
+def validate_party_type(party_type, party):
+    if party_type not in GST_PARTY_TYPES:
+        return
+
+    frappe.has_permission(party_type, doc=party, throw=True)
+    return True
+
+
 @frappe.whitelist()
 def check_duplicate_pan(pan, party_type, party):
-    frappe.has_permission(party_type, doc=party, throw=True)
-
-    _check_duplicate_pan(pan, party_type, party)
-
-
-def _check_duplicate_pan(pan, party_type, party):
-    """
-    Check if PAN already exists for another party of the same doctype.
-    """
-
     if not pan:
         return
 
+    if not validate_party_type(party_type, party):
+        return
+
     pan = pan.upper().strip()
-    existing_parties = frappe.get_all(
+
+    existing_parties = _get_duplicate_pan_party(pan, party_type, party)
+    if not existing_parties:
+        return
+
+    duplicate_links = [
+        f"<li>{get_link_to_form(party_type, name)}</li>" for name in existing_parties
+    ]
+
+    _show_duplicate_alert("PAN", pan, party_type, duplicate_links)
+
+
+def _get_duplicate_pan_party(pan, party_type, party):
+    """
+    Check if PAN already exists for another party of the same doctype.
+    """
+    return frappe.get_all(
         party_type,
         filters={"pan": ("=", pan), "name": ("!=", party)},
         pluck="name",
     )
 
-    if not existing_parties:
-        return
-
-    duplicate_links = "".join(
-        f"<li>{get_link_to_form(party_type, name)}</li>" for name in existing_parties
-    )
-
-    msg = _("PAN {0} is already registered with the following {1}(s):").format(
-        frappe.bold(pan),
-        party_type,
-    )
-    msg += f"<br><br><ul>{duplicate_links}</ul>"
-
-    frappe.msgprint(msg=msg, indicator="orange")
-
 
 @frappe.whitelist()
 def check_duplicate_gstin(gstin, party_type, party, address_name=None):
-    frappe.has_permission(party_type, doc=party, throw=True)
-
-    _check_duplicate_gstin(gstin, party_type, party, address_name)
-
-
-def _check_duplicate_gstin(gstin, party_type, party, address_name=None):
-    """
-    Check if GSTIN already exists for another party of the same doctype.
-    """
     if not gstin:
+        return
+
+    if not validate_party_type(party_type, party):
         return
 
     gstin = gstin.upper().strip()
 
-    existing_parties = frappe.get_all(
-        party_type,
-        filters={"gstin": ("=", gstin), "name": ("!=", party)},
-        pluck="name",
-    )
-
-    # Check in Address linked to parties of the same doctype
-    address = frappe.qb.DocType("Address")
-    links = frappe.qb.DocType("Dynamic Link")
-    query = (
-        frappe.qb.from_(address)
-        .join(links)
-        .on(links.parent == address.name)
-        .select(links.link_name, address.name.as_("address_name"))
-        .where(links.link_doctype == party_type)
-        .where(address.gstin == gstin)
-        .where(links.link_name != party)
-    )
-
-    # Exclude current address when checking from Address
-    if address_name:
-        query = query.where(address.name != address_name)
-
-    if existing_parties:
-        query = query.where(links.link_name.notin(existing_parties))
-
-    address_results = query.run(as_dict=True)
-
-    duplicates = []
-    for party in existing_parties:
-        duplicates.append({"name": party, "via_address": False})
-
-    for result in address_results:
-        duplicates.append(
-            {
-                "name": result.link_name,
-                "via_address": True,
-                "address": result.address_name,
-            }
-        )
-
+    duplicates = _get_duplicate_gstin_party(gstin, party_type, party, address_name)
     if not duplicates:
         return
 
-    # Build combined message
     duplicate_links = []
     for row in duplicates:
         party_link = get_link_to_form(party_type, row["name"])
@@ -1243,10 +1210,43 @@ def _check_duplicate_gstin(gstin, party_type, party, address_name=None):
 
         duplicate_links.append(f"<li>{link_msg}</li>")
 
-    msg = _("GSTIN {0} is already registered with the following {1}(s):").format(
-        frappe.bold(gstin),
-        party_type,
-    )
-    msg += f"<br><br><ul>{''.join(duplicate_links)}</ul>"
+    _show_duplicate_alert("GSTIN", gstin, party_type, duplicate_links)
 
-    frappe.msgprint(msg=msg, indicator="orange")
+
+def _get_duplicate_gstin_party(gstin, party_type, party, address_name=None):
+    parties_with_gstin = frappe.get_all(
+        party_type,
+        filters={"gstin": ("=", gstin), "name": ("!=", party)},
+        pluck="name",
+    )
+
+    # Check parties linked via Address with same GSTIN
+    address = frappe.qb.DocType("Address")
+    dynamic_link = frappe.qb.DocType("Dynamic Link")
+
+    query = (
+        frappe.qb.from_(address)
+        .join(dynamic_link)
+        .on(dynamic_link.parent == address.name)
+        .select(dynamic_link.link_name, address.name.as_("address_name"))
+        .where(dynamic_link.link_doctype == party_type)
+        .where(address.gstin == gstin)
+        .where(dynamic_link.link_name != party)
+    )
+
+    if address_name:
+        query = query.where(address.name != address_name)
+
+    if parties_with_gstin:
+        query = query.where(dynamic_link.link_name.notin(parties_with_gstin))
+
+    address_results = query.run(as_dict=True)
+
+    # Build result list
+    duplicates = [{"name": name, "via_address": False} for name in parties_with_gstin]
+    duplicates.extend(
+        {"name": row.link_name, "via_address": True, "address": row.address_name}
+        for row in address_results
+    )
+
+    return duplicates

--- a/india_compliance/gst_india/utils/__init__.py
+++ b/india_compliance/gst_india/utils/__init__.py
@@ -1163,9 +1163,9 @@ def check_duplicate_party(field, value, party_type, party=None):
     # Show message
     duplicate_links = []
     for row in existing_parties:
-        party_link = get_link_to_form(party_type, row["name"])
-        if row["via_address"]:
-            address_link = get_link_to_form("Address", row["address"])
+        party_link = get_link_to_form(party_type, row.name)
+        if row.via_address:
+            address_link = get_link_to_form("Address", row.address)
             link_msg = _("{0} (via Address {1})").format(party_link, address_link)
 
         else:

--- a/india_compliance/gst_india/utils/__init__.py
+++ b/india_compliance/gst_india/utils/__init__.py
@@ -1218,45 +1218,58 @@ def check_duplicate_gstin(gstin, party_type, party=None, address_name=None):
 
 
 def _get_duplicate_gstin_party(gstin, party_type, party=None, address_name=None):
-    party_filters = {"gstin": ("=", gstin)}
-    if party:
-        party_filters["name"] = ("!=", party)
-
-    parties_with_gstin = frappe.get_all(
-        party_type,
-        filters=party_filters,
-        pluck="name",
-    )
-
-    # Check parties linked via Address with same GSTIN
+    party_table = frappe.qb.DocType(party_type)
     address = frappe.qb.DocType("Address")
     dynamic_link = frappe.qb.DocType("Dynamic Link")
 
     query = (
+        frappe.qb.from_(party_table)
+        .select(
+            party_table.name,
+            frappe.qb.terms.ValueWrapper(None).as_("address_name"),
+            frappe.qb.terms.ValueWrapper(0).as_("via_address"),
+        )
+        .where(party_table.gstin == gstin)
+    )
+
+    if party:
+        query = query.where(party_table.name != party)
+
+    address_query = (
         frappe.qb.from_(address)
         .join(dynamic_link)
         .on(dynamic_link.parent == address.name)
-        .select(dynamic_link.link_name, address.name.as_("address_name"))
+        .select(
+            dynamic_link.link_name.as_("name"),
+            address.name.as_("address_name"),
+            frappe.qb.terms.ValueWrapper(1).as_("via_address"),
+        )
         .where(dynamic_link.link_doctype == party_type)
         .where(address.gstin == gstin)
     )
 
     if party:
-        query = query.where(dynamic_link.link_name != party)
+        address_query = address_query.where(dynamic_link.link_name != party)
 
     if address_name:
-        query = query.where(address.name != address_name)
+        address_query = address_query.where(address.name != address_name)
 
-    if parties_with_gstin:
-        query = query.where(dynamic_link.link_name.notin(parties_with_gstin))
+    results = (query + address_query).run(as_dict=True)
 
-    address_results = query.run(as_dict=True)
+    duplicates_dict = {}
+    for row in results:
+        if row.name in duplicates_dict:
+            if not row.via_address:
+                duplicates_dict[row.name] = {
+                    "name": row.name,
+                    "via_address": False,
+                    "address": None,
+                }
+        else:
+            duplicates_dict[row.name] = {
+                "name": row.name,
+                "via_address": bool(row.via_address),
+                "address": row.address_name,
+            }
 
-    # Build result list
-    duplicates = [{"name": name, "via_address": False} for name in parties_with_gstin]
-    duplicates.extend(
-        {"name": row.link_name, "via_address": True, "address": row.address_name}
-        for row in address_results
-    )
-
-    return duplicates
+    return list(duplicates_dict.values())

--- a/india_compliance/gst_india/utils/__init__.py
+++ b/india_compliance/gst_india/utils/__init__.py
@@ -1131,3 +1131,135 @@ def has_permission_of_page(page_name, throw=False):
         )
 
     return True
+
+
+@frappe.whitelist()
+def check_duplicate_pan(pan, party_type, party):
+    frappe.has_permission(party_type, doc=party, throw=True)
+
+    _check_duplicate_pan(pan, party_type, party)
+
+
+def _check_duplicate_pan(pan, party_type, party):
+    """
+    Check if PAN already exists for another party of the same doctype.
+    """
+
+    if not pan:
+        return
+
+    pan = pan.upper().strip()
+    existing_parties = frappe.get_all(
+        party_type,
+        filters={"pan": ("=", pan), "name": ("!=", party)},
+        pluck="name",
+    )
+
+    if not existing_parties:
+        return
+
+    msg = _(
+        "PAN {0} is already registered with the following {1}(s):<br><br>"
+        "<ul>{2}</ul><br>"
+        "Please verify if you want to create a duplicate entry."
+    ).format(
+        frappe.bold(pan),
+        party_type,
+        "".join(
+            f"<li>{get_link_to_form(party_type, party)}</li>"
+            for party in existing_parties
+        ),
+    )
+
+    frappe.msgprint(msg=msg, indicator="orange")
+
+
+@frappe.whitelist()
+def check_duplicate_gstin(gstin, party_type, party, address_name=None):
+    frappe.has_permission(party_type, doc=party, throw=True)
+
+    _check_duplicate_gstin(gstin, party_type, party, address_name)
+
+
+def _check_duplicate_gstin(gstin, party_type, party, address_name=None):
+    """
+    Check if GSTIN already exists for another party of the same doctype.
+    Shows a single alert with all duplicates found.
+
+    :param gstin: GSTIN to check for duplicates
+    :param party_type: Type of party (Customer, Supplier, Company)
+    :param party_name: Current party name (to exclude from check during updates)
+    :param address_name: Current address name (to exclude when checking from Address)
+    """
+    if not gstin:
+        return
+
+    gstin = gstin.upper().strip()
+
+    existing_parties = frappe.get_all(
+        party_type,
+        filters={"gstin": ("=", gstin), "name": ("!=", party)},
+        pluck="name",
+    )
+
+    # Check in Address linked to parties of the same doctype
+    address = frappe.qb.DocType("Address")
+    links = frappe.qb.DocType("Dynamic Link")
+    query = (
+        frappe.qb.from_(address)
+        .join(links)
+        .on(links.parent == address.name)
+        .select(links.link_name, address.name.as_("address_name"))
+        .where(links.link_doctype == party_type)
+        .where(address.gstin == gstin)
+        .where(links.link_name != party)
+    )
+
+    # Exclude current address when checking from Address
+    if address_name:
+        query = query.where(address.name != address_name)
+
+    if existing_parties:
+        query = query.where(links.link_name.notin(existing_parties))
+
+    address_results = query.run(as_dict=True)
+
+    duplicates = []
+    for party in existing_parties:
+        duplicates.append({"name": party, "via_address": False})
+
+    for result in address_results:
+        duplicates.append(
+            {
+                "name": result.link_name,
+                "via_address": True,
+                "address": result.address_name,
+            }
+        )
+
+    if not duplicates:
+        return
+
+    # Build combined message
+    duplicate_links = []
+    for dup in duplicates:
+        party_link = get_link_to_form(party_type, dup["name"])
+        if dup["via_address"]:
+            address_link = get_link_to_form("Address", dup["address"])
+            duplicate_links.append(
+                f"<li>{party_link} (via Address: {address_link})</li>"
+            )
+        else:
+            duplicate_links.append(f"<li>{party_link}</li>")
+
+    msg = _(
+        "{0} {1} is already registered with the following {2}(s):<br><br>"
+        "<ul>{3}</ul><br>"
+    ).format(
+        "GSTIN",
+        frappe.bold(gstin),
+        party_type,
+        "".join(duplicate_links),
+    )
+
+    frappe.msgprint(msg=msg, indicator="orange")

--- a/india_compliance/gst_india/utils/__init__.py
+++ b/india_compliance/gst_india/utils/__init__.py
@@ -1134,95 +1134,67 @@ def has_permission_of_page(page_name, throw=False):
     return True
 
 
-def _show_duplicate_alert(field_label, value, party_type, duplicate_links):
+@frappe.whitelist()
+def check_duplicate_party(field, value, party_type, party=None):
+    """
+    Check duplicates based on PAN/GSTIN for the given party type.
+    """
+    if not value:
+        return
+
+    if party_type not in GST_PARTY_TYPES:
+        return
+
+    frappe.has_permission(party_type, doc=party, throw=True)
+
+    value = value.upper().strip()
+
+    # Check for duplicates
+    if field == "pan":
+        existing_parties = _get_duplicate_pan_party(value, party_type, party)
+    elif field == "gstin":
+        existing_parties = _get_duplicate_gstin_party(value, party_type, party)
+    else:
+        return
+
+    if not existing_parties:
+        return
+
+    # Show message
+    duplicate_links = []
+    for row in existing_parties:
+        party_link = get_link_to_form(party_type, row["name"])
+        if row["via_address"]:
+            address_link = get_link_to_form("Address", row["address"])
+            link_msg = _("{0} (via Address {1})").format(party_link, address_link)
+
+        else:
+            link_msg = party_link
+
+        duplicate_links.append(f"<li>{link_msg}</li>")
+
     msg = _("{0} {1} is already registered with the following {2}(s):").format(
-        field_label,
-        frappe.bold(value),
-        party_type,
+        field.capitalize(), frappe.bold(value), party_type
     )
     msg += f"<br><br><ul>{''.join(duplicate_links)}</ul>"
 
     frappe.msgprint(msg=msg, indicator="orange")
 
 
-def validate_party_type(party_type, party):
-    if party_type not in GST_PARTY_TYPES:
-        return
-
-    frappe.has_permission(party_type, doc=party, throw=True)
-    return True
-
-
-@frappe.whitelist()
-def check_duplicate_pan(pan, party_type, party=None):
-    if not pan:
-        return
-
-    if not validate_party_type(party_type, party):
-        return
-
-    pan = pan.upper().strip()
-
-    existing_parties = _get_duplicate_pan_party(pan, party_type, party)
-    if not existing_parties:
-        return
-
-    duplicate_links = [
-        f"<li>{get_link_to_form(party_type, name)}</li>" for name in existing_parties
-    ]
-
-    _show_duplicate_alert("PAN", pan, party_type, duplicate_links)
-
-
 def _get_duplicate_pan_party(pan, party_type, party=None):
-    """
-    Check if PAN already exists for another party of the same doctype.
-    """
     filters = {"pan": ("=", pan)}
     if party:
         filters["name"] = ("!=", party)
 
-    return frappe.get_all(
-        party_type,
-        filters=filters,
-        pluck="name",
-    )
+    return frappe.get_all(party_type, filters=filters)
 
 
-@frappe.whitelist()
-def check_duplicate_gstin(gstin, party_type, party=None, address_name=None):
-    if not gstin:
-        return
-
-    if not validate_party_type(party_type, party):
-        return
-
-    gstin = gstin.upper().strip()
-
-    duplicates = _get_duplicate_gstin_party(gstin, party_type, party, address_name)
-    if not duplicates:
-        return
-
-    duplicate_links = []
-    for row in duplicates:
-        party_link = get_link_to_form(party_type, row["name"])
-        if row["via_address"]:
-            address_link = get_link_to_form("Address", row["address"])
-            link_msg = _("{0} (via Address {1})").format(party_link, address_link)
-        else:
-            link_msg = party_link
-
-        duplicate_links.append(f"<li>{link_msg}</li>")
-
-    _show_duplicate_alert("GSTIN", gstin, party_type, duplicate_links)
-
-
-def _get_duplicate_gstin_party(gstin, party_type, party=None, address_name=None):
+def _get_duplicate_gstin_party(gstin, party_type, party=None):
     party_table = frappe.qb.DocType(party_type)
     address = frappe.qb.DocType("Address")
     dynamic_link = frappe.qb.DocType("Dynamic Link")
 
-    query = (
+    party_query = (
         frappe.qb.from_(party_table)
         .select(
             party_table.name,
@@ -1233,7 +1205,7 @@ def _get_duplicate_gstin_party(gstin, party_type, party=None, address_name=None)
     )
 
     if party:
-        query = query.where(party_table.name != party)
+        party_query = party_query.where(party_table.name != party)
 
     address_query = (
         frappe.qb.from_(address)
@@ -1251,25 +1223,17 @@ def _get_duplicate_gstin_party(gstin, party_type, party=None, address_name=None)
     if party:
         address_query = address_query.where(dynamic_link.link_name != party)
 
-    if address_name:
-        address_query = address_query.where(address.name != address_name)
-
-    results = (query + address_query).run(as_dict=True)
+    results = (party_query + address_query).orderby("via_address").run(as_dict=True)
 
     duplicates_dict = {}
     for row in results:
         if row.name in duplicates_dict:
-            if not row.via_address:
-                duplicates_dict[row.name] = {
-                    "name": row.name,
-                    "via_address": False,
-                    "address": None,
-                }
-        else:
-            duplicates_dict[row.name] = {
-                "name": row.name,
-                "via_address": bool(row.via_address),
-                "address": row.address_name,
-            }
+            continue
+
+        duplicates_dict[row.name] = {
+            "name": row.name,
+            "via_address": bool(row.via_address),
+            "address": row.address_name,
+        }
 
     return list(duplicates_dict.values())

--- a/india_compliance/gst_india/utils/__init__.py
+++ b/india_compliance/gst_india/utils/__init__.py
@@ -1154,7 +1154,7 @@ def validate_party_type(party_type, party):
 
 
 @frappe.whitelist()
-def check_duplicate_pan(pan, party_type, party):
+def check_duplicate_pan(pan, party_type, party=None):
     if not pan:
         return
 
@@ -1174,19 +1174,23 @@ def check_duplicate_pan(pan, party_type, party):
     _show_duplicate_alert("PAN", pan, party_type, duplicate_links)
 
 
-def _get_duplicate_pan_party(pan, party_type, party):
+def _get_duplicate_pan_party(pan, party_type, party=None):
     """
     Check if PAN already exists for another party of the same doctype.
     """
+    filters = {"pan": ("=", pan)}
+    if party:
+        filters["name"] = ("!=", party)
+
     return frappe.get_all(
         party_type,
-        filters={"pan": ("=", pan), "name": ("!=", party)},
+        filters=filters,
         pluck="name",
     )
 
 
 @frappe.whitelist()
-def check_duplicate_gstin(gstin, party_type, party, address_name=None):
+def check_duplicate_gstin(gstin, party_type, party=None, address_name=None):
     if not gstin:
         return
 
@@ -1213,10 +1217,14 @@ def check_duplicate_gstin(gstin, party_type, party, address_name=None):
     _show_duplicate_alert("GSTIN", gstin, party_type, duplicate_links)
 
 
-def _get_duplicate_gstin_party(gstin, party_type, party, address_name=None):
+def _get_duplicate_gstin_party(gstin, party_type, party=None, address_name=None):
+    party_filters = {"gstin": ("=", gstin)}
+    if party:
+        party_filters["name"] = ("!=", party)
+
     parties_with_gstin = frappe.get_all(
         party_type,
-        filters={"gstin": ("=", gstin), "name": ("!=", party)},
+        filters=party_filters,
         pluck="name",
     )
 
@@ -1231,8 +1239,10 @@ def _get_duplicate_gstin_party(gstin, party_type, party, address_name=None):
         .select(dynamic_link.link_name, address.name.as_("address_name"))
         .where(dynamic_link.link_doctype == party_type)
         .where(address.gstin == gstin)
-        .where(dynamic_link.link_name != party)
     )
+
+    if party:
+        query = query.where(dynamic_link.link_name != party)
 
     if address_name:
         query = query.where(address.name != address_name)

--- a/india_compliance/public/js/quick_entry.js
+++ b/india_compliance/public/js/quick_entry.js
@@ -97,6 +97,8 @@ class GSTQuickEntryForm extends frappe.ui.form.QuickEntryForm {
                 onchange: () => {
                     const d = this.dialog;
 
+                    check_duplicate_gstin(d, this.doctype);
+
                     if (["Customer", "Supplier"].includes(this.doctype)) {
                         d.set_value(
                             `${this.doctype.toLowerCase()}_type`,
@@ -169,21 +171,21 @@ class PartyQuickEntryForm extends GSTQuickEntryForm {
                 collapsible: 0,
             },
             {
-				label: __("First Name"),
-				fieldname: "map_to_first_name",
-				fieldtype: "Data",
-				depends_on: "eval:doc.customer_type=='Company' || doc.supplier_type=='Company'",
-			},
-             {
+                label: __("First Name"),
+                fieldname: "map_to_first_name",
+                fieldtype: "Data",
+                depends_on: "eval:doc.customer_type=='Company' || doc.supplier_type=='Company'",
+            },
+            {
                 fieldtype: "Column Break",
             },
-			{
-				label: __("Last Name"),
-				fieldname: "map_to_last_name",
-				fieldtype: "Data",
-				depends_on: "eval:doc.customer_type=='Company' || doc.supplier_type=='Company'",
-			},
-             {
+            {
+                label: __("Last Name"),
+                fieldname: "map_to_last_name",
+                fieldtype: "Data",
+                depends_on: "eval:doc.customer_type=='Company' || doc.supplier_type=='Company'",
+            },
+            {
                 fieldname: "primary_contact_section_2",
                 fieldtype: "Section Break",
                 collapsible: 0,
@@ -492,4 +494,31 @@ function get_gstin_description() {
     }
 
     return __("Autofill is not supported in sandbox mode");
+}
+
+
+function check_duplicate_gstin(dialog, doctype) {
+    let gstin = dialog.doc._gstin;
+
+    if (!gstin || gstin.length < 15) return;
+
+    let party_type = doctype;
+    let party_name = null;
+
+    if (doctype === "Address") {
+        party_type = dialog.doc.link_doctype;
+        party_name = dialog.doc.link_name;
+    }
+
+    if (!party_type) return;
+    if (!frappe.boot.gst_party_types.includes(party_type)) return;
+
+    frappe.call({
+        method: "india_compliance.gst_india.utils.check_duplicate_gstin",
+        args: {
+            gstin: gstin,
+            party_type: party_type,
+            party: party_name,
+        },
+    });
 }

--- a/india_compliance/public/js/quick_entry.js
+++ b/india_compliance/public/js/quick_entry.js
@@ -97,11 +97,7 @@ class GSTQuickEntryForm extends frappe.ui.form.QuickEntryForm {
                 onchange: () => {
                     const d = this.dialog;
 
-                    if (this.doctype !== "Address")
-                        india_compliance.check_duplicate_gstin(
-                            d.doc._gstin,
-                            this.doctype,
-                        );
+                    india_compliance.check_duplicate_gstin(d.doc._gstin, this.doctype);
 
                     if (["Customer", "Supplier"].includes(this.doctype)) {
                         d.set_value(

--- a/india_compliance/public/js/quick_entry.js
+++ b/india_compliance/public/js/quick_entry.js
@@ -97,7 +97,11 @@ class GSTQuickEntryForm extends frappe.ui.form.QuickEntryForm {
                 onchange: () => {
                     const d = this.dialog;
 
-                    check_duplicate_gstin(d, this.doctype);
+                    if (this.doctype !== "Address")
+                        india_compliance.check_duplicate_gstin(
+                            d.doc._gstin,
+                            this.doctype,
+                        );
 
                     if (["Customer", "Supplier"].includes(this.doctype)) {
                         d.set_value(
@@ -112,7 +116,10 @@ class GSTQuickEntryForm extends frappe.ui.form.QuickEntryForm {
 
                     d.set_value(
                         "gst_category",
-                        india_compliance.guess_gst_category(d.doc._gstin, d.doc.country)
+                        india_compliance.guess_gst_category(
+                            d.doc._gstin,
+                            d.doc.country,
+                        ),
                     );
                 },
             },
@@ -497,30 +504,4 @@ function get_gstin_description() {
     }
 
     return __("Autofill is not supported in sandbox mode");
-}
-
-function check_duplicate_gstin(dialog, doctype) {
-    let gstin = dialog.doc._gstin;
-
-    if (!gstin || gstin.length < 15) return;
-
-    let party_type = doctype;
-    let party_name = null;
-
-    if (doctype === "Address") {
-        party_type = dialog.doc.link_doctype;
-        party_name = dialog.doc.link_name;
-    }
-
-    if (!party_type) return;
-    if (!frappe.boot.gst_party_types.includes(party_type)) return;
-
-    frappe.call({
-        method: "india_compliance.gst_india.utils.check_duplicate_gstin",
-        args: {
-            gstin: gstin,
-            party_type: party_type,
-            party: party_name,
-        },
-    });
 }

--- a/india_compliance/public/js/quick_entry.js
+++ b/india_compliance/public/js/quick_entry.js
@@ -28,11 +28,11 @@ class GSTQuickEntryForm extends frappe.ui.form.QuickEntryForm {
                 fieldtype: "Section Break",
                 description: this.api_enabled
                     ? __(
-                        `When you enter a GSTIN, the permanent address linked to it is
+                          `When you enter a GSTIN, the permanent address linked to it is
                         autofilled.<br>
                         Change the {0} to autofill other addresses.`,
-                        [frappe.meta.get_label("Address", "pincode")]
-                    )
+                          [frappe.meta.get_label("Address", "pincode")]
+                      )
                     : "",
                 collapsible: 0,
             },
@@ -102,7 +102,8 @@ class GSTQuickEntryForm extends frappe.ui.form.QuickEntryForm {
                     if (["Customer", "Supplier"].includes(this.doctype)) {
                         d.set_value(
                             `${this.doctype.toLowerCase()}_type`,
-                            this.gstin_to_party_type_map[d.doc._gstin[5]] || "Individual"
+                            this.gstin_to_party_type_map[d.doc._gstin[5]] ||
+                                "Individual"
                         );
                     }
 
@@ -174,7 +175,8 @@ class PartyQuickEntryForm extends GSTQuickEntryForm {
                 label: __("First Name"),
                 fieldname: "map_to_first_name",
                 fieldtype: "Data",
-                depends_on: "eval:doc.customer_type=='Company' || doc.supplier_type=='Company'",
+                depends_on:
+                    "eval:doc.customer_type=='Company' || doc.supplier_type=='Company'",
             },
             {
                 fieldtype: "Column Break",
@@ -183,7 +185,8 @@ class PartyQuickEntryForm extends GSTQuickEntryForm {
                 label: __("Last Name"),
                 fieldname: "map_to_last_name",
                 fieldtype: "Data",
-                depends_on: "eval:doc.customer_type=='Company' || doc.supplier_type=='Company'",
+                depends_on:
+                    "eval:doc.customer_type=='Company' || doc.supplier_type=='Company'",
             },
             {
                 fieldname: "primary_contact_section_2",
@@ -345,7 +348,7 @@ class AddressQuickEntryForm extends GSTQuickEntryForm {
                 "Customer",
                 "Supplier",
                 "Company",
-                "Lead"
+                "Lead",
             ].includes(doc.doctype)
         )
             return;
@@ -495,7 +498,6 @@ function get_gstin_description() {
 
     return __("Autofill is not supported in sandbox mode");
 }
-
 
 function check_duplicate_gstin(dialog, doctype) {
     let gstin = dialog.doc._gstin;

--- a/india_compliance/public/js/utils.js
+++ b/india_compliance/public/js/utils.js
@@ -70,6 +70,26 @@ Object.assign(india_compliance, {
         return `${month}${year}`;
     },
 
+    check_duplicate_gstin(gstin, party_type, party = null) {
+        if (!gstin || gstin.length !== 15) return;
+        this.check_duplicate_party("gstin", gstin, party_type, party);
+    },
+
+    check_duplicate_pan(pan, party_type, party = null) {
+        if (!pan || pan.length !== 10) return;
+        this.check_duplicate_party("pan", pan, party_type, party);
+    },
+
+    check_duplicate_party(field, value, party_type, party = null) {
+        if (!party_type) return;
+        if (!frappe.boot.gst_party_types.includes(party_type)) return;
+
+        frappe.call({
+            method: "india_compliance.gst_india.utils.check_duplicate_party",
+            args: { field, value, party_type, party },
+        });
+    },
+
     get_gstin_query(party, party_type = "Company", exclude_isd = false) {
         if (!party) {
             frappe.show_alert({


### PR DESCRIPTION
closes: https://github.com/resilient-tech/india-compliance/issues/3781

<img width="603" height="251" alt="image" src="https://github.com/user-attachments/assets/9396f89d-5f82-4a76-a2d3-1f1fa13f94c4" />

<img width="577" height="212" alt="image" src="https://github.com/user-attachments/assets/59d2fe7b-59cf-432b-8ad2-9d6bbfc9de0f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Duplicate-detection for GSTIN and PAN across parties and linked addresses; surfaces orange alerts when potential conflicts are found.
  * Duplicate checks trigger automatically after GSTIN/PAN entry and during quick-entry flows for faster review.
  * Alerts include contextual, highlighted links to matching records (including via-address matches) to aid resolution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->