### PR TITLE
fix: do not execute patch if 'is_reverse_charge_account' field does not exists

### DIFF
--- a/india_compliance/patches/post_install/update_gst_accounts.py
+++ b/india_compliance/patches/post_install/update_gst_accounts.py
@@ -4,6 +4,9 @@ import frappe
 
 
 def execute():
+    if not frappe.db.has_column("GST Account", "is_reverse_charge_account"):
+        return
+
     gst_accounts = frappe.get_all(
         "GST Account",
         filters={"parent": "GST Settings", "account_type": ("is", "not set")},


### PR DESCRIPTION
closes: https://github.com/resilient-tech/india-compliance/issues/3825

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability during setup by skipping GST account processing when a required account field is missing, preventing unexpected failures and ensuring smoother post-install/upgrade behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->