### PR TITLE
fix: store IP address in credentials

### DIFF
--- a/india_compliance/gst_india/api_classes/base.py
+++ b/india_compliance/gst_india/api_classes/base.py
@@ -96,6 +96,7 @@ class BaseAPI:
         self.session_key = b64decode(row.session_key or "")
         self.session_expiry = row.session_expiry
         self.auth_token = row.auth_token
+        self.ip_address = row.ip_address
 
     def get_url(self, *parts):
         parts = list(parts)

--- a/india_compliance/gst_india/api_classes/base.py
+++ b/india_compliance/gst_india/api_classes/base.py
@@ -96,7 +96,7 @@ class BaseAPI:
         self.session_key = b64decode(row.session_key or "")
         self.session_expiry = row.session_expiry
         self.auth_token = row.auth_token
-        self.ip_address = row.ip_address
+        self.session_ip = row.session_ip
 
     def get_url(self, *parts):
         parts = list(parts)

--- a/india_compliance/gst_india/api_classes/nic/test_auth.py
+++ b/india_compliance/gst_india/api_classes/nic/test_auth.py
@@ -369,6 +369,142 @@ class TestStandardAuth(TestNICAuth):
         result = auth.process_response(response)
         self.assertEqual(result, original_response)
 
+    def test_ip_usr_header_included_when_session_ip_set(self):
+        """Test that ip-usr header is included when session_ip is set"""
+        from india_compliance.gst_india.api_classes.taxpayer_base import TaxpayerBaseAPI
+
+        # Prevent automatic setup in __init__
+        with patch(
+            "india_compliance.gst_india.api_classes.base.BaseAPI.__init__",
+            return_value=None,
+        ):
+            api = TaxpayerBaseAPI()
+
+            # Set required attributes manually
+            api.company_gstin = "24AAQCA8719H1ZC"
+            api.username = "test_user"
+            api.session_ip = "192.168.1.100"
+            api.sandbox_mode = False
+            api.default_headers = {}
+
+            # Test setup method with mocked credential fetch
+            with patch.object(api, "fetch_credentials"):
+                api.setup("24AAQCA8719H1ZC")
+
+            # Verify ip-usr header is set correctly
+            self.assertEqual(api.default_headers["ip-usr"], "192.168.1.100")
+
+    @responses.activate
+    def test_returns_api_ip_fetch_with_auth_token(self):
+        """Test that Returns API fetches IP during auth token generation"""
+        from india_compliance.exceptions import OTPRequestedError
+        from india_compliance.gst_india.api_classes.taxpayer_base import (
+            TaxpayerAuthenticate,
+        )
+
+        # Mock HTTP endpoints only
+        responses.add(
+            responses.GET,
+            f"{BASE_URL}/get-public-ip",
+            json={"ip": "203.0.113.1"},
+            status=200,
+        )
+
+        responses.add(
+            responses.POST,
+            f"{BASE_URL}/authenticate",
+            json={"status_cd": 1, "message": "OTP sent successfully"},
+            status=200,
+        )
+
+        # Prevent automatic setup in __init__
+        with patch(
+            "india_compliance.gst_india.api_classes.base.BaseAPI.__init__",
+            return_value=None,
+        ):
+            api = TaxpayerAuthenticate()
+
+            # Set required attributes directly
+            api.company_gstin = "24AAQCA8719H1ZC"
+            api.username = "test_user"
+            api.app_key = "12345678901234567890123456789012"
+            api.default_headers = {}
+
+            # Test auth reset with minimal mocking
+            with patch("frappe.db.set_value") as mock_db_set:
+                with patch.object(api, "get_public_ip", return_value="203.0.113.1"):
+                    with patch.object(
+                        api, "request_otp", side_effect=OTPRequestedError()
+                    ):
+                        try:
+                            api.autheticate_with_otp(otp=None)
+                        except OTPRequestedError:
+                            pass  # Expected behavior
+
+                        # Verify database call and IP setting
+                        mock_db_set.assert_called_once_with(
+                            "GST Credential",
+                            {
+                                "gstin": "24AAQCA8719H1ZC",
+                                "username": "test_user",
+                                "service": "Returns",
+                            },
+                            {"auth_token": None, "session_ip": "203.0.113.1"},
+                        )
+                        self.assertEqual(api.session_ip, "203.0.113.1")
+
+    @responses.activate
+    def test_authenticate_with_otp_includes_ip_usr_header(self):
+        """Test that authenticate_with_otp includes ip-usr header in API calls"""
+        from india_compliance.gst_india.api_classes.taxpayer_base import (
+            TaxpayerAuthenticate,
+        )
+
+        # Mock HTTP endpoint
+        responses.add(
+            responses.POST,
+            f"{BASE_URL}/authenticate",
+            json={
+                "status_cd": 1,
+                "auth_token": "test_token",
+                "sek": "test_sek",
+                "expiry": "360",
+            },
+            status=200,
+        )
+
+        # Prevent automatic setup in __init__
+        with patch(
+            "india_compliance.gst_india.api_classes.base.BaseAPI.__init__",
+            return_value=None,
+        ):
+            api = TaxpayerAuthenticate()
+
+            # Set required attributes
+            api.company_gstin = "24AAQCA8719H1ZC"
+            api.username = "test_user"
+            api.app_key = "12345678901234567890123456789012"
+            api.sandbox_mode = False
+            api.base_url = BASE_URL
+            api.default_headers = {"ip-usr": "192.168.1.100"}
+            api.default_log_values = {}
+            api.base_path = ""
+
+            # Mock encryption and database operations
+            with patch.object(api, "encrypt_request"):
+                with patch("frappe.db.set_value"):
+                    with patch("frappe.cache.set_value"):
+                        # Call authenticate with OTP
+                        api.autheticate_with_otp(otp="123456")
+
+                        # Verify the request was made with ip-usr header
+                        self.assertEqual(len(responses.calls), 1)
+                        request_headers = responses.calls[0].request.headers
+
+                        # Check that ip-usr header was included in the request
+                        self.assertIn("ip-usr", request_headers)
+                        self.assertEqual(request_headers["ip-usr"], "192.168.1.100")
+
 
 class TestEWaybillAuth(TestNICAuth):
     @classmethod
@@ -455,6 +591,7 @@ class TestEWaybillAuth(TestNICAuth):
         # Test the full cycle
         # Initialize e-Waybill API (this will trigger auth)
         self._mock_get_nic_public_key()
+        self._mock_asp_get_public_ip()
         self._mock_ewaybill_auth_response(auth_response)
 
         api = StandardEWaybillAPI(si)
@@ -523,6 +660,15 @@ class TestEWaybillAuth(TestNICAuth):
             responses.GET,
             f"{BASE_URL}/static/nic_public_key",
             json={"message": self.test_data.public_key},
+            status=200,
+        )
+
+    def _mock_asp_get_public_ip(self):
+        """Mock ASP endpoint for fetching public IP address"""
+        responses.add(
+            responses.GET,
+            "https://asp.resilient.tech/get-public-ip",
+            json={"ip": "203.0.113.1"},
             status=200,
         )
 
@@ -656,6 +802,7 @@ class TestEInvoiceAuth(TestNICAuth):
 
         # Initialize e-Invoice API (this will trigger auth)
         self._mock_get_nic_public_key()
+        self._mock_asp_get_public_ip()
         self._mock_einvoice_auth_response(auth_response)
 
         api = StandardEInvoiceAPI(si)

--- a/india_compliance/gst_india/api_classes/nic/test_auth.py
+++ b/india_compliance/gst_india/api_classes/nic/test_auth.py
@@ -591,7 +591,6 @@ class TestEWaybillAuth(TestNICAuth):
         # Test the full cycle
         # Initialize e-Waybill API (this will trigger auth)
         self._mock_get_nic_public_key()
-        self._mock_asp_get_public_ip()
         self._mock_ewaybill_auth_response(auth_response)
 
         api = StandardEWaybillAPI(si)
@@ -660,15 +659,6 @@ class TestEWaybillAuth(TestNICAuth):
             responses.GET,
             f"{BASE_URL}/static/nic_public_key",
             json={"message": self.test_data.public_key},
-            status=200,
-        )
-
-    def _mock_asp_get_public_ip(self):
-        """Mock ASP endpoint for fetching public IP address"""
-        responses.add(
-            responses.GET,
-            "https://asp.resilient.tech/get-public-ip",
-            json={"ip": "203.0.113.1"},
             status=200,
         )
 
@@ -802,7 +792,6 @@ class TestEInvoiceAuth(TestNICAuth):
 
         # Initialize e-Invoice API (this will trigger auth)
         self._mock_get_nic_public_key()
-        self._mock_asp_get_public_ip()
         self._mock_einvoice_auth_response(auth_response)
 
         api = StandardEInvoiceAPI(si)

--- a/india_compliance/gst_india/api_classes/taxpayer_base.py
+++ b/india_compliance/gst_india/api_classes/taxpayer_base.py
@@ -15,7 +15,7 @@ from india_compliance.exceptions import (
     InvalidOTPError,
     OTPRequestedError,
 )
-from india_compliance.gst_india.api_classes.base import BaseAPI
+from india_compliance.gst_india.api_classes.base import BaseAPI, change_base_path
 from india_compliance.gst_india.utils import merge_dicts, tar_gz_bytes_to_data
 from india_compliance.gst_india.utils.cryptography import (
     aes_decrypt_data,
@@ -69,7 +69,7 @@ class StaticResourcesAPI(BaseAPI):
 
 
 class FilesAPI(BaseAPI):
-    BASE_PATH = "standard/gstn/files"
+    BASE_PATH = "standard/gstn_/files"
 
     def get_all(self, url_details):
         response = frappe._dict()
@@ -155,10 +155,11 @@ class TaxpayerAuthenticate(BaseAPI):
                     "username": self.username,
                     "service": "Returns",
                 },
-                {"auth_token": None},
+                {"auth_token": None, "ip_address": None},
             )
 
             self.auth_token = None
+            self.ip_address = self.get_public_ip()
             return self.request_otp()
 
         response = super().post(
@@ -290,19 +291,43 @@ class TaxpayerAuthenticate(BaseAPI):
                 "username": self.username,
                 "service": "Returns",
             },
-            {"auth_token": None},
+            {"auth_token": None, "ip_address": None},
         )
 
         if not frappe.flags.in_test:
             frappe.db.commit()  # nosemgrep - executed in after enqueue
 
+    @change_base_path("")
+    def get_public_ip(self):
+        """
+        Fetch current public IP address from ASP endpoint
+        """
+        response = super().get(endpoint="get-public-ip")
+
+        ip_address = response.get("ip")
+
+        if not ip_address:
+            frappe.throw(_("Could not fetch Public IP address."))
+
+        frappe.db.set_value(
+            "GST Credential",
+            {
+                "gstin": self.company_gstin,
+                "username": self.username,
+                "service": "Returns",
+            },
+            {"ip_address": ip_address},
+        )
+        return ip_address
+
 
 class TaxpayerBaseAPI(TaxpayerAuthenticate):
-    BASE_PATH = "standard/gstn"
+    BASE_PATH = "standard/gstn_"
 
     IGNORED_ERROR_CODES = {
         **TaxpayerAuthenticate.IGNORED_ERROR_CODES,
         "RT-R1R3BAV-1007": "authorization_failed",  # Either auth-token or username is invalid. Raised in get_filing_preference
+        "RT-R1R3BAV-1013": "authorization_failed",  # "Invalid ip-usr." Change in request IP
     }
 
     def setup(self, company_gstin):
@@ -311,12 +336,16 @@ class TaxpayerBaseAPI(TaxpayerAuthenticate):
 
         self.company_gstin = company_gstin
         self.fetch_credentials(self.company_gstin, "Returns", require_password=False)
+        if not self.ip_address:
+            self.ip_address = self.get_public_ip()
+
         self.default_headers.update(
             {
                 "gstin": self.company_gstin,
                 "state-cd": self.company_gstin[:2],
                 "username": self.username,
                 "txn": self.generate_request_id(length=32),
+                "ip-usr": self.ip_address,
             }
         )
 

--- a/india_compliance/gst_india/api_classes/taxpayer_base.py
+++ b/india_compliance/gst_india/api_classes/taxpayer_base.py
@@ -336,8 +336,6 @@ class TaxpayerBaseAPI(TaxpayerAuthenticate):
 
         self.company_gstin = company_gstin
         self.fetch_credentials(self.company_gstin, "Returns", require_password=False)
-        if not self.session_ip:
-            self.session_ip = self.get_public_ip()
 
         self.default_headers.update(
             {

--- a/india_compliance/gst_india/api_classes/taxpayer_base.py
+++ b/india_compliance/gst_india/api_classes/taxpayer_base.py
@@ -147,7 +147,8 @@ class TaxpayerAuthenticate(BaseAPI):
                 frappe.local.job.after_job.add(self.reset_auth_token)
                 raise InvalidAuthTokenError
 
-            # reset auth token
+            session_ip = self.get_public_ip()
+
             frappe.db.set_value(
                 "GST Credential",
                 {
@@ -155,11 +156,15 @@ class TaxpayerAuthenticate(BaseAPI):
                     "username": self.username,
                     "service": "Returns",
                 },
-                {"auth_token": None, "session_ip": None},
+                {"auth_token": None, "session_ip": session_ip},
             )
+            frappe.clear_document_cache("GST Settings")
 
             self.auth_token = None
-            self.session_ip = self.get_public_ip()
+            self.session_ip = session_ip
+
+            self.default_headers["ip-usr"] = self.session_ip
+
             return self.request_otp()
 
         response = super().post(
@@ -309,15 +314,6 @@ class TaxpayerAuthenticate(BaseAPI):
         if not session_ip:
             frappe.throw(_("Could not fetch Public IP address."))
 
-        frappe.db.set_value(
-            "GST Credential",
-            {
-                "gstin": self.company_gstin,
-                "username": self.username,
-                "service": "Returns",
-            },
-            {"session_ip": session_ip},
-        )
         return session_ip
 
 

--- a/india_compliance/gst_india/api_classes/taxpayer_base.py
+++ b/india_compliance/gst_india/api_classes/taxpayer_base.py
@@ -155,11 +155,11 @@ class TaxpayerAuthenticate(BaseAPI):
                     "username": self.username,
                     "service": "Returns",
                 },
-                {"auth_token": None, "ip_address": None},
+                {"auth_token": None, "session_ip": None},
             )
 
             self.auth_token = None
-            self.ip_address = self.get_public_ip()
+            self.session_ip = self.get_public_ip()
             return self.request_otp()
 
         response = super().post(
@@ -291,7 +291,7 @@ class TaxpayerAuthenticate(BaseAPI):
                 "username": self.username,
                 "service": "Returns",
             },
-            {"auth_token": None, "ip_address": None},
+            {"auth_token": None, "session_ip": None},
         )
 
         if not frappe.flags.in_test:
@@ -304,9 +304,9 @@ class TaxpayerAuthenticate(BaseAPI):
         """
         response = super().get(endpoint="get-public-ip")
 
-        ip_address = response.get("ip")
+        session_ip = response.get("ip")
 
-        if not ip_address:
+        if not session_ip:
             frappe.throw(_("Could not fetch Public IP address."))
 
         frappe.db.set_value(
@@ -316,9 +316,9 @@ class TaxpayerAuthenticate(BaseAPI):
                 "username": self.username,
                 "service": "Returns",
             },
-            {"ip_address": ip_address},
+            {"session_ip": session_ip},
         )
-        return ip_address
+        return session_ip
 
 
 class TaxpayerBaseAPI(TaxpayerAuthenticate):
@@ -336,8 +336,8 @@ class TaxpayerBaseAPI(TaxpayerAuthenticate):
 
         self.company_gstin = company_gstin
         self.fetch_credentials(self.company_gstin, "Returns", require_password=False)
-        if not self.ip_address:
-            self.ip_address = self.get_public_ip()
+        if not self.session_ip:
+            self.session_ip = self.get_public_ip()
 
         self.default_headers.update(
             {
@@ -345,7 +345,7 @@ class TaxpayerBaseAPI(TaxpayerAuthenticate):
                 "state-cd": self.company_gstin[:2],
                 "username": self.username,
                 "txn": self.generate_request_id(length=32),
-                "ip-usr": self.ip_address,
+                "ip-usr": self.session_ip,
             }
         )
 

--- a/india_compliance/gst_india/api_classes/taxpayer_base.py
+++ b/india_compliance/gst_india/api_classes/taxpayer_base.py
@@ -327,7 +327,7 @@ class TaxpayerBaseAPI(TaxpayerAuthenticate):
     IGNORED_ERROR_CODES = {
         **TaxpayerAuthenticate.IGNORED_ERROR_CODES,
         "RT-R1R3BAV-1007": "authorization_failed",  # Either auth-token or username is invalid. Raised in get_filing_preference
-        "RT-R1R3BAV-1013": "authorization_failed",  # "Invalid ip-usr." Change in request IP
+        # "RT-R1R3BAV-1013": "authorization_failed",  # "Invalid ip-usr." Change in request IP
     }
 
     def setup(self, company_gstin):

--- a/india_compliance/gst_india/doctype/gst_credential/gst_credential.json
+++ b/india_compliance/gst_india/doctype/gst_credential/gst_credential.json
@@ -14,7 +14,8 @@
   "app_key",
   "session_key",
   "auth_token",
-  "session_expiry"
+  "session_expiry",
+  "ip_address"
  ],
  "fields": [
   {
@@ -81,17 +82,25 @@
    "hidden": 1,
    "label": "Session Expiry Date",
    "read_only": 1
+  },
+  {
+   "fieldname": "ip_address",
+   "fieldtype": "Data",
+   "hidden": 1,
+   "label": "IP Address",
+   "read_only": 1
   }
  ],
  "istable": 1,
  "links": [],
- "modified": "2024-03-29 11:54:42.495483",
+ "modified": "2025-12-10 12:17:33.705751",
  "modified_by": "Administrator",
  "module": "GST India",
  "name": "GST Credential",
  "naming_rule": "Random",
  "owner": "Administrator",
  "permissions": [],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": []

--- a/india_compliance/gst_india/doctype/gst_credential/gst_credential.json
+++ b/india_compliance/gst_india/doctype/gst_credential/gst_credential.json
@@ -15,7 +15,7 @@
   "session_key",
   "auth_token",
   "session_expiry",
-  "ip_address"
+  "session_ip"
  ],
  "fields": [
   {
@@ -84,10 +84,10 @@
    "read_only": 1
   },
   {
-   "fieldname": "ip_address",
+   "fieldname": "session_ip",
    "fieldtype": "Data",
    "hidden": 1,
-   "label": "IP Address",
+   "label": "Session IP",
    "read_only": 1
   }
  ],

--- a/india_compliance/patches.txt
+++ b/india_compliance/patches.txt
@@ -77,3 +77,4 @@ india_compliance.patches.v14.set_pending_boe_qty #1
 india_compliance.patches.v15.remove_itc_amount_custom_fields
 india_compliance.patches.v14.update_tax_withholding_categories
 india_compliance.patches.v16.remove_legacy_report_fixtures
+india_compliance.patches.v15.unset_auth_token

--- a/india_compliance/patches/v15/unset_auth_token.py
+++ b/india_compliance/patches/v15/unset_auth_token.py
@@ -1,0 +1,5 @@
+import frappe
+
+
+def execute():
+    frappe.db.set_value("GST Credential", {"service": "Returns"}, "auth_token", None)


### PR DESCRIPTION
Issue: If authentication is made from a different IP and request is made from different error is raised.
```
{
    "error": {
        "error_cd": "RT-R1R3BAV-1013",
        "message": "Invalid ip-usr."
    },
    "status_cd": 0
}
```
- Store IP Address in credentials.
- New endpoint which accepts `ip-usr`.


Frappe Support Issue: https://support.frappe.io/desk/hd-ticket/55004 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic public IP capture and storage during GST authentication; session IP surfaced in credential records
  * Public IP included in OTP flows and added to request headers

* **Bug Fixes / Reliability**
  * Improved handling for IP-related authorization scenarios

* **Data / Chores**
  * Added a migration to clear stored auth tokens for the Returns service and updated patch listing

* **Tests**
  * Added tests and mocks to verify public-IP capture and header behavior during auth flows

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->