### PR TITLE
fix: strip whitespace from gst_hsn_code

### DIFF
--- a/india_compliance/gst_india/overrides/item.py
+++ b/india_compliance/gst_india/overrides/item.py
@@ -23,7 +23,6 @@ def update_hsn_code(doc):
 
 
 def validate_hsn_code(doc):
-    doc.gst_hsn_code = (doc.gst_hsn_code or "").replace(" ", "")
     # HSN Code is being validated only for sales items
     if not doc.is_sales_item:
         return

--- a/india_compliance/gst_india/overrides/item.py
+++ b/india_compliance/gst_india/overrides/item.py
@@ -23,6 +23,7 @@ def update_hsn_code(doc):
 
 
 def validate_hsn_code(doc):
+    doc.gst_hsn_code = (doc.gst_hsn_code or "").replace(" ", "")
     # HSN Code is being validated only for sales items
     if not doc.is_sales_item:
         return

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -692,6 +692,8 @@ def _validate_hsn_codes(doc, valid_hsn_length, throw=False, message=None):
     rows_with_invalid_hsn = []
 
     for item in doc.items:
+        item.gst_hsn_code = (item.gst_hsn_code or "").replace(" ", "")
+
         if not (hsn_code := item.get("gst_hsn_code")):
             rows_with_missing_hsn.append(str(item.idx))
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HSN code validation by normalizing and trimming whitespace before checks, ensuring whitespace-only values are handled correctly and validation/errors are consistent.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->