### PR TITLE
feat: e-Waybill bulk actions in Delivery Note

### DIFF
--- a/india_compliance/gst_india/client_scripts/bulk_actions_utils.js
+++ b/india_compliance/gst_india/client_scripts/bulk_actions_utils.js
@@ -1,0 +1,95 @@
+/********
+ * Shared Utility Functions for Bulk Actions
+ *******/
+
+function add_bulk_action_for_documents(list_view, label, callback, allowed_status) {
+    if (!allowed_status) allowed_status = [1];
+    list_view.page.add_actions_menu_item(label, async () => {
+        const selected_docs = list_view.get_checked_items();
+        const submitted_docs = await validate_doc_status(selected_docs, allowed_status);
+        if (submitted_docs && submitted_docs.length > 0) {
+            callback(submitted_docs);
+        }
+    });
+}
+
+async function enqueue_bulk_generation(method, args) {
+    const job_id = await frappe.xcall(method, args);
+
+    const now = frappe.datetime.system_datetime();
+    const creation_filter = `[">", "${now}"]`;
+    const api_requests_link = frappe.utils.generate_route({
+        type: "doctype",
+        name: "Integration Request",
+        route_options: {
+            integration_request_service: "India Compliance API",
+            creation: creation_filter,
+        },
+    });
+    const error_logs_link = frappe.utils.generate_route({
+        type: "doctype",
+        name: "Error Log",
+        route_options: {
+            creation: creation_filter,
+        },
+    });
+
+    frappe.msgprint(
+        __(
+            `Bulk Generation has been queued. You can track the
+            <a href='{0}'>Background Job</a>,
+            <a href='{1}'>API Request(s)</a>,
+            and <a href='{2}'>Error Log(s)</a>.`,
+            [
+                frappe.utils.get_form_link("RQ Job", job_id),
+                api_requests_link,
+                error_logs_link,
+            ]
+        )
+    );
+}
+
+async function validate_doc_status(selected_docs, allowed_status) {
+    const valid_docs = [];
+    const invalid_docs = [];
+    const status_map = {
+        0: "draft",
+        1: "submitted",
+        2: "cancelled",
+    };
+
+    for (const doc of selected_docs) {
+        if (!allowed_status.includes(doc.docstatus)) {
+            invalid_docs.push(doc.name);
+        } else {
+            valid_docs.push(doc.name);
+        }
+    }
+
+    if (!invalid_docs.length) return valid_docs;
+
+    const allowed_status_str = allowed_status
+        .map(status => status_map[status])
+        .join(" or ");
+
+    if (!valid_docs.length) {
+        frappe.throw(
+            __("This action can only be performed on {0} documents", [
+                allowed_status_str,
+            ])
+        );
+    }
+
+    const confirmed = await new Promise(resolve => {
+        frappe.confirm(
+            __(
+                "This action can only be performed on {0} documents. Do you want to continue without the following documents?<br><br><strong>{1}</strong>",
+                [allowed_status_str, invalid_docs.join("<br>")]
+            ),
+            () => resolve(true),
+            () => resolve(false)
+        );
+    });
+
+    return confirmed ? valid_docs : false;
+}

--- a/india_compliance/gst_india/client_scripts/delivery_note_list.js
+++ b/india_compliance/gst_india/client_scripts/delivery_note_list.js
@@ -1,4 +1,4 @@
-const DOCTYPE = "Sales Invoice";
+const DOCTYPE = "Delivery Note";
 
 const erpnext_onload = frappe.listview_settings[DOCTYPE].onload;
 frappe.listview_settings[DOCTYPE].onload = function (list_view) {

--- a/india_compliance/gst_india/client_scripts/e_invoice_actions.js
+++ b/india_compliance/gst_india/client_scripts/e_invoice_actions.js
@@ -419,3 +419,31 @@ function is_valid_e_invoice_applicability_date(frm) {
         ? true
         : false;
 }
+
+/********
+ * Bulk Operations for List Views
+ *******/
+
+function setup_bulk_e_invoice_actions(doctype, list_view) {
+    if (!frappe.perm.has_perm(doctype, 0, "submit")) return;
+    if (!india_compliance.is_e_invoice_enabled()) return;
+
+    setup_bulk_e_invoice_generation_action(doctype, list_view);
+}
+
+function setup_bulk_e_invoice_generation_action(doctype, list_view) {
+    if (doctype !== "Sales Invoice") return;
+
+    add_bulk_action_for_documents(
+        list_view,
+        __("Enqueue Bulk e-Invoice Generation"),
+        enqueue_bulk_e_invoice_generation
+    );
+}
+
+async function enqueue_bulk_e_invoice_generation(docnames) {
+    enqueue_bulk_generation(
+        "india_compliance.gst_india.utils.e_invoice.enqueue_bulk_e_invoice_generation",
+        { docnames }
+    );
+}

--- a/india_compliance/gst_india/client_scripts/e_waybill_actions.js
+++ b/india_compliance/gst_india/client_scripts/e_waybill_actions.js
@@ -1496,62 +1496,74 @@ function show_sandbox_mode_indicator() {
         );
 }
 
+function is_e_waybill_enabled(doctype) {
+    if (!gst_settings.enable_e_waybill) return false;
+
+    if (doctype === "Sales Invoice") return true;
+
+    if (doctype === "Delivery Note") {
+        return gst_settings.enable_e_waybill_from_dn;
+    }
+    if (doctype === "Purchase Invoice") {
+        return gst_settings.enable_e_waybill_from_pi;
+    }
+    if (["Stock Entry", "Subcontracting Receipt"].includes(doctype)) {
+        return gst_settings.enable_e_waybill_from_sc;
+    }
+
+    return false;
+}
+
 /********
  * Bulk Operations for List Views
  *******/
 
 function setup_bulk_e_waybill_actions(doctype, list_view) {
     if (!frappe.perm.has_perm(doctype, 0, "submit")) return;
+    if (!is_e_waybill_enabled(doctype)) return;
 
     setup_bulk_e_waybill_json_action(doctype, list_view);
     setup_bulk_transporter_update_action(doctype, list_view);
     setup_bulk_e_waybill_generation_action(doctype, list_view);
     setup_bulk_e_waybill_print_action(doctype, list_view);
+}
+
+function setup_bulk_e_invoice_actions(doctype, list_view) {
+    if (!frappe.perm.has_perm(doctype, 0, "submit")) return;
+    if (!india_compliance.is_e_invoice_enabled()) return;
+
     setup_bulk_e_invoice_generation_action(doctype, list_view);
 }
 
 function setup_bulk_e_waybill_json_action(doctype, list_view) {
-    if (!gst_settings.enable_e_waybill) return;
     if (doctype !== "Sales Invoice") return;
 
     add_bulk_action_for_documents(list_view, __("Generate e-Waybill JSON"), docnames =>
-        generate_e_waybill_json_for_doctype(doctype, docnames)
+        generate_e_waybill_json(doctype, docnames)
     );
 }
 
 function setup_bulk_transporter_update_action(doctype, list_view) {
-    if (!gst_settings.enable_e_waybill) return;
-
-    if (doctype === "Delivery Note" && !gst_settings.enable_e_waybill_from_dn) {
-        return;
-    }
-
     add_bulk_action_for_documents(
         list_view,
         __("Bulk Update Transporter Detail"),
-        docnames => show_bulk_update_transporter_dialog_for_doctype(doctype, docnames),
+        docnames => show_bulk_update_transporter_dialog(doctype, docnames),
         [0, 1]
     );
 }
 
 function setup_bulk_e_waybill_generation_action(doctype, list_view) {
-    if (!gst_settings.enable_e_waybill) return;
-
-    if (doctype === "Delivery Note" && !gst_settings.enable_e_waybill_from_dn) {
-        return;
-    }
-
     if (doctype === "Sales Invoice") {
         add_bulk_action_for_documents(
             list_view,
             __("Enqueue Bulk e-Waybill Generation"),
-            docnames => enqueue_bulk_e_waybill_generation_for_doctype(doctype, docnames)
+            docnames => enqueue_bulk_e_waybill_generation(doctype, docnames)
         );
     } else {
         add_bulk_action_for_documents(
             list_view,
             __("Enqueue Bulk e-Waybill Generation"),
-            docnames => show_bulk_e_waybill_generation_dialog(doctype, docnames)
+            docnames => show_bulk_generate_e_waybill_dialog(doctype, docnames)
         );
     }
 }
@@ -1560,18 +1572,18 @@ function setup_bulk_e_waybill_print_action(doctype, list_view) {
     if (!frappe.model.can_print("e-Waybill Log")) return;
 
     add_bulk_action_for_documents(list_view, __("Print e-Waybill"), docnames =>
-        bulk_e_waybill_print_for_doctype(doctype, docnames)
+        bulk_e_waybill_print(doctype, docnames)
     );
 }
 
 function setup_bulk_e_invoice_generation_action(doctype, list_view) {
-    if (doctype === "Sales Invoice" && india_compliance.is_e_invoice_enabled()) {
-        add_bulk_action_for_documents(
-            list_view,
-            __("Enqueue Bulk e-Invoice Generation"),
-            enqueue_bulk_e_invoice_generation
-        );
-    }
+    if (doctype !== "Sales Invoice") return;
+
+    add_bulk_action_for_documents(
+        list_view,
+        __("Enqueue Bulk e-Invoice Generation"),
+        enqueue_bulk_e_invoice_generation
+    );
 }
 
 function add_bulk_action_for_documents(list_view, label, callback, allowed_status) {
@@ -1583,7 +1595,7 @@ function add_bulk_action_for_documents(list_view, label, callback, allowed_statu
     });
 }
 
-async function generate_e_waybill_json_for_doctype(doctype, docnames) {
+async function generate_e_waybill_json(doctype, docnames) {
     const ewb_data = await frappe.xcall(
         "india_compliance.gst_india.utils.e_waybill.generate_e_waybill_json",
         { doctype: doctype, docnames }
@@ -1592,7 +1604,7 @@ async function generate_e_waybill_json_for_doctype(doctype, docnames) {
     india_compliance.trigger_file_download(ewb_data, get_e_waybill_file_name());
 }
 
-function show_bulk_update_transporter_dialog_for_doctype(doctype, docnames) {
+function show_bulk_update_transporter_dialog(doctype, docnames) {
     const frm = { doctype: doctype, doc: {} };
     const d = get_generate_e_waybill_dialog(
         {
@@ -1618,7 +1630,7 @@ function show_bulk_update_transporter_dialog_for_doctype(doctype, docnames) {
     d.show();
 }
 
-async function bulk_e_waybill_print_for_doctype(doctype, docnames) {
+async function bulk_e_waybill_print(doctype, docnames) {
     frappe.call({
         method: "india_compliance.gst_india.utils.e_waybill.get_valid_and_invalid_e_waybill_log",
         args: {
@@ -1652,11 +1664,7 @@ async function bulk_e_waybill_print_for_doctype(doctype, docnames) {
     });
 }
 
-async function enqueue_bulk_e_waybill_generation_for_doctype(
-    doctype,
-    docnames,
-    values
-) {
+async function enqueue_bulk_e_waybill_generation(doctype, docnames, values) {
     const args = { doctype, docnames };
     if (values) args.values = values;
     await enqueue_bulk_generation(
@@ -1672,7 +1680,7 @@ async function enqueue_bulk_e_invoice_generation(docnames) {
     );
 }
 
-function show_bulk_e_waybill_generation_dialog(doctype, docnames) {
+function show_bulk_generate_e_waybill_dialog(doctype, docnames) {
     const frm = { doctype: doctype, doc: {} };
     const d = get_generate_e_waybill_dialog(
         {
@@ -1680,11 +1688,7 @@ function show_bulk_e_waybill_generation_dialog(doctype, docnames) {
             primary_action_label: __("Generate e-Waybills"),
             primary_action(values) {
                 d.hide();
-                enqueue_bulk_e_waybill_generation_for_doctype(
-                    doctype,
-                    docnames,
-                    values
-                );
+                enqueue_bulk_e_waybill_generation(doctype, docnames, values);
             },
         },
         frm

--- a/india_compliance/gst_india/client_scripts/e_waybill_actions.js
+++ b/india_compliance/gst_india/client_scripts/e_waybill_actions.js
@@ -1508,7 +1508,7 @@ function is_e_waybill_enabled(doctype) {
         return gst_settings.enable_e_waybill_from_pi;
     }
     if (["Stock Entry", "Subcontracting Receipt"].includes(doctype)) {
-        return gst_settings.enable_e_waybill_from_sc;
+        return gst_settings.enable_e_waybill_for_sc;
     }
 
     return false;

--- a/india_compliance/gst_india/client_scripts/e_waybill_actions.js
+++ b/india_compliance/gst_india/client_scripts/e_waybill_actions.js
@@ -580,7 +580,6 @@ function get_document_detail_fields(frm) {
     ];
 }
 
-
 function get_generate_e_waybill_dialog(opts, frm) {
     if (!frm) frm = { doc: {} };
 
@@ -844,6 +843,7 @@ function show_fetch_if_generated_dialog(frm) {
 
     d.show();
 }
+
 function show_mark_e_waybill_as_generated_dialog(frm) {
     const d = new frappe.ui.Dialog({
         title: __("Update e-Waybill Details"),
@@ -1761,7 +1761,7 @@ async function bulk_e_waybill_print(doctype, docnames) {
         },
         callback: function (r) {
             if (r.message) {
-                if (r.message.invalid_log.length > 1) {
+                if (r.message.invalid_log.length > 0) {
                     const invalid_docs = r.message.invalid_log.map(
                         doc => `${doc.link} - ${doc.reason}`
                     );
@@ -1926,7 +1926,8 @@ async function validate_doc_status(selected_docs, allowed_status) {
                 "This action can only be performed on {0} documents. Do you want to continue without the following documents?<br><br><strong>{1}</strong>",
                 [allowed_status_str, invalid_docs.join("<br>")]
             ),
-            () => resolve(true)
+            () => resolve(true),
+            () => resolve(false)
         );
     });
 

--- a/india_compliance/gst_india/client_scripts/e_waybill_actions.js
+++ b/india_compliance/gst_india/client_scripts/e_waybill_actions.js
@@ -1591,7 +1591,9 @@ function add_bulk_action_for_documents(list_view, label, callback, allowed_statu
     list_view.page.add_actions_menu_item(label, async () => {
         const selected_docs = list_view.get_checked_items();
         const submitted_docs = await validate_doc_status(selected_docs, allowed_status);
-        if (submitted_docs) callback(submitted_docs);
+        if (submitted_docs && submitted_docs.length > 0) {
+            callback(submitted_docs);
+        }
     });
 }
 

--- a/india_compliance/gst_india/client_scripts/e_waybill_actions.js
+++ b/india_compliance/gst_india/client_scripts/e_waybill_actions.js
@@ -1504,7 +1504,7 @@ function is_e_waybill_enabled(doctype) {
     if (doctype === "Delivery Note") {
         return gst_settings.enable_e_waybill_from_dn;
     }
-    if (doctype === "Purchase Invoice") {
+    if  (["Purchase Invoice", "Purchase Receipt"].includes(doctype)) {
         return gst_settings.enable_e_waybill_from_pi;
     }
     if (["Stock Entry", "Subcontracting Receipt"].includes(doctype)) {

--- a/india_compliance/gst_india/client_scripts/e_waybill_actions.js
+++ b/india_compliance/gst_india/client_scripts/e_waybill_actions.js
@@ -1705,9 +1705,6 @@ function show_bulk_generate_e_waybill_dialog(doctype, docnames) {
         primary_action_label: __("Generate e-Waybills"),
         primary_action(values) {
             d.hide();
-            if (!values.update_transporter_details) {
-                values = null;
-            }
             enqueue_bulk_e_waybill_generation(doctype, docnames, values);
         },
     });

--- a/india_compliance/gst_india/client_scripts/e_waybill_actions.js
+++ b/india_compliance/gst_india/client_scripts/e_waybill_actions.js
@@ -337,55 +337,71 @@ function show_generate_e_waybill_dialog(frm) {
     }
 }
 
-function get_generate_e_waybill_dialog(opts, frm) {
+function get_generate_e_waybill_dialog(opts, frm, transporter_only = false) {
     if (!frm) frm = { doc: {} };
     const is_foreign_transaction =
         frm.doc.gst_category === "Overseas" &&
         frm.doc.place_of_supply === "96-Other Countries";
 
-    const ewaybill_defaults = get_sub_suppy_type_options(frm, is_foreign_transaction);
+    const fields = [];
 
-    const fields = [
-        {
-            label: "Document Details",
-            fieldname: "section_doc_details",
-            fieldtype: "Section Break",
-            // collapsible: ewaybill_defaults.sub_supply_type.length === 1,
-        },
-        {
-            label: "Supply Type",
-            fieldname: "supply_type",
-            fieldtype: "Data",
-            read_only: 1,
-            default: ewaybill_defaults.supply_type,
-        },
-        {
-            label: "Document Type",
-            fieldname: "document_type",
-            fieldtype: "Data",
-            read_only: 1,
-            default: ewaybill_defaults.document_type,
-        },
-        {
-            fieldtype: "Column Break",
-        },
-        {
-            label: "Sub Supply Type",
-            fieldname: "sub_supply_type",
-            fieldtype: "Select",
-            options: ewaybill_defaults.sub_supply_type.join("\n"),
-            default: ewaybill_defaults.sub_supply_type[0],
-            read_only: ewaybill_defaults.sub_supply_type.length === 1,
-            reqd: ewaybill_defaults.sub_supply_type.length !== 1,
-        },
-        {
-            label: "Sub Supply Description",
-            fieldname: "sub_supply_desc",
-            fieldtype: "Data",
-            depends_on: "eval: doc.sub_supply_type == 'Others'",
-            mandatory_depends_on: "eval: doc.sub_supply_type == 'Others'",
-            default: ewaybill_defaults.sub_supply_desc,
-        },
+    if (!transporter_only) {
+        const ewaybill_defaults = get_sub_suppy_type_options(
+            frm,
+            is_foreign_transaction
+        );
+
+        fields.push(
+            {
+                label: "Document Details",
+                fieldname: "section_doc_details",
+                fieldtype: "Section Break",
+            },
+            {
+                label: "Supply Type",
+                fieldname: "supply_type",
+                fieldtype: "Select",
+                read_only: ewaybill_defaults.supply_type.length === 1,
+                default: ewaybill_defaults.supply_type[0],
+                options: ewaybill_defaults.supply_type.join("\n"),
+                reqd: ewaybill_defaults.supply_type.length !== 1,
+                onchange: () => {
+                    if (ewaybill_defaults.supply_type.length > 1) {
+                        update_sub_supply_type_options(d, frm);
+                    }
+                },
+            },
+            {
+                label: "Document Type",
+                fieldname: "document_type",
+                fieldtype: "Data",
+                read_only: 1,
+                default: ewaybill_defaults.document_type,
+            },
+            {
+                fieldtype: "Column Break",
+            },
+            {
+                label: "Sub Supply Type",
+                fieldname: "sub_supply_type",
+                fieldtype: "Select",
+                options: ewaybill_defaults.sub_supply_type.join("\n"),
+                default: ewaybill_defaults.sub_supply_type[0],
+                read_only: ewaybill_defaults.sub_supply_type.length === 1,
+                reqd: ewaybill_defaults.sub_supply_type.length !== 1,
+            },
+            {
+                label: "Sub Supply Description",
+                fieldname: "sub_supply_desc",
+                fieldtype: "Data",
+                depends_on: "eval: doc.sub_supply_type == 'Others'",
+                mandatory_depends_on: "eval: doc.sub_supply_type == 'Others'",
+                default: ewaybill_defaults.sub_supply_desc,
+            }
+        );
+    }
+
+    fields.push(
         {
             label: "Part A",
             fieldname: "section_part_a",
@@ -477,10 +493,13 @@ function get_generate_e_waybill_dialog(opts, frm) {
             depends_on: 'eval:["Road", "Ship"].includes(doc.mode_of_transport)',
             read_only_depends_on: "eval: doc.mode_of_transport == 'Ship'",
             default: frm.doc.gst_vehicle_type || "Regular",
-        },
-    ];
+        }
+    );
 
-    if (["Sales Invoice","Delivery Note"].includes(frm.doctype) && is_foreign_transaction) {
+    if (
+        ["Sales Invoice", "Delivery Note"].includes(frm.doctype) &&
+        is_foreign_transaction
+    ) {
         fields.splice(5, 0, {
             label: "Origin Port / Border Checkpost Address",
             fieldname: "port_address",
@@ -512,11 +531,11 @@ function get_generate_e_waybill_dialog(opts, frm) {
 function get_sub_suppy_type_options(frm, is_foreign_transaction) {
     let supply_type, sub_supply_type, sub_supply_desc, document_type;
 
-    if (frm.doctype === "Delivery Note") {
+    if (frm.doctype === "Delivery Note" && frm?.doc?.company_gstin) {
         const same_gstin = frm.doc.billing_address_gstin == frm.doc.company_gstin;
 
         if (frm.doc.is_return) {
-            supply_type = "Inward";
+            supply_type = ["Inward"];
             document_type = "Delivery Challan";
             if (same_gstin) {
                 sub_supply_type = ["For Own Use", "Exhibition or Fairs", "Others"];
@@ -524,7 +543,7 @@ function get_sub_suppy_type_options(frm, is_foreign_transaction) {
                 sub_supply_type = ["Job Work Returns", "SKD/CKD", "Others"];
             }
         } else {
-            supply_type = "Outward";
+            supply_type = ["Outward"];
             document_type = "Delivery Challan";
             if (same_gstin) {
                 sub_supply_type = [
@@ -538,20 +557,43 @@ function get_sub_suppy_type_options(frm, is_foreign_transaction) {
                 sub_supply_type = ["Job Work", "SKD/CKD", "Others"];
             }
         }
+    } else if (frm.doctype === "Delivery Note") {
+        supply_type = ["Inward", "Outward"];
+        document_type = "Delivery Challan";
+
+        if (frm.doc.is_return === 1) {
+            sub_supply_type = [
+                "For Own Use",
+                "Exhibition or Fairs",
+                "Job Work Returns",
+                "SKD/CKD",
+                "Others",
+            ];
+        } else {
+            sub_supply_type = [
+                "For Own Use",
+                "Exhibition or Fairs",
+                "Job Work",
+                "SKD/CKD",
+                "Line Sales",
+                "Recipient Not Known",
+                "Others",
+            ];
+        }
     } else if (frm.doctype === "Stock Entry") {
         document_type = "Delivery Challan";
 
         if (frm.doc.purpose === "Send to Subcontractor") {
-            supply_type = "Outward";
+            supply_type = ["Outward"];
             sub_supply_type = ["Job Work"];
         } else if (["Material Transfer", "Material Issue"].includes(frm.doc.purpose)) {
             const same_gstin = frm.doc.bill_from_gstin === frm.doc.bill_to_gstin;
 
             if (frm.doc.is_return) {
-                supply_type = "Inward";
+                supply_type = ["Inward"];
                 sub_supply_type = ["Job Work Returns"];
             } else if (same_gstin) {
-                supply_type = "Outward";
+                supply_type = ["Outward"];
                 sub_supply_type = [
                     "For Own Use",
                     "Exhibition or Fairs",
@@ -559,9 +601,8 @@ function get_sub_suppy_type_options(frm, is_foreign_transaction) {
                     "Recipient Not Known",
                     "Others",
                 ];
-            }
-            else {
-                supply_type = "Outward";
+            } else {
+                supply_type = ["Outward"];
                 sub_supply_type = ["Job Work", "SKD/CKD", "Others"];
             }
         }
@@ -570,51 +611,51 @@ function get_sub_suppy_type_options(frm, is_foreign_transaction) {
         frm.doc.is_return === 0 &&
         is_foreign_transaction
     ) {
-        supply_type = "Outward";
+        supply_type = ["Outward"];
         sub_supply_type = ["Export"];
         document_type = "Tax Invoice";
     } else {
         const key = `${frm.doctype}_${frm.doc.is_return || 0}`;
         const default_supply_types = {
             "Sales Invoice_0": {
-                supply_type: "Outward",
+                supply_type: ["Outward"],
                 sub_supply_type: ["Supply"],
                 document_type: "Tax Invoice",
             },
             "Sales Invoice_1": {
-                supply_type: "Inward",
+                supply_type: ["Inward"],
                 sub_supply_type: ["Sales Return"],
                 document_type: "Delivery Challan",
             },
             "Purchase Invoice_0": {
-                supply_type: "Inward",
+                supply_type: ["Inward"],
                 sub_supply_type: ["Supply"],
                 document_type: "Tax Invoice",
             },
             "Purchase Invoice_1": {
-                supply_type: "Outward",
+                supply_type: ["Outward"],
                 sub_supply_type: ["Others"],
                 sub_supply_desc: "Purchase Return",
                 document_type: "Others",
             },
             "Purchase Receipt_0": {
-                supply_type: "Inward",
+                supply_type: ["Inward"],
                 sub_supply_type: ["Supply"],
                 document_type: "Tax Invoice",
             },
             "Purchase Receipt_1": {
-                supply_type: "Outward",
+                supply_type: ["Outward"],
                 sub_supply_type: ["Others"],
                 sub_supply_desc: "Purchase Return",
                 document_type: "Delivery Challan",
             },
             "Subcontracting Receipt_0": {
-                supply_type: "Inward",
+                supply_type: ["Inward"],
                 sub_supply_type: ["Job Work Returns"],
                 document_type: "Delivery Challan",
             },
             "Subcontracting Receipt_1": {
-                supply_type: "Outward",
+                supply_type: ["Outward"],
                 sub_supply_type: ["Job Work"],
                 document_type: "Delivery Challan",
             },
@@ -624,6 +665,23 @@ function get_sub_suppy_type_options(frm, is_foreign_transaction) {
     }
 
     return { supply_type, sub_supply_type, sub_supply_desc, document_type };
+}
+
+function update_sub_supply_type_options(dialog, frm) {
+    const supply_type = dialog.get_value("supply_type");
+    if (!supply_type) return;
+
+    // Create temporary frm object with selected supply type to get correct options
+    const temp_frm = {
+        ...frm,
+        doc: { ...frm.doc, is_return: supply_type === "Inward" ? 1 : 0 },
+    };
+    const options = get_sub_suppy_type_options(temp_frm);
+
+    const sub_supply_field = dialog.get_field("sub_supply_type");
+    sub_supply_field.df.options = options.sub_supply_type.join("\n");
+    sub_supply_field.refresh();
+    dialog.set_value("sub_supply_type", options.sub_supply_type[0]);
 }
 
 function show_fetch_if_generated_dialog(frm) {
@@ -1427,10 +1485,290 @@ function show_sandbox_mode_indicator() {
                 <p><label class="indicator-pill no-indicator-dot yellow" title="${__(
                     "Your site has enabled Sandbox Mode in GST Settings."
                 )}">${__("Sandbox Mode")}</label></p>
-                <p><a class="small text-muted" href="${frappe.utils.get_form_link("GST Settings", "GST Settings")}" target="_blank">${__(
-                    "Sandbox Mode is enabled for GST APIs."
-                )}</a></p>
+                <p><a class="small text-muted" href="${frappe.utils.get_form_link(
+                    "GST Settings",
+                    "GST Settings"
+                )}" target="_blank">${__(
+                "Sandbox Mode is enabled for GST APIs."
+            )}</a></p>
             </div>
             `
         );
+}
+
+/********
+ * Bulk Operations for List Views
+ *******/
+
+function setup_bulk_e_waybill_actions(doctype, list_view) {
+    if (!frappe.perm.has_perm(doctype, 0, "submit")) return;
+
+    setup_bulk_e_waybill_json_action(doctype, list_view);
+    setup_bulk_transporter_update_action(doctype, list_view);
+    setup_bulk_e_waybill_generation_action(doctype, list_view);
+    setup_bulk_e_waybill_print_action(doctype, list_view);
+    setup_bulk_e_invoice_generation_action(doctype, list_view);
+}
+
+function setup_bulk_e_waybill_json_action(doctype, list_view) {
+    if (!gst_settings.enable_e_waybill) return;
+    if (doctype !== "Sales Invoice") return;
+
+    add_bulk_action_for_documents(list_view, __("Generate e-Waybill JSON"), docnames =>
+        generate_e_waybill_json_for_doctype(doctype, docnames)
+    );
+}
+
+function setup_bulk_transporter_update_action(doctype, list_view) {
+    if (!gst_settings.enable_e_waybill) return;
+
+    if (doctype === "Delivery Note" && !gst_settings.enable_e_waybill_from_dn) {
+        return;
+    }
+
+    add_bulk_action_for_documents(
+        list_view,
+        __("Bulk Update Transporter Detail"),
+        docnames => show_bulk_update_transporter_dialog_for_doctype(doctype, docnames),
+        [0, 1]
+    );
+}
+
+function setup_bulk_e_waybill_generation_action(doctype, list_view) {
+    if (!gst_settings.enable_e_waybill) return;
+
+    if (doctype === "Delivery Note" && !gst_settings.enable_e_waybill_from_dn) {
+        return;
+    }
+
+    if (doctype === "Sales Invoice") {
+        add_bulk_action_for_documents(
+            list_view,
+            __("Enqueue Bulk e-Waybill Generation"),
+            docnames => enqueue_bulk_e_waybill_generation_for_doctype(doctype, docnames)
+        );
+    } else {
+        add_bulk_action_for_documents(
+            list_view,
+            __("Enqueue Bulk e-Waybill Generation"),
+            docnames => show_bulk_e_waybill_generation_dialog(doctype, docnames)
+        );
+    }
+}
+
+function setup_bulk_e_waybill_print_action(doctype, list_view) {
+    if (!frappe.model.can_print("e-Waybill Log")) return;
+
+    add_bulk_action_for_documents(list_view, __("Print e-Waybill"), docnames =>
+        bulk_e_waybill_print_for_doctype(doctype, docnames)
+    );
+}
+
+function setup_bulk_e_invoice_generation_action(doctype, list_view) {
+    if (doctype === "Sales Invoice" && india_compliance.is_e_invoice_enabled()) {
+        add_bulk_action_for_documents(
+            list_view,
+            __("Enqueue Bulk e-Invoice Generation"),
+            enqueue_bulk_e_invoice_generation
+        );
+    }
+}
+
+function add_bulk_action_for_documents(list_view, label, callback, allowed_status) {
+    if (!allowed_status) allowed_status = [1];
+    list_view.page.add_actions_menu_item(label, async () => {
+        const selected_docs = list_view.get_checked_items();
+        const submitted_docs = await validate_doc_status(selected_docs, allowed_status);
+        if (submitted_docs) callback(submitted_docs);
+    });
+}
+
+async function generate_e_waybill_json_for_doctype(doctype, docnames) {
+    const ewb_data = await frappe.xcall(
+        "india_compliance.gst_india.utils.e_waybill.generate_e_waybill_json",
+        { doctype: doctype, docnames }
+    );
+
+    india_compliance.trigger_file_download(ewb_data, get_e_waybill_file_name());
+}
+
+function show_bulk_update_transporter_dialog_for_doctype(doctype, docnames) {
+    const frm = { doctype: doctype, doc: {} };
+    const d = get_generate_e_waybill_dialog(
+        {
+            title: __("Update Transporter Detail"),
+            primary_action_label: __("Update {0}", [doctype]),
+            primary_action(values) {
+                d.hide();
+
+                frappe.call({
+                    method: "india_compliance.gst_india.utils.e_waybill.bulk_update_transporter_in_docs",
+                    args: {
+                        doctype: doctype,
+                        docnames,
+                        values,
+                    },
+                });
+            },
+        },
+        frm,
+        true // transporter_only = true
+    );
+
+    d.show();
+}
+
+async function bulk_e_waybill_print_for_doctype(doctype, docnames) {
+    frappe.call({
+        method: "india_compliance.gst_india.utils.e_waybill.get_valid_and_invalid_e_waybill_log",
+        args: {
+            doctype: doctype,
+            docs: JSON.stringify(docnames),
+        },
+        callback: function (r) {
+            if (r.message) {
+                if (r.message.invalid_log.length > 1) {
+                    const invalid_docs = r.message.invalid_log.map(
+                        doc => `${doc.link} - ${doc.reason}`
+                    );
+                    frappe.msgprint(
+                        __(
+                            "Cannot print e-Waybill for following documents:<br><br>{0}",
+                            [invalid_docs.join("<br>")]
+                        )
+                    );
+                }
+
+                window.open_url_post(
+                    "/api/method/frappe.utils.print_format.download_multi_pdf",
+                    {
+                        doctype: "e-Waybill Log",
+                        name: JSON.stringify(r.message.valid_log),
+                    },
+                    true
+                );
+            }
+        },
+    });
+}
+
+async function enqueue_bulk_e_waybill_generation_for_doctype(
+    doctype,
+    docnames,
+    values
+) {
+    const args = { doctype, docnames };
+    if (values) args.values = values;
+    await enqueue_bulk_generation(
+        "india_compliance.gst_india.utils.e_waybill.enqueue_bulk_e_waybill_generation",
+        args
+    );
+}
+
+async function enqueue_bulk_e_invoice_generation(docnames) {
+    enqueue_bulk_generation(
+        "india_compliance.gst_india.utils.e_invoice.enqueue_bulk_e_invoice_generation",
+        { docnames }
+    );
+}
+
+function show_bulk_e_waybill_generation_dialog(doctype, docnames) {
+    const frm = { doctype: doctype, doc: {} };
+    const d = get_generate_e_waybill_dialog(
+        {
+            title: __("Bulk e-Waybill Generation"),
+            primary_action_label: __("Generate e-Waybills"),
+            primary_action(values) {
+                d.hide();
+                enqueue_bulk_e_waybill_generation_for_doctype(
+                    doctype,
+                    docnames,
+                    values
+                );
+            },
+        },
+        frm
+    );
+
+    d.show();
+}
+
+async function enqueue_bulk_generation(method, args) {
+    const job_id = await frappe.xcall(method, args);
+
+    const now = frappe.datetime.system_datetime();
+    const creation_filter = `[">", "${now}"]`;
+    const api_requests_link = frappe.utils.generate_route({
+        type: "doctype",
+        name: "Integration Request",
+        route_options: {
+            integration_request_service: "India Compliance API",
+            creation: creation_filter,
+        },
+    });
+    const error_logs_link = frappe.utils.generate_route({
+        type: "doctype",
+        name: "Error Log",
+        route_options: {
+            creation: creation_filter,
+        },
+    });
+
+    frappe.msgprint(
+        __(
+            `Bulk Generation has been queued. You can track the
+            <a href='{0}'>Background Job</a>,
+            <a href='{1}'>API Request(s)</a>,
+            and <a href='{2}'>Error Log(s)</a>.`,
+            [
+                frappe.utils.get_form_link("RQ Job", job_id),
+                api_requests_link,
+                error_logs_link,
+            ]
+        )
+    );
+}
+
+async function validate_doc_status(selected_docs, allowed_status) {
+    const valid_docs = [];
+    const invalid_docs = [];
+    const status_map = {
+        0: "draft",
+        1: "submitted",
+        2: "cancelled",
+    };
+
+    for (const doc of selected_docs) {
+        if (!allowed_status.includes(doc.docstatus)) {
+            invalid_docs.push(doc.name);
+        } else {
+            valid_docs.push(doc.name);
+        }
+    }
+
+    if (!invalid_docs.length) return valid_docs;
+
+    const allowed_status_str = allowed_status
+        .map(status => status_map[status])
+        .join(" or ");
+
+    if (!valid_docs.length) {
+        frappe.throw(
+            __("This action can only be performed on {0} documents", [
+                allowed_status_str,
+            ])
+        );
+    }
+
+    const confirmed = await new Promise(resolve => {
+        frappe.confirm(
+            __(
+                "This action can only be performed on {0} documents. Do you want to continue without the following documents?<br><br><strong>{1}</strong>",
+                [allowed_status_str, invalid_docs.join("<br>")]
+            ),
+            () => resolve(true)
+        );
+    });
+
+    return confirmed ? valid_docs : false;
 }

--- a/india_compliance/gst_india/client_scripts/e_waybill_actions.js
+++ b/india_compliance/gst_india/client_scripts/e_waybill_actions.js
@@ -249,6 +249,7 @@ function show_generate_e_waybill_dialog(frm) {
                 docname: frm.doc.name,
                 values: values,
                 force: true,
+                throw: true
             },
             callback: () => {
                 return frm.refresh();

--- a/india_compliance/gst_india/client_scripts/e_waybill_actions.js
+++ b/india_compliance/gst_india/client_scripts/e_waybill_actions.js
@@ -1586,13 +1586,6 @@ function setup_bulk_e_waybill_actions(doctype, list_view) {
     setup_bulk_e_waybill_print_action(doctype, list_view);
 }
 
-function setup_bulk_e_invoice_actions(doctype, list_view) {
-    if (!frappe.perm.has_perm(doctype, 0, "submit")) return;
-    if (!india_compliance.is_e_invoice_enabled()) return;
-
-    setup_bulk_e_invoice_generation_action(doctype, list_view);
-}
-
 function setup_bulk_e_waybill_json_action(doctype, list_view) {
     if (doctype !== "Sales Invoice") return;
 
@@ -1624,27 +1617,6 @@ function setup_bulk_e_waybill_print_action(doctype, list_view) {
     add_bulk_action_for_documents(list_view, __("Print e-Waybill"), docnames =>
         bulk_e_waybill_print(doctype, docnames)
     );
-}
-
-function setup_bulk_e_invoice_generation_action(doctype, list_view) {
-    if (doctype !== "Sales Invoice") return;
-
-    add_bulk_action_for_documents(
-        list_view,
-        __("Enqueue Bulk e-Invoice Generation"),
-        enqueue_bulk_e_invoice_generation
-    );
-}
-
-function add_bulk_action_for_documents(list_view, label, callback, allowed_status) {
-    if (!allowed_status) allowed_status = [1];
-    list_view.page.add_actions_menu_item(label, async () => {
-        const selected_docs = list_view.get_checked_items();
-        const submitted_docs = await validate_doc_status(selected_docs, allowed_status);
-        if (submitted_docs && submitted_docs.length > 0) {
-            callback(submitted_docs);
-        }
-    });
 }
 
 async function generate_e_waybill_json(doctype, docnames) {
@@ -1724,13 +1696,6 @@ async function enqueue_bulk_e_waybill_generation(doctype, docnames, values) {
     );
 }
 
-async function enqueue_bulk_e_invoice_generation(docnames) {
-    enqueue_bulk_generation(
-        "india_compliance.gst_india.utils.e_invoice.enqueue_bulk_e_invoice_generation",
-        { docnames }
-    );
-}
-
 function show_bulk_generate_e_waybill_dialog(doctype, docnames) {
     frappe.ui.form.ControlData.trigger_change_on_input_event = false;
     const d = new frappe.ui.Dialog({
@@ -1780,85 +1745,4 @@ function get_bulk_generate_dialog_fields(doctype) {
         },
         ...get_transporter_part_b_fields(frm),
     ];
-}
-
-async function enqueue_bulk_generation(method, args) {
-    const job_id = await frappe.xcall(method, args);
-
-    const now = frappe.datetime.system_datetime();
-    const creation_filter = `[">", "${now}"]`;
-    const api_requests_link = frappe.utils.generate_route({
-        type: "doctype",
-        name: "Integration Request",
-        route_options: {
-            integration_request_service: "India Compliance API",
-            creation: creation_filter,
-        },
-    });
-    const error_logs_link = frappe.utils.generate_route({
-        type: "doctype",
-        name: "Error Log",
-        route_options: {
-            creation: creation_filter,
-        },
-    });
-
-    frappe.msgprint(
-        __(
-            `Bulk Generation has been queued. You can track the
-            <a href='{0}'>Background Job</a>,
-            <a href='{1}'>API Request(s)</a>,
-            and <a href='{2}'>Error Log(s)</a>.`,
-            [
-                frappe.utils.get_form_link("RQ Job", job_id),
-                api_requests_link,
-                error_logs_link,
-            ]
-        )
-    );
-}
-
-async function validate_doc_status(selected_docs, allowed_status) {
-    const valid_docs = [];
-    const invalid_docs = [];
-    const status_map = {
-        0: "draft",
-        1: "submitted",
-        2: "cancelled",
-    };
-
-    for (const doc of selected_docs) {
-        if (!allowed_status.includes(doc.docstatus)) {
-            invalid_docs.push(doc.name);
-        } else {
-            valid_docs.push(doc.name);
-        }
-    }
-
-    if (!invalid_docs.length) return valid_docs;
-
-    const allowed_status_str = allowed_status
-        .map(status => status_map[status])
-        .join(" or ");
-
-    if (!valid_docs.length) {
-        frappe.throw(
-            __("This action can only be performed on {0} documents", [
-                allowed_status_str,
-            ])
-        );
-    }
-
-    const confirmed = await new Promise(resolve => {
-        frappe.confirm(
-            __(
-                "This action can only be performed on {0} documents. Do you want to continue without the following documents?<br><br><strong>{1}</strong>",
-                [allowed_status_str, invalid_docs.join("<br>")]
-            ),
-            () => resolve(true),
-            () => resolve(false)
-        );
-    });
-
-    return confirmed ? valid_docs : false;
 }

--- a/india_compliance/gst_india/client_scripts/e_waybill_actions.js
+++ b/india_compliance/gst_india/client_scripts/e_waybill_actions.js
@@ -291,9 +291,9 @@ function show_generate_e_waybill_dialog(frm) {
                 api_enabled && frm.doc.doctype ? __("Download JSON") : null,
             secondary_action: api_enabled
                 ? () => {
-                      d.hide();
-                      json_action(d.get_values());
-                  }
+                    d.hide();
+                    json_action(d.get_values());
+                }
                 : null,
         },
         frm
@@ -337,69 +337,8 @@ function show_generate_e_waybill_dialog(frm) {
     }
 }
 
-function get_generate_e_waybill_dialog(opts, frm, transporter_only = false) {
-    if (!frm) frm = { doc: {} };
-
-    const fields = [];
-    if (!transporter_only) {
-        const ewaybill_defaults = get_sub_supply_type_options(frm);
-
-        fields.push(
-            {
-                label: "Document Details",
-                fieldname: "section_doc_details",
-                fieldtype: "Section Break",
-            },
-            {
-                label: "Supply Type",
-                fieldname: "supply_type",
-                fieldtype: "Select",
-                read_only: ewaybill_defaults.supply_type.length === 1,
-                default: ewaybill_defaults.supply_type[0],
-                options: ewaybill_defaults.supply_type.join("\n"),
-                reqd: ewaybill_defaults.supply_type.length !== 1,
-                onchange: () => {
-                    if (ewaybill_defaults.supply_type.length > 1) {
-                        update_sub_supply_type_options(d, frm);
-                    }
-                },
-            },
-            {
-                label: "Document Type",
-                fieldname: "document_type",
-                fieldtype: "Data",
-                read_only: 1,
-                default: ewaybill_defaults.document_type,
-            },
-            {
-                fieldtype: "Column Break",
-            },
-            {
-                label: "Sub Supply Type",
-                fieldname: "sub_supply_type",
-                fieldtype: "Select",
-                options: ewaybill_defaults.sub_supply_type.join("\n"),
-                default: ewaybill_defaults.sub_supply_type[0],
-                read_only: ewaybill_defaults.sub_supply_type.length === 1,
-                reqd: ewaybill_defaults.sub_supply_type.length !== 1,
-            },
-            {
-                label: "Sub Supply Description",
-                fieldname: "sub_supply_desc",
-                fieldtype: "Data",
-                depends_on: "eval: doc.sub_supply_type == 'Others'",
-                mandatory_depends_on: "eval: doc.sub_supply_type == 'Others'",
-                default: ewaybill_defaults.sub_supply_desc,
-            }
-        );
-    }
-
-    fields.push(
-        {
-            label: "Part A",
-            fieldname: "section_part_a",
-            fieldtype: "Section Break",
-        },
+function get_transporter_fields(frm) {
+    return [
         {
             label: "Transporter",
             fieldname: "transporter",
@@ -413,7 +352,10 @@ function get_generate_e_waybill_dialog(opts, frm, transporter_only = false) {
                     },
                 };
             },
-            onchange: () => update_gst_tranporter_id(d),
+            onchange: function () {
+                if (!this.layout) return;
+                update_gst_tranporter_id(this.layout);
+            },
         },
         {
             label: "Distance (in km)",
@@ -434,27 +376,35 @@ function get_generate_e_waybill_dialog(opts, frm, transporter_only = false) {
                 frm.doc.gst_transporter_id?.length == 15
                     ? frm.doc.gst_transporter_id
                     : "",
-            onchange: () => validate_gst_transporter_id(d, frm.doc),
+            onchange: function () {
+                if (!this.layout) return;
+                validate_gst_transporter_id(this.layout, frm.doc);
+            },
         },
         {
             label: "Part B",
             fieldname: "section_part_b",
             fieldtype: "Section Break",
         },
-
         {
             label: "Vehicle No",
             fieldname: "vehicle_no",
             fieldtype: "Data",
             default: frm.doc.vehicle_no,
-            onchange: () => update_generation_dialog(d, frm.doc),
+            onchange: function () {
+                if (!this.layout) return;
+                update_generation_dialog(this.layout, frm.doc);
+            },
         },
         {
             label: "Transport Receipt No",
             fieldname: "lr_no",
             fieldtype: "Data",
             default: frm.doc.lr_no,
-            onchange: () => update_generation_dialog(d, frm.doc),
+            onchange: function () {
+                if (!this.layout) return;
+                update_generation_dialog(this.layout, frm.doc);
+            },
         },
         {
             label: "Transport Receipt Date",
@@ -466,16 +416,16 @@ function get_generate_e_waybill_dialog(opts, frm, transporter_only = false) {
         {
             fieldtype: "Column Break",
         },
-
         {
             label: "Mode Of Transport",
             fieldname: "mode_of_transport",
             fieldtype: "Select",
             options: `\nRoad\nAir\nRail\nShip`,
             default: frm.doc.mode_of_transport || "Road",
-            onchange: () => {
-                update_generation_dialog(d, frm.doc);
-                update_vehicle_type(d);
+            onchange: function () {
+                if (!this.layout) return;
+                update_generation_dialog(this.layout, frm.doc);
+                update_vehicle_type(this.layout);
             },
         },
         {
@@ -486,8 +436,163 @@ function get_generate_e_waybill_dialog(opts, frm, transporter_only = false) {
             depends_on: 'eval:["Road", "Ship"].includes(doc.mode_of_transport)',
             read_only_depends_on: "eval: doc.mode_of_transport == 'Ship'",
             default: frm.doc.gst_vehicle_type || "Regular",
-        }
-    );
+        },
+    ];
+}
+
+function get_bulk_transporter_part_a_fields() {
+    return [
+        {
+            label: "Transporter",
+            fieldname: "transporter",
+            fieldtype: "Link",
+            options: "Supplier",
+            get_query: () => {
+                return {
+                    filters: {
+                        is_transporter: 1,
+                    },
+                };
+            },
+            onchange: function () {
+                if (!this.layout) return;
+                update_gst_tranporter_id(this.layout);
+            },
+        },
+        {
+            label: "Distance (in km)",
+            fieldname: "distance",
+            fieldtype: "Float",
+            default: 0,
+            description:
+                "Set as zero to update distance as per the e-Waybill portal (if available)",
+        },
+        {
+            fieldtype: "Column Break",
+        },
+        {
+            label: "GST Transporter ID",
+            fieldname: "gst_transporter_id",
+            fieldtype: "Data",
+            onchange: function () {
+                if (!this.layout) return;
+                validate_gst_transporter_id(this.layout, {});
+            },
+        },
+    ];
+}
+
+function get_bulk_transporter_part_b_fields() {
+    return [
+        {
+            label: "Vehicle No",
+            fieldname: "vehicle_no",
+            fieldtype: "Data",
+        },
+        {
+            label: "Transport Receipt No",
+            fieldname: "lr_no",
+            fieldtype: "Data",
+        },
+        {
+            label: "Transport Receipt Date",
+            fieldname: "lr_date",
+            fieldtype: "Date",
+            default: "Today",
+            mandatory_depends_on: "eval:doc.lr_no",
+        },
+        {
+            fieldtype: "Column Break",
+        },
+        {
+            label: "Mode Of Transport",
+            fieldname: "mode_of_transport",
+            fieldtype: "Select",
+            options: `\nRoad\nAir\nRail\nShip`,
+            default: "Road",
+            onchange: function () {
+                if (!this.layout) return;
+                update_vehicle_type(this.layout);
+            },
+        },
+        {
+            label: "GST Vehicle Type",
+            fieldname: "gst_vehicle_type",
+            fieldtype: "Select",
+            options: `Regular\nOver Dimensional Cargo (ODC)`,
+            depends_on: 'eval:["Road", "Ship"].includes(doc.mode_of_transport)',
+            read_only_depends_on: "eval: doc.mode_of_transport == 'Ship'",
+            default: "Regular",
+        },
+    ];
+}
+
+function get_document_detail_fields(frm) {
+    const ewaybill_defaults = get_sub_supply_type_options(frm);
+
+    return [
+        {
+            label: "Document Details",
+            fieldname: "section_doc_details",
+            fieldtype: "Section Break",
+        },
+        {
+            label: "Supply Type",
+            fieldname: "supply_type",
+            fieldtype: "Select",
+            read_only: ewaybill_defaults.supply_type.length === 1,
+            default: ewaybill_defaults.supply_type[0],
+            options: ewaybill_defaults.supply_type.join("\n"),
+            reqd: ewaybill_defaults.supply_type.length !== 1,
+            onchange: function () {
+                if (ewaybill_defaults.supply_type.length > 1 && this.layout) {
+                    update_sub_supply_type_options(this.layout, frm);
+                }
+            },
+        },
+        {
+            label: "Document Type",
+            fieldname: "document_type",
+            fieldtype: "Data",
+            read_only: 1,
+            default: ewaybill_defaults.document_type,
+        },
+        {
+            fieldtype: "Column Break",
+        },
+        {
+            label: "Sub Supply Type",
+            fieldname: "sub_supply_type",
+            fieldtype: "Select",
+            options: ewaybill_defaults.sub_supply_type.join("\n"),
+            default: ewaybill_defaults.sub_supply_type[0],
+            read_only: ewaybill_defaults.sub_supply_type.length === 1,
+            reqd: ewaybill_defaults.sub_supply_type.length !== 1,
+        },
+        {
+            label: "Sub Supply Description",
+            fieldname: "sub_supply_desc",
+            fieldtype: "Data",
+            depends_on: "eval: doc.sub_supply_type == 'Others'",
+            mandatory_depends_on: "eval: doc.sub_supply_type == 'Others'",
+            default: ewaybill_defaults.sub_supply_desc,
+        },
+    ];
+}
+
+
+function get_generate_e_waybill_dialog(opts, frm) {
+    if (!frm) frm = { doc: {} };
+
+    let fields = [
+        ...get_document_detail_fields(frm),
+        {
+            label: "Part A",
+            fieldname: "section_part_a",
+            fieldtype: "Section Break",
+        },
+        ...get_transporter_fields(frm),
+    ];
 
     if (
         ["Sales Invoice", "Delivery Note"].includes(frm.doctype) &&
@@ -514,6 +619,27 @@ function get_generate_e_waybill_dialog(opts, frm, transporter_only = false) {
 
     // HACK!
     // To prevent triggering of change event on input twice
+    frappe.ui.form.ControlData.trigger_change_on_input_event = false;
+    const d = new frappe.ui.Dialog(opts);
+    frappe.ui.form.ControlData.trigger_change_on_input_event = true;
+
+    return d;
+}
+
+function get_transporter_update_dialog(opts, frm) {
+    if (!frm) frm = { doc: {} };
+
+    let fields = [
+        {
+            label: "Part A",
+            fieldname: "section_part_a",
+            fieldtype: "Section Break",
+        },
+        ...get_transporter_fields(frm),
+    ];
+
+    opts.fields = fields;
+
     frappe.ui.form.ControlData.trigger_change_on_input_event = false;
     const d = new frappe.ui.Dialog(opts);
     frappe.ui.form.ControlData.trigger_change_on_input_event = true;
@@ -1001,7 +1127,7 @@ function show_update_transporter_dialog(frm) {
                 reqd: 1,
                 default:
                     frm.doc.gst_transporter_id &&
-                    frm.doc.gst_transporter_id.length === 15
+                        frm.doc.gst_transporter_id.length === 15
                         ? frm.doc.gst_transporter_id
                         : "",
                 onchange: () => validate_gst_transporter_id(d, frm.doc),
@@ -1486,12 +1612,12 @@ function show_sandbox_mode_indicator() {
             `
             <div class="sidebar-section ic-sandbox-mode">
                 <p><label class="indicator-pill no-indicator-dot yellow" title="${__(
-                    "Your site has enabled Sandbox Mode in GST Settings."
-                )}">${__("Sandbox Mode")}</label></p>
+                "Your site has enabled Sandbox Mode in GST Settings."
+            )}">${__("Sandbox Mode")}</label></p>
                 <p><a class="small text-muted" href="${frappe.utils.get_form_link(
-                    "GST Settings",
-                    "GST Settings"
-                )}" target="_blank">${__(
+                "GST Settings",
+                "GST Settings"
+            )}" target="_blank">${__(
                 "Sandbox Mode is enabled for GST APIs."
             )}</a></p>
             </div>
@@ -1556,19 +1682,11 @@ function setup_bulk_transporter_update_action(doctype, list_view) {
 }
 
 function setup_bulk_e_waybill_generation_action(doctype, list_view) {
-    if (doctype === "Sales Invoice") {
-        add_bulk_action_for_documents(
-            list_view,
-            __("Enqueue Bulk e-Waybill Generation"),
-            docnames => enqueue_bulk_e_waybill_generation(doctype, docnames)
-        );
-    } else {
-        add_bulk_action_for_documents(
-            list_view,
-            __("Enqueue Bulk e-Waybill Generation"),
-            docnames => show_bulk_generate_e_waybill_dialog(doctype, docnames)
-        );
-    }
+    add_bulk_action_for_documents(
+        list_view,
+        __("Enqueue Bulk e-Waybill Generation"),
+        docnames => show_bulk_generate_e_waybill_dialog(doctype, docnames)
+    );
 }
 
 function setup_bulk_e_waybill_print_action(doctype, list_view) {
@@ -1611,7 +1729,7 @@ async function generate_e_waybill_json(doctype, docnames) {
 
 function show_bulk_update_transporter_dialog(doctype, docnames) {
     const frm = { doctype: doctype, doc: {} };
-    const d = get_generate_e_waybill_dialog(
+    const d = get_transporter_update_dialog(
         {
             title: __("Update Transporter Detail"),
             primary_action_label: __("Update {0}", [doctype]),
@@ -1628,8 +1746,7 @@ function show_bulk_update_transporter_dialog(doctype, docnames) {
                 });
             },
         },
-        frm,
-        true // transporter_only = true
+        frm
     );
 
     d.show();
@@ -1686,20 +1803,54 @@ async function enqueue_bulk_e_invoice_generation(docnames) {
 }
 
 function show_bulk_generate_e_waybill_dialog(doctype, docnames) {
-    const frm = { doctype: doctype, doc: {} };
-    const d = get_generate_e_waybill_dialog(
-        {
-            title: __("Bulk e-Waybill Generation"),
-            primary_action_label: __("Generate e-Waybills"),
-            primary_action(values) {
-                d.hide();
-                enqueue_bulk_e_waybill_generation(doctype, docnames, values);
-            },
+    frappe.ui.form.ControlData.trigger_change_on_input_event = false;
+    const d = new frappe.ui.Dialog({
+        title: __("Bulk e-Waybill Generation"),
+        fields: get_bulk_generate_dialog_fields(doctype),
+        primary_action_label: __("Generate e-Waybills"),
+        primary_action(values) {
+            d.hide();
+            if (!values.update_transporter_details) {
+                values = null;
+            }
+            enqueue_bulk_e_waybill_generation(doctype, docnames, values);
         },
-        frm
-    );
+    });
+    frappe.ui.form.ControlData.trigger_change_on_input_event = true;
 
     d.show();
+}
+
+function get_bulk_generate_dialog_fields(doctype) {
+    const frm = { doctype: doctype, doc: {} };
+    return [
+        ...get_document_detail_fields(frm),
+        {
+            fieldname: "section_transporter_toggle",
+            fieldtype: "Section Break",
+            hide_border: 1,
+        },
+        {
+            label: "Update Transporter Details",
+            fieldname: "update_transporter_details",
+            fieldtype: "Check",
+            default: 0,
+        },
+        {
+            label: "Part A",
+            fieldname: "section_part_a",
+            fieldtype: "Section Break",
+            depends_on: "eval: doc.update_transporter_details",
+        },
+        ...get_bulk_transporter_part_a_fields(),
+        {
+            label: "Part B",
+            fieldname: "section_part_b",
+            fieldtype: "Section Break",
+            depends_on: "eval: doc.update_transporter_details",
+        },
+        ...get_bulk_transporter_part_b_fields(),
+    ];
 }
 
 async function enqueue_bulk_generation(method, args) {

--- a/india_compliance/gst_india/client_scripts/e_waybill_actions.js
+++ b/india_compliance/gst_india/client_scripts/e_waybill_actions.js
@@ -339,6 +339,20 @@ function show_generate_e_waybill_dialog(frm) {
 
 function get_transporter_fields(frm) {
     return [
+        ...get_transporter_part_a_fields(frm),
+        {
+            label: "Part B",
+            fieldname: "section_part_b",
+            fieldtype: "Section Break",
+        },
+        ...get_transporter_part_b_fields(frm),
+    ];
+}
+
+function get_transporter_part_a_fields(frm) {
+    if (!frm) frm = { doc: {} };
+
+    return [
         {
             label: "Transporter",
             fieldname: "transporter",
@@ -381,11 +395,13 @@ function get_transporter_fields(frm) {
                 validate_gst_transporter_id(this.layout, frm.doc);
             },
         },
-        {
-            label: "Part B",
-            fieldname: "section_part_b",
-            fieldtype: "Section Break",
-        },
+    ];
+}
+
+function get_transporter_part_b_fields(frm) {
+    if (!frm) frm = { doc: {} };
+
+    return [
         {
             label: "Vehicle No",
             fieldname: "vehicle_no",
@@ -436,93 +452,6 @@ function get_transporter_fields(frm) {
             depends_on: 'eval:["Road", "Ship"].includes(doc.mode_of_transport)',
             read_only_depends_on: "eval: doc.mode_of_transport == 'Ship'",
             default: frm.doc.gst_vehicle_type || "Regular",
-        },
-    ];
-}
-
-function get_bulk_transporter_part_a_fields() {
-    return [
-        {
-            label: "Transporter",
-            fieldname: "transporter",
-            fieldtype: "Link",
-            options: "Supplier",
-            get_query: () => {
-                return {
-                    filters: {
-                        is_transporter: 1,
-                    },
-                };
-            },
-            onchange: function () {
-                if (!this.layout) return;
-                update_gst_tranporter_id(this.layout);
-            },
-        },
-        {
-            label: "Distance (in km)",
-            fieldname: "distance",
-            fieldtype: "Float",
-            default: 0,
-            description:
-                "Set as zero to update distance as per the e-Waybill portal (if available)",
-        },
-        {
-            fieldtype: "Column Break",
-        },
-        {
-            label: "GST Transporter ID",
-            fieldname: "gst_transporter_id",
-            fieldtype: "Data",
-            onchange: function () {
-                if (!this.layout) return;
-                validate_gst_transporter_id(this.layout, {});
-            },
-        },
-    ];
-}
-
-function get_bulk_transporter_part_b_fields() {
-    return [
-        {
-            label: "Vehicle No",
-            fieldname: "vehicle_no",
-            fieldtype: "Data",
-        },
-        {
-            label: "Transport Receipt No",
-            fieldname: "lr_no",
-            fieldtype: "Data",
-        },
-        {
-            label: "Transport Receipt Date",
-            fieldname: "lr_date",
-            fieldtype: "Date",
-            default: "Today",
-            mandatory_depends_on: "eval:doc.lr_no",
-        },
-        {
-            fieldtype: "Column Break",
-        },
-        {
-            label: "Mode Of Transport",
-            fieldname: "mode_of_transport",
-            fieldtype: "Select",
-            options: `\nRoad\nAir\nRail\nShip`,
-            default: "Road",
-            onchange: function () {
-                if (!this.layout) return;
-                update_vehicle_type(this.layout);
-            },
-        },
-        {
-            label: "GST Vehicle Type",
-            fieldname: "gst_vehicle_type",
-            fieldtype: "Select",
-            options: `Regular\nOver Dimensional Cargo (ODC)`,
-            depends_on: 'eval:["Road", "Ship"].includes(doc.mode_of_transport)',
-            read_only_depends_on: "eval: doc.mode_of_transport == 'Ship'",
-            default: "Regular",
         },
     ];
 }
@@ -1842,14 +1771,14 @@ function get_bulk_generate_dialog_fields(doctype) {
             fieldtype: "Section Break",
             depends_on: "eval: doc.update_transporter_details",
         },
-        ...get_bulk_transporter_part_a_fields(),
+        ...get_transporter_part_a_fields(frm),
         {
             label: "Part B",
             fieldname: "section_part_b",
             fieldtype: "Section Break",
             depends_on: "eval: doc.update_transporter_details",
         },
-        ...get_bulk_transporter_part_b_fields(),
+        ...get_transporter_part_b_fields(frm),
     ];
 }
 

--- a/india_compliance/gst_india/client_scripts/e_waybill_actions.js
+++ b/india_compliance/gst_india/client_scripts/e_waybill_actions.js
@@ -339,17 +339,10 @@ function show_generate_e_waybill_dialog(frm) {
 
 function get_generate_e_waybill_dialog(opts, frm, transporter_only = false) {
     if (!frm) frm = { doc: {} };
-    const is_foreign_transaction =
-        frm.doc.gst_category === "Overseas" &&
-        frm.doc.place_of_supply === "96-Other Countries";
 
     const fields = [];
-
     if (!transporter_only) {
-        const ewaybill_defaults = get_sub_suppy_type_options(
-            frm,
-            is_foreign_transaction
-        );
+        const ewaybill_defaults = get_sub_supply_type_options(frm);
 
         fields.push(
             {
@@ -498,7 +491,7 @@ function get_generate_e_waybill_dialog(opts, frm, transporter_only = false) {
 
     if (
         ["Sales Invoice", "Delivery Note"].includes(frm.doctype) &&
-        is_foreign_transaction
+        is_foreign_transaction(frm)
     ) {
         fields.splice(5, 0, {
             label: "Origin Port / Border Checkpost Address",
@@ -528,7 +521,7 @@ function get_generate_e_waybill_dialog(opts, frm, transporter_only = false) {
     return d;
 }
 
-function get_sub_suppy_type_options(frm, is_foreign_transaction) {
+function get_sub_supply_type_options(frm) {
     let supply_type, sub_supply_type, sub_supply_desc, document_type;
 
     if (frm.doctype === "Delivery Note" && frm?.doc?.company_gstin) {
@@ -558,7 +551,7 @@ function get_sub_suppy_type_options(frm, is_foreign_transaction) {
             }
         }
     } else if (frm.doctype === "Delivery Note") {
-        supply_type = ["Inward", "Outward"];
+        supply_type = ["Outward", "Inward"];
         document_type = "Delivery Challan";
 
         if (frm.doc.is_return === 1) {
@@ -609,7 +602,7 @@ function get_sub_suppy_type_options(frm, is_foreign_transaction) {
     } else if (
         frm.doctype === "Sales Invoice" &&
         frm.doc.is_return === 0 &&
-        is_foreign_transaction
+        is_foreign_transaction(frm)
     ) {
         supply_type = ["Outward"];
         sub_supply_type = ["Export"];
@@ -671,17 +664,20 @@ function update_sub_supply_type_options(dialog, frm) {
     const supply_type = dialog.get_value("supply_type");
     if (!supply_type) return;
 
-    // Create temporary frm object with selected supply type to get correct options
     const temp_frm = {
         ...frm,
-        doc: { ...frm.doc, is_return: supply_type === "Inward" ? 1 : 0 },
+        doc: {
+            ...frm.doc,
+            is_return: supply_type === "Inward" ? 1 : 0,
+        },
     };
-    const options = get_sub_suppy_type_options(temp_frm);
 
+    const options = get_sub_supply_type_options(temp_frm);
+    const sub_supply_options = options?.sub_supply_type || [];
     const sub_supply_field = dialog.get_field("sub_supply_type");
-    sub_supply_field.df.options = options.sub_supply_type.join("\n");
+    sub_supply_field.df.options = sub_supply_options.join("\n");
     sub_supply_field.refresh();
-    dialog.set_value("sub_supply_type", options.sub_supply_type[0]);
+    dialog.set_value("sub_supply_type", sub_supply_options[0]);
 }
 
 function show_fetch_if_generated_dialog(frm) {
@@ -1504,7 +1500,7 @@ function is_e_waybill_enabled(doctype) {
     if (doctype === "Delivery Note") {
         return gst_settings.enable_e_waybill_from_dn;
     }
-    if  (["Purchase Invoice", "Purchase Receipt"].includes(doctype)) {
+    if (["Purchase Invoice", "Purchase Receipt"].includes(doctype)) {
         return gst_settings.enable_e_waybill_from_pi;
     }
     if (["Stock Entry", "Subcontracting Receipt"].includes(doctype)) {

--- a/india_compliance/gst_india/client_scripts/e_waybill_actions.js
+++ b/india_compliance/gst_india/client_scripts/e_waybill_actions.js
@@ -521,6 +521,13 @@ function get_generate_e_waybill_dialog(opts, frm, transporter_only = false) {
     return d;
 }
 
+function is_foreign_transaction(frm) {
+    return (
+        frm.doc?.gst_category === "Overseas" &&
+        frm.doc?.place_of_supply === "96-Other Countries"
+    );
+}
+
 function get_sub_supply_type_options(frm) {
     let supply_type, sub_supply_type, sub_supply_desc, document_type;
 
@@ -556,18 +563,18 @@ function get_sub_supply_type_options(frm) {
 
         if (frm.doc.is_return === 1) {
             sub_supply_type = [
-                "For Own Use",
-                "Exhibition or Fairs",
                 "Job Work Returns",
                 "SKD/CKD",
+                "For Own Use",
+                "Exhibition or Fairs",
                 "Others",
             ];
         } else {
             sub_supply_type = [
-                "For Own Use",
-                "Exhibition or Fairs",
                 "Job Work",
                 "SKD/CKD",
+                "For Own Use",
+                "Exhibition or Fairs",
                 "Line Sales",
                 "Recipient Not Known",
                 "Others",

--- a/india_compliance/gst_india/client_scripts/sales_invoice_list.js
+++ b/india_compliance/gst_india/client_scripts/sales_invoice_list.js
@@ -7,4 +7,5 @@ frappe.listview_settings[DOCTYPE].onload = function (list_view) {
     }
 
     setup_bulk_e_waybill_actions(DOCTYPE, list_view);
+    setup_bulk_e_invoice_actions(DOCTYPE, list_view);
 };

--- a/india_compliance/gst_india/data/test_e_waybill.json
+++ b/india_compliance/gst_india/data/test_e_waybill.json
@@ -1215,7 +1215,7 @@
         "request_data": {
             "userGstin": "05AAACG2115R1ZN",
             "supplyType": "O",
-            "subSupplyType": 4,
+            "subSupplyType": 5,
             "docType": "CHL",
             "docNo": "test_invoice_no",
             "docDate": "19/07/2024",

--- a/india_compliance/gst_india/data/test_e_waybill.json
+++ b/india_compliance/gst_india/data/test_e_waybill.json
@@ -1210,7 +1210,7 @@
             "distance": 0.0,
             "mode_of_transport": "Road",
             "vehicle_no": "GJ07DL9009",
-            "sub_supply_type": "Job Work"
+            "sub_supply_type": "For Own Use"
         },
         "request_data": {
             "userGstin": "05AAACG2115R1ZN",

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -96,15 +96,7 @@ def enqueue_bulk_e_waybill_generation(doctype, docnames, values=None):
     Enqueue bulk generation of e-Waybill for the given documents.
     """
     frappe.has_permission(doctype, "submit", throw=True)
-
-    gst_settings = frappe.get_cached_doc("GST Settings")
-    if not is_api_enabled(gst_settings) or not gst_settings.enable_e_waybill:
-        frappe.throw(_("Please enable e-Waybill in GST Settings first."))
-
-    if doctype == "Delivery Note" and not gst_settings.enable_e_waybill_from_dn:
-        frappe.throw(
-            _("Please enable e-Waybill for Delivery Note in GST Settings first.")
-        )
+    validate_is_e_waybill_api_enabled(doctype)
 
     docnames = frappe.parse_json(docnames) if docnames.startswith("[") else [docnames]
     rq_job = frappe.enqueue(
@@ -1114,6 +1106,35 @@ def get_address_map(doc):
     return out
 
 
+def validate_is_e_waybill_api_enabled(doctype: str, throw: bool = True) -> bool:
+    """Check if e-Waybill is enabled for a specific document type."""
+
+    def _throw(message: str):
+        if throw:
+            frappe.throw(_(message))
+
+    gst_settings = frappe.get_cached_doc("GST Settings")
+    if not is_api_enabled(gst_settings) or not gst_settings.enable_e_waybill:
+        _throw(_("Please enable e-Waybill in GST Settings"))
+        return False
+
+    setting_map = {
+        "Sales Invoice": True,
+        "Delivery Note": gst_settings.enable_e_waybill_for_delivery_note,
+        "Purchase Invoice": gst_settings.enable_e_waybill_for_pi,
+        "Purchase Receipt": gst_settings.enable_e_waybill_for_pi,
+        "Stock Entry": gst_settings.enable_e_waybill_for_sc,
+        "Subcontracting Receipt": gst_settings.enable_e_waybill_for_sc,
+    }
+
+    enabled = setting_map.get(doctype, False)
+
+    if not enabled:
+        _throw(f"Please enable e-Waybill for {doctype} in GST Settings")
+
+    return enabled
+
+
 @frappe.whitelist()
 def get_source_destination_address(doctype, docname, address_type):
     # using load_doc for onload trigger required for stock entry.
@@ -1176,6 +1197,7 @@ class EWaybillData(GSTTransactionData):
         self.set_item_list()
         self.set_transporter_details()
         self.set_party_address_details()
+        self.validate_sub_supply_type()
         self.validate_distance_for_same_pincode()
 
         return self.get_transaction_data()
@@ -1584,8 +1606,6 @@ class EWaybillData(GSTTransactionData):
             default_supply_types.get((doc.doctype, doc.get("is_return") or 0), {})
         )
 
-        self.validate_sub_supply_type()
-
         if is_foreign_doc(self.doc):
             self.transaction_details.update(sub_supply_type=3)  # Export
             if not doc.is_export_with_gst:
@@ -1604,9 +1624,6 @@ class EWaybillData(GSTTransactionData):
             self.transaction_details.name = self.doc.bill_no or self.doc.name
 
     def validate_sub_supply_type(self):
-        """
-        Validate sub supply type for Delivery Note based on GSTIN comparison and business rules.
-        """
         sub_supply_type = self.transaction_details.get("sub_supply_type")
 
         if not sub_supply_type:
@@ -1634,45 +1651,41 @@ class EWaybillData(GSTTransactionData):
                 _("Sub Supply Description is required when Sub Supply Type is 'Others'")
             )
 
-    def _validate_sub_supply_for_same_gstin(self, sub_supply_type):
-        if self.doc.doctype != "Delivery Note":
-            return
-
-        doc = self.doc
-
-        company_gstin = self.doc.company_gstin
-        billing_address_gstin = self.doc.billing_address_gstin
-        same_gstin = billing_address_gstin == company_gstin
-
-        if self.doc.is_return:
-            if same_gstin:
-                allowed_types = ["For Own Use", "Exhibition or Fairs", "Others"]
-            else:
-                allowed_types = ["Job Work Returns", "SKD/CKD", "Others"]
-        else:
-            if same_gstin:
-                allowed_types = [
+    def _get_applicable_sub_supply_types(self, supply_type, same_gstin):
+        type_map = {
+            "Inward": {
+                True: ["For Own Use", "Exhibition or Fairs", "Others"],
+                False: ["Job Work Returns", "SKD/CKD", "Others"],
+            },
+            "Outward": {
+                True: [
                     "For Own Use",
                     "Exhibition or Fairs",
                     "Line Sales",
                     "Recipient Not Known",
                     "Others",
-                ]
-            else:
-                allowed_types = ["Job Work", "SKD/CKD", "Others"]
+                ],
+                False: ["Job Work", "SKD/CKD", "Others"],
+            },
+        }
+        return type_map.get(supply_type, {}).get(same_gstin, [])
+
+    def _validate_sub_supply_for_same_gstin(self, sub_supply_type):
+        same_gstin = self.bill_from.gstin == self.bill_to.gstin
+        supply_type = self.transaction_details.get("supply_type")
+        supply_type = "Inward" if supply_type == "I" else "Outward"
+
+        allowed_types = self._get_applicable_sub_supply_types(supply_type, same_gstin)
 
         if sub_supply_type not in allowed_types:
             gstin_context = "same GSTIN" if same_gstin else "different GSTIN"
-            return_context = "return" if doc.is_return else "outward"
 
             frappe.throw(
                 _(
-                    "Sub Supply Type '{0}' is not allowed for {1} {2} with {3}. "
-                    "Allowed types are: {4}"
+                    "Sub Supply Type '{0}' is not allowed with {1}. "
+                    "Allowed types are: {2}"
                 ).format(
                     sub_supply_type,
-                    self.doc.doctype,
-                    return_context,
                     gstin_context,
                     ", ".join(allowed_types),
                 )

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -128,12 +128,8 @@ def generate_e_waybills(doctype, docnames, force=False, values=None):
         try:
             doc = load_doc(doctype, docname, "submit")
 
-            # Apply values to document if provided (for bulk operations)
             if values:
-                update_transaction(
-                    doc,
-                    frappe.parse_json(values) if isinstance(values, str) else values,
-                )
+                update_transaction(doc, frappe.parse_json(values))
                 send_updated_doc(doc)
 
             _generate_e_waybill(doc, force=force)

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -1119,9 +1119,9 @@ def validate_is_e_waybill_api_enabled(doctype: str, throw: bool = True) -> bool:
 
     setting_map = {
         "Sales Invoice": True,
-        "Delivery Note": gst_settings.enable_e_waybill_for_delivery_note,
-        "Purchase Invoice": gst_settings.enable_e_waybill_for_pi,
-        "Purchase Receipt": gst_settings.enable_e_waybill_for_pi,
+        "Delivery Note": gst_settings.enable_e_waybill_from_dn,
+        "Purchase Invoice": gst_settings.enable_e_waybill_from_pi,
+        "Purchase Receipt": gst_settings.enable_e_waybill_from_pi,
         "Stock Entry": gst_settings.enable_e_waybill_for_sc,
         "Subcontracting Receipt": gst_settings.enable_e_waybill_for_sc,
     }

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -1034,28 +1034,29 @@ def update_e_waybill_log_for_extention(
 
 
 def update_transaction(doc, values):
-    transporter_name = (
-        frappe.db.get_value("Supplier", values.transporter, "supplier_name")
-        if values.transporter
-        else None
-    )
+    if values.get("update_transporter_details", True):
+        transporter_name = (
+            frappe.db.get_value("Supplier", values.transporter, "supplier_name")
+            if values.transporter
+            else None
+        )
 
-    data = {
-        "transporter": values.transporter,
-        "transporter_name": transporter_name,
-        "gst_transporter_id": values.gst_transporter_id,
-        "vehicle_no": values.vehicle_no,
-        "distance": values.distance,
-        "lr_no": values.lr_no,
-        "lr_date": values.lr_date,
-        "mode_of_transport": values.mode_of_transport,
-        "gst_vehicle_type": values.gst_vehicle_type,
-    }
+        data = {
+            "transporter": values.transporter,
+            "transporter_name": transporter_name,
+            "gst_transporter_id": values.gst_transporter_id,
+            "vehicle_no": values.vehicle_no,
+            "distance": values.distance,
+            "lr_no": values.lr_no,
+            "lr_date": values.lr_date,
+            "mode_of_transport": values.mode_of_transport,
+            "gst_vehicle_type": values.gst_vehicle_type,
+        }
 
-    if doc.doctype in ["Sales Invoice", "Delivery Note"]:
-        data["port_address"] = values.port_address
+        if doc.doctype in ["Sales Invoice", "Delivery Note"]:
+            data["port_address"] = values.port_address
 
-    doc.db_set(data)
+        doc.db_set(data)
 
     if doc.doctype in ("Delivery Note", "Stock Entry", "Subcontracting Receipt"):
         doc._sub_supply_type = SUB_SUPPLY_TYPES[values.sub_supply_type]

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -1670,6 +1670,9 @@ class EWaybillData(GSTTransactionData):
         return type_map.get(supply_type, {}).get(same_gstin, [])
 
     def _validate_sub_supply_for_same_gstin(self, sub_supply_type):
+        if sub_supply_type == "Export":
+            return
+
         same_gstin = self.bill_from.gstin == self.bill_to.gstin
         supply_type = self.transaction_details.get("supply_type")
         supply_type = "Inward" if supply_type == "I" else "Outward"

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -1112,7 +1112,7 @@ def validate_is_e_waybill_api_enabled(doctype: str, throw: bool = True) -> bool:
 
     def _throw(message: str):
         if throw:
-            frappe.throw(_(message))
+            frappe.throw(message)
 
     gst_settings = frappe.get_cached_doc("GST Settings")
     if not is_api_enabled(gst_settings) or not gst_settings.enable_e_waybill:

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -111,21 +111,15 @@ def enqueue_bulk_e_waybill_generation(doctype, docnames, values=None):
     return rq_job.id
 
 
-def generate_e_waybills(doctype, docnames, force=False, values=None):
+def generate_e_waybills(doctype, docnames, values=None, force=False):
     """
     Bulk generate e-Waybill for the given documents.
     """
-    if values:
-        values = frappe.parse_json(values)
-
     for docname in docnames:
         try:
-            doc = load_doc(doctype, docname, "submit")
-
-            if values:
-                update_transaction(doc, values)
-
-            _generate_e_waybill(doc, force=force)
+            generate_e_waybill(
+                doctype=doctype, docname=docname, values=values, force=force, throw=True
+            )
         except Exception:
             frappe.log_error(
                 title=_("e-Waybill generation failed for {0} {1}").format(
@@ -141,12 +135,14 @@ def generate_e_waybills(doctype, docnames, force=False, values=None):
 
 
 @frappe.whitelist()
-def generate_e_waybill(*, doctype, docname, values=None, force: bool = False):
+def generate_e_waybill(
+    *, doctype, docname, values=None, force: bool = False, throw: bool = False
+):
     doc = load_doc(doctype, docname, "submit")
     if values:
         update_transaction(doc, frappe.parse_json(values))
 
-    _generate_e_waybill(doc, throw=True if values else False, force=force)
+    _generate_e_waybill(doc, throw=throw, force=force)
 
 
 def _generate_e_waybill(doc, throw=True, force=False):

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -1129,7 +1129,7 @@ def validate_is_e_waybill_api_enabled(doctype: str, throw: bool = True) -> bool:
     enabled = setting_map.get(doctype, False)
 
     if not enabled:
-        _throw(f"Please enable e-Waybill for {doctype} in GST Settings")
+        _throw(_("Please enable e-Waybill for {0} in GST Settings").format(doctype))
 
     return enabled
 

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -122,7 +122,6 @@ def generate_e_waybills(doctype, docnames, force=False, values=None):
 
             if values:
                 update_transaction(doc, frappe.parse_json(values))
-                send_updated_doc(doc)
 
             _generate_e_waybill(doc, force=force)
         except Exception:

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -115,13 +115,15 @@ def generate_e_waybills(doctype, docnames, force=False, values=None):
     """
     Bulk generate e-Waybill for the given documents.
     """
+    if values:
+        values = frappe.parse_json(values)
 
     for docname in docnames:
         try:
             doc = load_doc(doctype, docname, "submit")
 
             if values:
-                update_transaction(doc, frappe.parse_json(values))
+                update_transaction(doc, values)
 
             _generate_e_waybill(doc, force=force)
         except Exception:
@@ -1639,6 +1641,13 @@ class EWaybillData(GSTTransactionData):
             (k for k, v in SUB_SUPPLY_TYPES.items() if v == sub_supply_type),
             None,
         )
+
+        if not sub_supply_type:
+            frappe.throw(
+                _("Invalid Sub Supply Type: {0}").format(
+                    self.transaction_details.get("sub_supply_type")
+                )
+            )
 
         self._validate_sub_supply_description(sub_supply_type)
         self._validate_sub_supply_for_same_gstin(sub_supply_type)

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -91,7 +91,7 @@ def bulk_update_transporter_in_docs(doctype, docnames, values):
 
 
 @frappe.whitelist()
-def enqueue_bulk_e_waybill_generation(doctype, docnames):
+def enqueue_bulk_e_waybill_generation(doctype, docnames, values=None):
     """
     Enqueue bulk generation of e-Waybill for the given documents.
     """
@@ -101,6 +101,11 @@ def enqueue_bulk_e_waybill_generation(doctype, docnames):
     if not is_api_enabled(gst_settings) or not gst_settings.enable_e_waybill:
         frappe.throw(_("Please enable e-Waybill in GST Settings first."))
 
+    if doctype == "Delivery Note" and not gst_settings.enable_e_waybill_from_dn:
+        frappe.throw(
+            _("Please enable e-Waybill for Delivery Note in GST Settings first.")
+        )
+
     docnames = frappe.parse_json(docnames) if docnames.startswith("[") else [docnames]
     rq_job = frappe.enqueue(
         "india_compliance.gst_india.utils.e_waybill.generate_e_waybills",
@@ -108,12 +113,13 @@ def enqueue_bulk_e_waybill_generation(doctype, docnames):
         timeout=len(docnames) * 240,  # 4 mins per e-Waybill
         doctype=doctype,
         docnames=docnames,
+        values=values,
     )
 
     return rq_job.id
 
 
-def generate_e_waybills(doctype, docnames, force=False):
+def generate_e_waybills(doctype, docnames, force=False, values=None):
     """
     Bulk generate e-Waybill for the given documents.
     """
@@ -121,6 +127,15 @@ def generate_e_waybills(doctype, docnames, force=False):
     for docname in docnames:
         try:
             doc = load_doc(doctype, docname, "submit")
+
+            # Apply values to document if provided (for bulk operations)
+            if values:
+                update_transaction(
+                    doc,
+                    frappe.parse_json(values) if isinstance(values, str) else values,
+                )
+                send_updated_doc(doc)
+
             _generate_e_waybill(doc, force=force)
         except Exception:
             frappe.log_error(
@@ -1573,6 +1588,8 @@ class EWaybillData(GSTTransactionData):
             default_supply_types.get((doc.doctype, doc.get("is_return") or 0), {})
         )
 
+        self.validate_sub_supply_type()
+
         if is_foreign_doc(self.doc):
             self.transaction_details.update(sub_supply_type=3)  # Export
             if not doc.is_export_with_gst:
@@ -1589,6 +1606,81 @@ class EWaybillData(GSTTransactionData):
 
         if self.doc.doctype == "Purchase Invoice" and not self.doc.is_return:
             self.transaction_details.name = self.doc.bill_no or self.doc.name
+
+    def validate_sub_supply_type(self):
+        """
+        Validate sub supply type for Delivery Note based on GSTIN comparison and business rules.
+        """
+        sub_supply_type = self.transaction_details.get("sub_supply_type")
+
+        if not sub_supply_type:
+            frappe.throw(_("Sub Supply Type is required for generating e-Waybill"))
+
+        if self.doc.doctype not in (
+            "Delivery Note",
+            "Stock Entry",
+            "Subcontracting Receipt",
+        ):
+            return
+
+        sub_supply_type = next(
+            (k for k, v in SUB_SUPPLY_TYPES.items() if v == sub_supply_type),
+            None,
+        )
+
+        self._validate_sub_supply_description(sub_supply_type)
+        self._validate_sub_supply_for_same_gstin(sub_supply_type)
+
+    def _validate_sub_supply_description(self, sub_supply_type):
+        description = self.transaction_details.get("sub_supply_desc")
+        if sub_supply_type == "Others" and not description:
+            frappe.throw(
+                _("Sub Supply Description is required when Sub Supply Type is 'Others'")
+            )
+
+    def _validate_sub_supply_for_same_gstin(self, sub_supply_type):
+        if self.doc.doctype != "Delivery Note":
+            return
+
+        doc = self.doc
+
+        company_gstin = self.doc.company_gstin
+        billing_address_gstin = self.doc.billing_address_gstin
+        same_gstin = billing_address_gstin == company_gstin
+
+        if self.doc.is_return:
+            if same_gstin:
+                allowed_types = ["For Own Use", "Exhibition or Fairs", "Others"]
+            else:
+                allowed_types = ["Job Work Returns", "SKD/CKD", "Others"]
+        else:
+            if same_gstin:
+                allowed_types = [
+                    "For Own Use",
+                    "Exhibition or Fairs",
+                    "Line Sales",
+                    "Recipient Not Known",
+                    "Others",
+                ]
+            else:
+                allowed_types = ["Job Work", "SKD/CKD", "Others"]
+
+        if sub_supply_type not in allowed_types:
+            gstin_context = "same GSTIN" if same_gstin else "different GSTIN"
+            return_context = "return" if doc.is_return else "outward"
+
+            frappe.throw(
+                _(
+                    "Sub Supply Type '{0}' is not allowed for {1} {2} with {3}. "
+                    "Allowed types are: {4}"
+                ).format(
+                    sub_supply_type,
+                    self.doc.doctype,
+                    return_context,
+                    gstin_context,
+                    ", ".join(allowed_types),
+                )
+            )
 
     def set_party_address_details(self):
         self.set_address_gstin_map()

--- a/india_compliance/gst_india/utils/test_e_waybill.py
+++ b/india_compliance/gst_india/utils/test_e_waybill.py
@@ -979,6 +979,29 @@ class TestEWaybill(IntegrationTestCase):
             purchase_order,
         )
 
+    def test_validate_sub_supply_type_for_same_gstin(self):
+        """Test sub supply type validation for same GSTIN scenarios"""
+        dn = create_transaction(
+            doctype="Delivery Note",
+            company_gstin="05AAACG2115R1ZN",
+            billing_address_gstin="05AAACG2115R1ZN",
+            do_not_submit=True,
+        )
+
+        # Test invalid sub supply type "Job Work" for same GSTIN outward supply
+        ewaybill_data = EWaybillData(dn)
+        ewaybill_data.transaction_details = frappe._dict(
+            {"supply_type": "O", "sub_supply_type": "Job Work"}  # Outward
+        )
+        ewaybill_data.bill_from = frappe._dict({"gstin": "05AAACG2115R1ZN"})
+        ewaybill_data.bill_to = frappe._dict({"gstin": "05AAACG2115R1ZN"})
+
+        self.assertRaisesRegex(
+            frappe.exceptions.ValidationError,
+            re.compile(r"Sub Supply Type .* is not allowed with.*same GSTIN"),
+            ewaybill_data.validate_sub_supply_type,
+        )
+
     @responses.activate
     def test_invoice_update_after_submit(self):
         si = self.create_sales_invoice_for("goods_item_with_ewaybill")

--- a/india_compliance/gst_india/utils/test_e_waybill.py
+++ b/india_compliance/gst_india/utils/test_e_waybill.py
@@ -991,7 +991,7 @@ class TestEWaybill(IntegrationTestCase):
         # Test invalid sub supply type "Job Work" for same GSTIN outward supply
         ewaybill_data = EWaybillData(dn)
         ewaybill_data.transaction_details = frappe._dict(
-            {"supply_type": "O", "sub_supply_type": "Job Work"}  # Outward
+            {"supply_type": "O", "sub_supply_type": 4}  # Outward - Job Work
         )
         ewaybill_data.bill_from = frappe._dict({"gstin": "05AAACG2115R1ZN"})
         ewaybill_data.bill_to = frappe._dict({"gstin": "05AAACG2115R1ZN"})

--- a/india_compliance/hooks.py
+++ b/india_compliance/hooks.py
@@ -112,7 +112,12 @@ doctype_list_js = {
         "gst_india/client_scripts/e_waybill_applicability.js",
         "gst_india/client_scripts/e_waybill_actions.js",
         "gst_india/client_scripts/sales_invoice_list.js",
-    ]
+    ],
+    "Delivery Note": [
+        "gst_india/client_scripts/e_waybill_applicability.js",
+        "gst_india/client_scripts/e_waybill_actions.js",
+        "gst_india/client_scripts/delivery_note_list.js",
+    ],
 }
 
 doc_events = {

--- a/india_compliance/hooks.py
+++ b/india_compliance/hooks.py
@@ -109,11 +109,14 @@ doctype_js = {
 
 doctype_list_js = {
     "Sales Invoice": [
+        "gst_india/client_scripts/bulk_actions_utils.js",
         "gst_india/client_scripts/e_waybill_applicability.js",
         "gst_india/client_scripts/e_waybill_actions.js",
+        "gst_india/client_scripts/e_invoice_actions.js",
         "gst_india/client_scripts/sales_invoice_list.js",
     ],
     "Delivery Note": [
+        "gst_india/client_scripts/bulk_actions_utils.js",
         "gst_india/client_scripts/e_waybill_applicability.js",
         "gst_india/client_scripts/e_waybill_actions.js",
         "gst_india/client_scripts/delivery_note_list.js",


### PR DESCRIPTION
- Bulk e-Waybill Options in Delivery Note
- Minor Refactor to avoid duplication.
- Added Sub Supply Type Validation
- Allow updating transporter values in bulk e-Waybill dialog

## TODOs

- [ ] Refactor sub-supply type

no-docs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized bulk e‑Waybill/e‑Invoice actions (generate, print, export JSON), bulk transporter updates and job‑tracking UI for Sales Invoices and Delivery Notes; Delivery Note list view now exposes these bulk actions.
  * Modular transporter/document dialogs and dynamic sub‑supply option UI; ability to pass optional per‑document values when enqueueing bulk generation.

* **Bug Fixes**
  * Stricter sub‑supply type validation with GSTIN‑aware rules and improved error handling.

* **Tests**
  * Added unit test covering sub‑supply validation when GSTINs are identical.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->