### PR TITLE
fix: disable PAN status verification feature

### DIFF
--- a/india_compliance/gst_india/client_scripts/company.js
+++ b/india_compliance/gst_india/client_scripts/company.js
@@ -5,7 +5,7 @@ validate_gstin(DOCTYPE);
 update_gstin_in_other_documents(DOCTYPE);
 show_overseas_disabled_warning(DOCTYPE);
 set_gstin_options_and_status(DOCTYPE);
-set_pan_status(DOCTYPE)
+// set_pan_status(DOCTYPE)
 
 frappe.ui.form.off(DOCTYPE, "make_default_tax_template");
 frappe.ui.form.on(DOCTYPE, {

--- a/india_compliance/gst_india/client_scripts/customer.js
+++ b/india_compliance/gst_india/client_scripts/customer.js
@@ -6,4 +6,4 @@ update_gstin_in_other_documents(DOCTYPE);
 show_overseas_disabled_warning(DOCTYPE);
 set_gstin_options_and_status(DOCTYPE);
 set_gst_category(DOCTYPE);
-set_pan_status(DOCTYPE);
+// set_pan_status(DOCTYPE);

--- a/india_compliance/gst_india/client_scripts/party.js
+++ b/india_compliance/gst_india/client_scripts/party.js
@@ -71,9 +71,9 @@ function validate_gstin(doctype) {
                 frm.doc.pan = pan;
                 frm.refresh_field("pan");
                 set_party_type(frm);
-                if (doctype != "Address") {
-                    india_compliance.set_pan_status(frm.get_field("pan"));
-                }
+                // if (doctype != "Address") {
+                //     india_compliance.set_pan_status(frm.get_field("pan"));
+                // }
             }
         },
     });
@@ -125,16 +125,16 @@ function set_gstin_options_and_status(doctype) {
     });
 }
 
-function set_pan_status(doctype) {
-    frappe.ui.form.on(doctype, {
-        refresh(frm) {
-            india_compliance.set_pan_status(frm.get_field("pan"));
-        },
-        pan(frm) {
-            india_compliance.set_pan_status(frm.get_field("pan"));
-        },
-    });
-}
+// function set_pan_status(doctype) {
+//     frappe.ui.form.on(doctype, {
+//         refresh(frm) {
+//             india_compliance.set_pan_status(frm.get_field("pan"));
+//         },
+//         pan(frm) {
+//             india_compliance.set_pan_status(frm.get_field("pan"));
+//         },
+//     });
+// }
 
 async function set_gstin_options(frm) {
     if (frm.is_new() || frm._gstin_options_set_for === frm.doc.name) return;

--- a/india_compliance/gst_india/client_scripts/supplier.js
+++ b/india_compliance/gst_india/client_scripts/supplier.js
@@ -6,7 +6,7 @@ update_gstin_in_other_documents(DOCTYPE);
 show_overseas_disabled_warning(DOCTYPE);
 set_gstin_options_and_status(DOCTYPE);
 set_gst_category(DOCTYPE);
-set_pan_status(DOCTYPE)
+// set_pan_status(DOCTYPE)
 
 frappe.ui.form.on(DOCTYPE, {
     gstin(frm) {

--- a/india_compliance/gst_india/doctype/pan/pan.js
+++ b/india_compliance/gst_india/doctype/pan/pan.js
@@ -5,8 +5,8 @@ frappe.ui.form.on("PAN", {
     refresh(frm) {
         frm.disable_form();
 
-        frm.add_custom_button(__("Refresh PAN Status"), () => {
-            frm.call("update_pan_status");
-        });
+        // frm.add_custom_button(__("Refresh PAN Status"), () => {
+        //     frm.call("update_pan_status");
+        // });
     },
 });

--- a/india_compliance/gst_india/doctype/pan/pan.py
+++ b/india_compliance/gst_india/doctype/pan/pan.py
@@ -111,6 +111,9 @@ def fetch_pan_status(pan, throw=False):
     Use random generated aadhaar number to ensure request is not blocked
     """
 
+    # Feature disabled - unofficial API no longer reliable
+    return
+
     url = "https://eportal.incometax.gov.in/iec/servicesapi/getEntity"
 
     try:


### PR DESCRIPTION
Temporarily disabled PAN status check as the unofficial API is unreliable due to government-imposed rate limits. All code is preserved for future integration with any other API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Disabled PAN status updates across company, supplier, and customer forms.
  * Removed "Refresh PAN Status" button and automatic status refresh functionality from related workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->