### PR TITLE
fix: multiple fixes in ci; make tests compatible with python version 3.14

### DIFF
--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -126,8 +126,6 @@ jobs:
 
     coverage:
         name: Coverage Wrap Up
-        env:
-          CODECOV_TOKEN: ${{ secrets.codecov_token || secrets.CODECOV_TOKEN }}
         needs: tests
         runs-on: ubuntu-latest
         steps:
@@ -138,9 +136,9 @@ jobs:
           uses: actions/download-artifact@v7
 
         - name: Upload coverage data
-          if: env.CODECOV_TOKEN != ''
           uses: codecov/codecov-action@v5
           with:
             name: MariaDB
             fail_ci_if_error: true
             verbose: true
+            token: ${{ secrets.codecov_token || secrets.CODECOV_TOKEN }}

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -126,6 +126,7 @@ jobs:
 
     coverage:
         name: Coverage Wrap Up
+        if: github.event_name == 'push'
         needs: tests
         runs-on: ubuntu-latest
         steps:

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -130,6 +130,14 @@ jobs:
         needs: tests
         runs-on: ubuntu-latest
         steps:
+        - name: Check for Codecov Token
+          shell: bash
+          run: |
+            if [ -z "$CODECOV_TOKEN" ]; then
+              echo "::error::CODECOV_TOKEN is missing!"
+              exit 1
+            fi
+
         - name: Clone
           uses: actions/checkout@v6
 

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -12,6 +12,7 @@ on:
       secrets:
         codecov_token:
 
+
     pull_request:
         paths-ignore:
             - "**.css"
@@ -126,18 +127,10 @@ jobs:
     coverage:
         name: Coverage Wrap Up
         env:
-            CODECOV_TOKEN: ${{ secrets.codecov_token || secrets.CODECOV_TOKEN }}
+          CODECOV_TOKEN: ${{ secrets.codecov_token || secrets.CODECOV_TOKEN }}
         needs: tests
         runs-on: ubuntu-latest
         steps:
-        - name: Check for Codecov Token
-          shell: bash
-          run: |
-            if [ -z "$CODECOV_TOKEN" ]; then
-              echo "::error::CODECOV_TOKEN is missing!"
-              exit 1
-            fi
-
         - name: Clone
           uses: actions/checkout@v6
 
@@ -145,10 +138,8 @@ jobs:
           uses: actions/download-artifact@v7
 
         - name: Upload coverage data
-          if: github.event.repository.name == 'india-compliance' || env.CODECOV_TOKEN != ''
+          if: env.CODECOV_TOKEN != ''
           uses: codecov/codecov-action@v5
-          env:
-            CODECOV_TOKEN: ${{ env.CODECOV_TOKEN }}
           with:
             name: MariaDB
             fail_ci_if_error: true

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -125,7 +125,8 @@ jobs:
 
     coverage:
         name: Coverage Wrap Up
-        if: secrets.CODECOV_TOKEN != ''
+        env:
+            CODECOV_TOKEN: ${{ secrets.codecov_token || secrets.CODECOV_TOKEN }}
         needs: tests
         runs-on: ubuntu-latest
         steps:
@@ -136,9 +137,11 @@ jobs:
           uses: actions/download-artifact@v7
 
         - name: Upload coverage data
+          if: github.event.repository.name == 'india-compliance' || env.CODECOV_TOKEN != ''
           uses: codecov/codecov-action@v5
+          env:
+            CODECOV_TOKEN: ${{ env.CODECOV_TOKEN }}
           with:
             name: MariaDB
             fail_ci_if_error: true
             verbose: true
-            token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -44,7 +44,7 @@ jobs:
 
         services:
             mariadb:
-                image: mariadb:10.6
+                image: mariadb:11.8
                 env:
                     MARIADB_ROOT_PASSWORD: 'travis'
                 ports:
@@ -58,12 +58,12 @@ jobs:
             - name: Setup Python
               uses: actions/setup-python@v6
               with:
-                  python-version: "3.11"
+                  python-version: "3.14"
 
             - name: Setup Node
               uses: actions/setup-node@v6
               with:
-                  node-version: 20
+                  node-version: 24
                   check-latest: true
 
             - name: Add to Hosts

--- a/india_compliance/gst_india/utils/gstr_1/gstr_1_json_map.py
+++ b/india_compliance/gst_india/utils/gstr_1/gstr_1_json_map.py
@@ -2308,9 +2308,8 @@ class BooksDataMapper:
 
                     invoice[key] = flt(invoice[key], self.PRECISION)
 
-                doc_value = flt(
-                    sum([invoice.get(field, 0) for field in tax_fields]), self.PRECISION
-                )
+                doc_value = sum([invoice.get(field, 0) for field in tax_fields])
+
                 invoice[inv_f.DOC_VALUE] = flt(doc_value, self.PRECISION)
 
             if hasattr(self, "invoice_totals"):

--- a/india_compliance/gst_india/utils/gstr_1/gstr_1_json_map.py
+++ b/india_compliance/gst_india/utils/gstr_1/gstr_1_json_map.py
@@ -763,7 +763,7 @@ class NilRated(GSTR1DataMapper):
         if all(amount == 0 for amount in amounts):
             return
 
-        invoice_data[inv_f.TAXABLE_VALUE] = sum(amounts)
+        invoice_data[inv_f.TAXABLE_VALUE] = flt(sum(amounts), 2)
         return invoice_data
 
     # value formatters
@@ -1254,14 +1254,17 @@ class HSNSUM(GSTR1DataMapper):
         if for_gov:
             return data
 
-        data[inv_f.DOC_VALUE] = sum(
-            (
-                data.get(inv_f.TAXABLE_VALUE, 0),
-                data.get(inv_f.IGST, 0),
-                data.get(inv_f.CGST, 0),
-                data.get(inv_f.SGST, 0),
-                data.get(inv_f.CESS, 0),
-            )
+        data[inv_f.DOC_VALUE] = flt(
+            sum(
+                (
+                    data.get(inv_f.TAXABLE_VALUE, 0),
+                    data.get(inv_f.IGST, 0),
+                    data.get(inv_f.CGST, 0),
+                    data.get(inv_f.SGST, 0),
+                    data.get(inv_f.CESS, 0),
+                )
+            ),
+            2,
         )
 
         if (message := data.get(inv_f.ERROR_MSG, "").strip()) and (
@@ -2305,7 +2308,9 @@ class BooksDataMapper:
 
                     invoice[key] = flt(invoice[key], self.PRECISION)
 
-                doc_value = sum([invoice.get(field, 0) for field in tax_fields])
+                doc_value = flt(
+                    sum([invoice.get(field, 0) for field in tax_fields]), self.PRECISION
+                )
                 invoice[inv_f.DOC_VALUE] = flt(doc_value, self.PRECISION)
 
             if hasattr(self, "invoice_totals"):

--- a/india_compliance/gst_india/utils/test_e_waybill.py
+++ b/india_compliance/gst_india/utils/test_e_waybill.py
@@ -81,10 +81,8 @@ class TestEWaybill(IntegrationTestCase):
             "request_data"
         )
 
-        self.assertDictContainsSubset(
-            e_waybill_data,
-            test_data,
-        )
+        for key, value in e_waybill_data.items():
+            self.assertEqual(test_data.get(key), value, f"Mismatch for key '{key}'")
 
     @change_settings("GST Settings", {"fetch_e_waybill_data": 1})
     @responses.activate
@@ -1126,10 +1124,10 @@ class TestEWaybill(IntegrationTestCase):
         purchase_invoice.submit()
 
         #  Test get_data
-        self.assertDictContainsSubset(
-            EWaybillData(purchase_invoice).get_data(),
-            purchase_invoice_data.get("request_data"),
-        )
+        e_waybill_data = EWaybillData(purchase_invoice).get_data()
+        test_data = purchase_invoice_data.get("request_data")
+        for key, value in e_waybill_data.items():
+            self.assertEqual(test_data.get(key), value, f"Mismatch for key '{key}'")
 
         self._generate_e_waybill(
             purchase_invoice.name, "Purchase Invoice", purchase_invoice_data

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,4 +28,4 @@ sections = ["FUTURE", "STDLIB", "THIRDPARTY", "FRAPPE", "ERPNEXT", "FIRSTPARTY",
 
 [tool.bench.dev-dependencies]
 parameterized = "~=0.8.1"
-time-machine = "~=2.10.0"
+time-machine = "~=3.2.0"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded CI runtimes (MariaDB 11.8, Python 3.14, Node 24), expanded CI path-ignore patterns, changed coverage job to run on push, and improved coverage token handling.
  * Bumped a development testing dependency to a newer minor version.

* **Bug Fixes**
  * Standardized rounding of tax and document values to two-decimal precision for consistent output.

* **Tests**
  * Tightened e-waybill tests to compare generated and expected values key-by-key.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->