### PR TITLE
fix: Update Company GSTIN custom field to fetch from billing address.

### DIFF
--- a/india_compliance/gst_india/constants/custom_fields.py
+++ b/india_compliance/gst_india/constants/custom_fields.py
@@ -116,7 +116,7 @@ CUSTOM_FIELDS = {
             "label": "Company GSTIN",
             "fieldtype": "Data",
             "insert_after": "billing_address_display",
-            "fetch_from": "company.gstin",
+            "fetch_from": "billing_address.gstin",
             "print_hide": 1,
             "read_only": 1,
             "translatable": 0,

--- a/india_compliance/patches.txt
+++ b/india_compliance/patches.txt
@@ -4,7 +4,7 @@ india_compliance.patches.v15.remove_duplicate_web_template
 
 [post_model_sync]
 india_compliance.patches.v14.set_default_for_overridden_accounts_setting
-execute:from india_compliance.gst_india.setup import create_custom_fields; create_custom_fields() #66
+execute:from india_compliance.gst_india.setup import create_custom_fields; create_custom_fields() #67
 execute:from india_compliance.gst_india.setup import create_property_setters; create_property_setters() #11
 execute:from india_compliance.income_tax_india.setup import create_custom_fields; create_custom_fields() #4
 india_compliance.patches.post_install.remove_old_fields #2


### PR DESCRIPTION
Issue: Billing GSTIN was being fetched from the company instead of the billing address.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Company GSTIN data source in Subcontracting mappings to fetch from the billing address instead of company record, ensuring accurate tax identification retrieval.

* **Chores**
  * Minor documentation update in patch configuration files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->