### PR TITLE
fix: add validation for company, GSTIN, and period in IMS

### DIFF
--- a/india_compliance/gst_india/doctype/gst_invoice_management_system/gst_invoice_management_system.js
+++ b/india_compliance/gst_india/doctype/gst_invoice_management_system/gst_invoice_management_system.js
@@ -619,6 +619,20 @@ class IMSAction {
         this.frm = frm;
     }
 
+    validate_filters() {
+        if (!this.frm.doc.company) {
+            frappe.throw(__("Please select Company."));
+        }
+
+        if (!this.frm.doc.company_gstin) {
+            frappe.throw(__("Please select Company GSTIN."));
+        }
+
+        if (!this.frm.doc.period) {
+            frappe.throw(__("Please select Period."));
+        }
+    }
+
     setup_actions() {
         this.setup_document_actions();
         this.setup_row_actions();
@@ -684,6 +698,8 @@ class IMSAction {
     }
 
     async download_ims_data() {
+        this.validate_filters();
+
         const { message } = await taxpayer_api.call({
             method: `${DOC_PATH}.download_invoices`,
             args: { company_gstin: this.frm.doc.company_gstin },
@@ -702,6 +718,8 @@ class IMSAction {
     }
 
     async get_ims_data() {
+        this.validate_filters();
+
         const { message } = await this.frm.call("autoreconcile_and_get_data");
         this.frm.__invoice_data = message.invoice_data;
 
@@ -719,6 +737,8 @@ class IMSAction {
     }
 
     async upload_ims_data() {
+        this.validate_filters();
+
         if (!this.filter_invoices_to_upload().length) {
             frappe.msgprint({
                 title: __("No Data Found"),
@@ -837,6 +857,8 @@ class IMSAction {
     }
 
     async export_data() {
+        this.validate_filters();
+
         if (!this.frm.reconciliation_tabs.filtered_data) {
             await this.frm.ims_actions.get_ims_data();
         }


### PR DESCRIPTION
closes: https://github.com/resilient-tech/india-compliance/issues/3862
### Traceback
```
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 120, in application
    response = frappe.api.handle(request)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/api/__init__.py", line 52, in handle
    data = endpoint(**arguments)
           ^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/api/v1.py", line 40, in handle_rpc_call
    return frappe.handler.handle()
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/handler.py", line 53, in handle
    data = execute_cmd(cmd)
           ^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/handler.py", line 86, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/__init__.py", line 1754, in call
    return fn(*args, **newargs)
           ^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/utils/typing_validations.py", line 32, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "apps/india_compliance/india_compliance/gst_india/api_classes/taxpayer_base.py", line 42, in wrapper
    raise e
  File "apps/india_compliance/india_compliance/gst_india/api_classes/taxpayer_base.py", line 33, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
TypeError: download_invoices() missing 1 required positional argument: 'company_gstin'

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for required fields (company, GSTIN, and period) before executing GST invoice management operations, preventing invalid data downloads, retrievals, uploads, and exports.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->