### PR TITLE
fix: update `valid_upto` when fetching the e-Waybill; add `Fetch Latest` button;

### DIFF
--- a/india_compliance/gst_india/client_scripts/e_waybill_actions.js
+++ b/india_compliance/gst_india/client_scripts/e_waybill_actions.js
@@ -155,6 +155,14 @@ function setup_e_waybill_actions(doctype) {
                     () => fetch_e_waybill_data(frm, { attach: 1 }, () => frm.refresh()),
                     "e-Waybill"
                 );
+
+                frm.add_custom_button(
+                    __("Fetch Latest"),
+                    () => fetch_e_waybill_data(frm, { force: true }, () => {
+                        frappe.show_alert(__('Latest e-Waybill fetched successfully'));
+                    }),
+                    "e-Waybill"
+                );
             }
 
             if (frappe.perm.has_perm(frm.doctype, 0, "cancel", frm.doc.name)) {

--- a/india_compliance/gst_india/client_scripts/e_waybill_actions.js
+++ b/india_compliance/gst_india/client_scripts/e_waybill_actions.js
@@ -157,10 +157,13 @@ function setup_e_waybill_actions(doctype) {
                 );
 
                 frm.add_custom_button(
-                    __("Fetch Latest"),
-                    () => fetch_e_waybill_data(frm, { force: true }, () => {
-                        frappe.show_alert(__('Latest e-Waybill fetched successfully'));
-                    }),
+                    __("Fetch Latest Data"),
+                    () =>
+                        fetch_e_waybill_data(frm, { force: true }, () => {
+                            frappe.show_alert(
+                                __("Latest e-Waybill data fetched successfully")
+                            );
+                        }),
                     "e-Waybill"
                 );
             }

--- a/india_compliance/gst_india/doctype/e_waybill_log/e_waybill_log.js
+++ b/india_compliance/gst_india/doctype/e_waybill_log/e_waybill_log.js
@@ -4,9 +4,13 @@
 frappe.ui.form.on("e-Waybill Log", {
     refresh: function (frm) {
         frm.add_custom_button(__("Fetch Latest"), () =>
-            fetch_e_waybill_data(frm, { force: true }, () => {
-                frm.refresh();
-                frappe.show_alert(__("Latest e-Waybill fetched successfully"));
+            frappe.call({
+                method: "india_compliance.gst_india.utils.e_waybill.fetch_e_waybill_data",
+                args: { doctype: frm.doctype, docname: frm.doc.name, force: true },
+                callback: () => {
+                    frm.refresh();
+                    frappe.show_alert(__("Latest e-Waybill fetched successfully"));
+                },
             })
         );
     },

--- a/india_compliance/gst_india/doctype/e_waybill_log/e_waybill_log.js
+++ b/india_compliance/gst_india/doctype/e_waybill_log/e_waybill_log.js
@@ -3,19 +3,19 @@
 
 frappe.ui.form.on("e-Waybill Log", {
     refresh: function (frm) {
-        frm.add_custom_button(__("Fetch Latest"), () =>
+        frm.add_custom_button(__("Fetch Latest Data"), () =>
             frappe.call({
                 method: "india_compliance.gst_india.utils.e_waybill.fetch_e_waybill_data",
-                args: { doctype: frm.doctype, docname: frm.doc.name, force: true },
+                args: {
+                    doctype: frm.doc.reference_doctype,
+                    docname: frm.doc.reference_name,
+                    force: true,
+                },
                 freeze: true,
                 freeze_message: __("Fetching latest e-Waybill data..."),
                 callback: () => {
                     frm.refresh();
-                    frappe.show_alert(__("Latest e-Waybill fetched successfully"));
-                },
-                error: error => {
-                    console.error(error);
-                    frappe.show_alert(__("Failed to fetch latest e-Waybill data"));
+                    frappe.show_alert(__("Latest e-Waybill data fetched successfully"));
                 },
             })
         );

--- a/india_compliance/gst_india/doctype/e_waybill_log/e_waybill_log.js
+++ b/india_compliance/gst_india/doctype/e_waybill_log/e_waybill_log.js
@@ -7,9 +7,15 @@ frappe.ui.form.on("e-Waybill Log", {
             frappe.call({
                 method: "india_compliance.gst_india.utils.e_waybill.fetch_e_waybill_data",
                 args: { doctype: frm.doctype, docname: frm.doc.name, force: true },
+                freeze: true,
+                freeze_message: __("Fetching latest e-Waybill data..."),
                 callback: () => {
                     frm.refresh();
                     frappe.show_alert(__("Latest e-Waybill fetched successfully"));
+                },
+                error: error => {
+                    console.error(error);
+                    frappe.show_alert(__("Failed to fetch latest e-Waybill data"));
                 },
             })
         );

--- a/india_compliance/gst_india/doctype/e_waybill_log/e_waybill_log.js
+++ b/india_compliance/gst_india/doctype/e_waybill_log/e_waybill_log.js
@@ -1,8 +1,13 @@
 // Copyright (c) 2022, Resilient Tech and contributors
 // For license information, please see license.txt
 
-// frappe.ui.form.on('e-Waybill Log', {
-	// refresh: function(frm) {
-
-	// }
-// });
+frappe.ui.form.on("e-Waybill Log", {
+    refresh: function (frm) {
+        frm.add_custom_button(__("Fetch Latest"), () =>
+            fetch_e_waybill_data(frm, { force: true }, () => {
+                frm.refresh();
+                frappe.show_alert(__("Latest e-Waybill fetched successfully"));
+            })
+        );
+    },
+});

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -709,6 +709,7 @@ def _fetch_e_waybill_data(doc, log):
         {
             "data": frappe.as_json(result, indent=4),
             "is_latest_data": 1,
+            "valid_upto": result.get("validUpto"),
         }
     )
 

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -711,7 +711,7 @@ def _fetch_e_waybill_data(doc, log):
         {
             "data": frappe.as_json(result, indent=4),
             "is_latest_data": 1,
-            "valid_upto": result.get("validUpto"),
+            "valid_upto": parse_datetime(result.get("validUpto"), day_first=True),
         }
     )
 

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -685,10 +685,12 @@ def generate_pending_e_waybills():
 
 
 @frappe.whitelist()
-def fetch_e_waybill_data(*, doctype, docname, attach: bool = False):
+def fetch_e_waybill_data(
+    *, doctype, docname, attach: bool = False, force: bool = False
+):
     doc = load_doc(doctype, docname, "write" if attach else "print")
     log = frappe.get_doc("e-Waybill Log", doc.ewaybill)
-    if not log.is_latest_data:
+    if not log.is_latest_data or force:
         _fetch_e_waybill_data(doc, log)
 
     if not attach:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a "Fetch Latest Data" button in e-Waybill actions for authorized users.
  * Adds a force-refresh option to bypass cached checks and retrieve real-time e-Waybill data.
  * Stores e-Waybill validity expiration dates (valid_upto) for improved record management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->