### PR TITLE
fix: handle duplicate pincodes in Quick Entry Address Autofill

### DIFF
--- a/india_compliance/public/js/quick_entry.js
+++ b/india_compliance/public/js/quick_entry.js
@@ -423,18 +423,33 @@ function setup_pincode_field(dialog, gstin_info) {
     if (!gstin_info.all_addresses) return;
 
     const pincode_field = dialog.fields_dict._pincode;
+    const all_addresses = gstin_info.all_addresses;
+    let last_index = null;
+
     pincode_field.set_data(
-        gstin_info.all_addresses.map(address => {
-            return {
-                label: address.pincode,
-                value: address.pincode,
-                description: `${address.address_line1}, ${address.address_line2}, ${address.city}, ${address.state}`,
-            };
-        })
+        all_addresses.map((address, index) => ({
+            label: `${address.pincode}<br>${address.address_line1}, ${address.address_line2}, ${address.city}, ${address.state}`,
+            value: `idx:${index}`,
+        }))
     );
 
+    pincode_field.format_for_input = value => {
+        if (value === "" || value == null) return "";
+        if (!value.startsWith("idx:")) return value;
+        last_index = cint(value.replace("idx:", ""));
+        return all_addresses[last_index]?.pincode || "";
+    };
+
     pincode_field.df.onchange = () => {
-        autofill_address(dialog.doc, gstin_info);
+        if (last_index != null) {
+            const address = all_addresses[last_index];
+            last_index = null;
+            if (address) {
+                update_address_info(dialog.doc, address);
+            }
+        } else {
+            autofill_address(dialog.doc, gstin_info);
+        }
         dialog.refresh();
     };
 }

--- a/india_compliance/public/js/quick_entry.js
+++ b/india_compliance/public/js/quick_entry.js
@@ -28,11 +28,11 @@ class GSTQuickEntryForm extends frappe.ui.form.QuickEntryForm {
                 fieldtype: "Section Break",
                 description: this.api_enabled
                     ? __(
-                        `When you enter a GSTIN, the permanent address linked to it is
+                          `When you enter a GSTIN, the permanent address linked to it is
                         autofilled.<br>
                         Change the {0} to autofill other addresses.`,
-                        [frappe.meta.get_label("Address", "pincode")]
-                    )
+                          [frappe.meta.get_label("Address", "pincode")]
+                      )
                     : "",
                 collapsible: 0,
             },
@@ -100,7 +100,8 @@ class GSTQuickEntryForm extends frappe.ui.form.QuickEntryForm {
                     if (["Customer", "Supplier"].includes(this.doctype)) {
                         d.set_value(
                             `${this.doctype.toLowerCase()}_type`,
-                            this.gstin_to_party_type_map[d.doc._gstin[5]] || "Individual"
+                            this.gstin_to_party_type_map[d.doc._gstin[5]] ||
+                                "Individual"
                         );
                     }
 
@@ -169,21 +170,23 @@ class PartyQuickEntryForm extends GSTQuickEntryForm {
                 collapsible: 0,
             },
             {
-				label: __("First Name"),
-				fieldname: "map_to_first_name",
-				fieldtype: "Data",
-				depends_on: "eval:doc.customer_type=='Company' || doc.supplier_type=='Company'",
-			},
-             {
+                label: __("First Name"),
+                fieldname: "map_to_first_name",
+                fieldtype: "Data",
+                depends_on:
+                    "eval:doc.customer_type=='Company' || doc.supplier_type=='Company'",
+            },
+            {
                 fieldtype: "Column Break",
             },
-			{
-				label: __("Last Name"),
-				fieldname: "map_to_last_name",
-				fieldtype: "Data",
-				depends_on: "eval:doc.customer_type=='Company' || doc.supplier_type=='Company'",
-			},
-             {
+            {
+                label: __("Last Name"),
+                fieldname: "map_to_last_name",
+                fieldtype: "Data",
+                depends_on:
+                    "eval:doc.customer_type=='Company' || doc.supplier_type=='Company'",
+            },
+            {
                 fieldname: "primary_contact_section_2",
                 fieldtype: "Section Break",
                 collapsible: 0,
@@ -343,7 +346,7 @@ class AddressQuickEntryForm extends GSTQuickEntryForm {
                 "Customer",
                 "Supplier",
                 "Company",
-                "Lead"
+                "Lead",
             ].includes(doc.doctype)
         )
             return;
@@ -429,15 +432,18 @@ function setup_pincode_field(dialog, gstin_info) {
     pincode_field.set_data(
         all_addresses.map((address, index) => ({
             label: `${address.pincode}<br>${address.address_line1}, ${address.address_line2}, ${address.city}, ${address.state}`,
-            value: `idx:${index}`,
+            value: `${index}:${address.pincode}`,
         }))
     );
 
     pincode_field.format_for_input = value => {
         if (value === "" || value == null) return "";
-        if (!value.startsWith("idx:")) return value;
-        last_index = cint(value.replace("idx:", ""));
-        return all_addresses[last_index]?.pincode || "";
+        if (!value.includes(":")) return value;
+        let pincode = null;
+
+        [last_index, pincode] = value.split(":");
+
+        return pincode || "";
     };
 
     pincode_field.df.onchange = () => {


### PR DESCRIPTION
## Problem
When multiple GSTIN addresses shared the same pincode, the dropdown displayed
identical labels for all entries due to Frappe's autocomplete `get_item(value)`
returning only the first match.


Note: Now filtering can be done through the whole address.

Before:
<img width="267" height="324" alt="image" src="https://github.com/user-attachments/assets/7ce7f79d-66c6-44b5-a76d-b79106c4fd2c" />


After:
<img width="262" height="374" alt="image" src="https://github.com/user-attachments/assets/8860ad2e-1c1a-4f18-ade6-c8240ccd88bc" />


Frappe Support Issue: https://support.frappe.io/desk/hd-ticket/56565

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pincode autocomplete now shows combined pincode + address details for clearer selection.
  * Selecting a listed option automatically fills the matching address fields.
  * Selection state is remembered briefly to ensure the chosen address is applied correctly; invalid/blank inputs are ignored.
  * When a direct selection isn't made, the existing autofill behavior continues as a fallback.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->