### PR TITLE
fix: trigger `update_gst_details` for Supplier Quotation.

### DIFF
--- a/india_compliance/public/js/transaction.js
+++ b/india_compliance/public/js/transaction.js
@@ -7,6 +7,7 @@ const TRANSACTION_DOCTYPES = [
     "Sales Order",
     "Delivery Note",
     "Sales Invoice",
+    "Supplier Quotation",
     "Purchase Order",
     "Purchase Receipt",
     "Purchase Invoice",


### PR DESCRIPTION
Issue: On the change of Supplier Address or company address place of supply and taxes were not updated.





Frappe Support Issue: https://support.frappe.io/desk/hd-ticket/56652

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended GST validation checks to Supplier Quotation documents, including GST details validation, overseas GST category validation, and GSTIN status verification.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->