### PR TITLE
fix: validate item tax template based on gst rate instead of amount to avoid precision issue

### DIFF
--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -1713,12 +1713,12 @@ def validate_item_tax_template(doc):
         if item.gst_treatment == "Zero-Rated" and not doc.get("is_export_with_gst"):
             continue
 
-        total_taxes = abs(item.igst_amount + item.cgst_amount + item.sgst_amount)
+        is_gst_applied = bool(item.igst_rate + item.cgst_rate + item.sgst_rate)
 
-        if total_taxes and item.gst_treatment not in TAXABLE_GST_TREATMENTS:
+        if is_gst_applied and item.gst_treatment not in TAXABLE_GST_TREATMENTS:
             non_taxable_items_with_tax.append(item.idx)
 
-        if not total_taxes and item.gst_treatment in TAXABLE_GST_TREATMENTS:
+        if not is_gst_applied and item.gst_treatment in TAXABLE_GST_TREATMENTS:
             taxable_items_with_no_tax.append(item.idx)
 
     # Case: Zero Tax template with taxes or missing GST Accounts


### PR DESCRIPTION
Issue: When the taxable amount is very minimal, then incorrect validation is being raised.

Steps to replicate:
- Create a Sales Invoice
- Add item with rate as 0.001.
- Save

Validation error will be raised.

<img width="574" height="167" alt="image" src="https://github.com/user-attachments/assets/2512e8b0-d216-46e5-9c2e-c93771b1ab85" />


Frappe Support Issue: https://support.frappe.io/desk/hd-ticket/56948

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy in tax validation by refining how GST application is determined. The system now checks for the presence of GST rates to correctly identify taxable and non-taxable items, reducing misclassification in tax calculations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->