### PR TITLE
fix: set API_NAME for TaxpayerAuthenticate class

### DIFF
--- a/india_compliance/gst_india/api_classes/taxpayer_base.py
+++ b/india_compliance/gst_india/api_classes/taxpayer_base.py
@@ -108,6 +108,7 @@ class FilesAPI(BaseAPI):
 
 
 class TaxpayerAuthenticate(BaseAPI):
+    API_NAME = "GST Returns"
 
     IGNORED_ERROR_CODES = {
         "RETOTPREQUEST": "otp_requested",

--- a/india_compliance/gst_india/api_classes/taxpayer_returns.py
+++ b/india_compliance/gst_india/api_classes/taxpayer_returns.py
@@ -8,7 +8,6 @@ from india_compliance.gst_india.api_classes.taxpayer_base import (
 
 
 class ReturnsAPI(TaxpayerBaseAPI):
-    API_NAME = "GST Returns"
     IGNORED_ERROR_CODES = {
         **TaxpayerBaseAPI.IGNORED_ERROR_CODES,
         "RET11416": "no_docs_found",


### PR DESCRIPTION
The error message for missing credentials in `handle_duplicate_irn_error` was generic ("use the GST API") because API_NAME was not defined in the base class.

<img width="1065" height="350" alt="image" src="https://github.com/user-attachments/assets/8aacd8b7-9817-4c65-9dfb-b1f14169e1db" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated internal identification for the GST Returns API.
  * Cleanup of redundant API identifier to streamline internals; no changes to functionality or user-facing behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->