### PR TITLE
fix: handle missing E Invoice Settings in post-install patch

### DIFF
--- a/india_compliance/patches/post_install/add_einvoice_status_field.py
+++ b/india_compliance/patches/post_install/add_einvoice_status_field.py
@@ -7,8 +7,9 @@ def execute():
     # Sales Invoice should have field signed_einvoice
     # and E Invoice Settings should be enabled
 
-    if not frappe.db.has_column("Sales Invoice", "signed_einvoice") or not sbool(
-        frappe.db.get_single_value("E Invoice Settings", "enable")
+    if (
+        not frappe.db.has_column("Sales Invoice", "signed_einvoice")
+        or not is_einvoice_enabled()
     ):
         set_not_applicable_status()
         return
@@ -50,3 +51,15 @@ def set_not_applicable_status():
         & (Coalesce(sales_invoice.einvoice_status, "") == "")
         & (Coalesce(sales_invoice.irn, "") == "")
     ).run()
+
+
+def is_einvoice_enabled():
+    singles = frappe.qb.DocType("Singles")
+    result = (
+        frappe.qb.from_(singles)
+        .select(singles.value)
+        .where((singles.doctype == "E Invoice Settings") & (singles.field == "enable"))
+        .run()
+    )
+
+    return sbool(result[0][0]) if result else False


### PR DESCRIPTION
```
Traceback with variables (most recent call last):
  File "apps/frappe/frappe/commands/site.py", line 486, in install_app
    _install_app(app, verbose=context.verbose, force=force)
      context = {'sites': ['mmwpltest.m.frappe.cloud'], 'force': False, 'verbose': False, 'profile': False}
      apps = ('india_compliance',)
      force = True
      _install_app = <function install_app at 0x7f2606bb4220>
      filelock = <function filelock at 0x7f2607acdbc0>
      exit_code = 0
      site = 'mmwpltest.m.frappe.cloud'
      app = 'india_compliance'
      err = DoesNotExistError('DocType E Invoice Settings not found')
  File "apps/frappe/frappe/installer.py", line 326, in install_app
    frappe.get_attr(after_install)()
      name = 'india_compliance'
      verbose = False
      set_as_patched = True
      force = True
      sync_jobs = <function sync_jobs at 0x7f2606030c20>
      sync_for = <function sync_for at 0x7f2606031da0>
      sync_customizations = <function sync_customizations at 0x7f2607934b80>
      sync_fixtures = <function sync_fixtures at 0x7f2606031f80>
      app_hooks = {'accounting_dimension_doctypes': ['Bill of Entry', 'Bill of Entry Item'], 'after_app_install': ['india_compliance.install.after_app_install'], 'after_install': ['india_compliance.install.after_install'], 'after_migrate': ['india_compliance.audit_trail.setup.after_migrate'], 'app_color': ['grey'], 'app_description': ['ERPNext app to simplify compliance with Indian Rules and Regulations'], 'app_email': ['hello@indiacompliance.app'], 'app_icon': ['octicon octicon-file-directory'], 'app_include_js': ['india_compliance.bundle.js'], 'app_license': ['GNU General Public License (v3)'], 'app_name': ['india_compliance'], 'app_publisher': ['Resilient Tech'], 'app_title': ['India Compliance'], 'audit_trail_doctypes': ['Accounts Settings', 'Dunning', 'Invoice Discounting', 'Journal Entry', 'Payment Entry', 'Period Closing Voucher', 'Process Deferred Accounting', 'Purchase Invoice', 'Sales Invoice', 'Asset', 'Asset Capitalization', 'Asset Repair', 'Delivery Note', 'Landed Cost Voucher', 'Purchase R...
      installed_apps = ['frappe', 'erpnext']
      app = 'frappe/erpnext'
      required_app = 'erpnext'
      before_install = 'india_compliance.patches.check_version_compatibility.execute'
      out = None
      after_install = 'india_compliance.install.after_install'
  File "apps/india_compliance/india_compliance/install.py", line 78, in after_install
    raise e
  File "apps/india_compliance/india_compliance/install.py", line 67, in after_install
    run_post_install_patches()
  File "apps/india_compliance/india_compliance/install.py", line 91, in run_post_install_patches
    frappe.get_attr(f"india_compliance.patches.post_install.{patch}.execute")()
      patch = 'add_einvoice_status_field'
  File "apps/india_compliance/india_compliance/patches/post_install/add_einvoice_status_field.py", line 11, in execute
    frappe.db.get_single_value("E Invoice Settings", "enable")
  File "apps/frappe/frappe/database/database.py", line 839, in get_single_value
    df = frappe.get_meta(doctype).get_field(fieldname)
      self = <frappe.database.mariadb.database.MariaDBDatabase object at 0x7f2606bad490>
      doctype = 'E Invoice Settings'
      fieldname = 'enable'
      cache = True
      val = '1'
  File "apps/frappe/frappe/__init__.py", line 1338, in get_meta
    return frappe.model.meta.get_meta(doctype, cached=cached)
      doctype = 'E Invoice Settings'
      cached = True
      frappe = <module 'frappe' from 'apps/frappe/frappe/__init__.py'>
  File "apps/frappe/frappe/model/meta.py", line 71, in get_meta
    meta = Meta(doctype)
      doctype = 'E Invoice Settings'
      cached = True
      meta = None
  File "apps/frappe/frappe/model/meta.py", line 125, in __init__
    super().__init__("DocType", doctype)
      self = <Meta: E Invoice Settings>
      doctype = 'E Invoice Settings'
      __class__ = <class 'frappe.model.meta.Meta'>
  File "apps/frappe/frappe/model/document.py", line 126, in __init__
    self.load_from_db()
      self = <Meta: E Invoice Settings>
      args = ('DocType', 'E Invoice Settings')
      kwargs = {}
      __class__ = <class 'frappe.model.document.Document'>
  File "apps/frappe/frappe/model/meta.py", line 131, in load_from_db
    super().load_from_db()
      self = <Meta: E Invoice Settings>
      __class__ = <class 'frappe.model.meta.Meta'>
  File "apps/frappe/frappe/model/document.py", line 179, in load_from_db
    frappe.throw(
      self = <Meta: E Invoice Settings>
      get_value_kwargs = {'for_update': None, 'as_dict': True, 'order_by': None}
      d = None
      __class__ = <class 'frappe.model.document.Document'>
  File "apps/frappe/frappe/__init__.py", line 609, in throw
    msgprint(
      msg = 'DocType E Invoice Settings not found'
      exc = DoesNotExistError('DocType E Invoice Settings not found')
      title = None
      is_minimizable = False
      wide = False
      as_list = False
      primary_action = None
  File "apps/frappe/frappe/__init__.py", line 574, in msgprint
    _raise_exception()
      msg = 'DocType E Invoice Settings not found'
      title = None
      raise_exception = DoesNotExistError('DocType E Invoice Settings not found')
      as_table = False
      as_list = False
      indicator = 'red'
      alert = False
      primary_action = None
      is_minimizable = False
      wide = False
      realtime = False
      sys = <module 'sys' (built-in)>
      _raise_exception = <function msgprint.<locals>._raise_exception at 0x7f26031504a0>
      inspect = <module 'inspect' from '/usr/lib/python3.11/inspect.py'>
      out = {'message': 'DocType E Invoice Settings not found', 'title': 'Message', 'indicator': 'red', 'raise_exception': 1, '__frappe_exc_id': 'bf01e64d6bc58586480682ec74976a20da0c642fd8691684c8ea9e5d'}
  File "apps/frappe/frappe/__init__.py", line 525, in _raise_exception
    raise exc
      exc = DoesNotExistError('DocType E Invoice Settings not found')
      inspect = <module 'inspect' from '/usr/lib/python3.11/inspect.py'>
      msg = 'DocType E Invoice Settings not found'
      out = {'message': 'DocType E Invoice Settings not found', 'title': 'Message', 'indicator': 'red', 'raise_exception': 1, '__frappe_exc_id': 'bf01e64d6bc58586480682ec74976a20da0c642fd8691684c8ea9e5d'}
      raise_exception = DoesNotExistError('DocType E Invoice Settings not found')
frappe.exceptions.DoesNotExistError: DocType E Invoice Settings not found
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal improvements to e-invoice configuration handling logic.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->