### PR TITLE
fix: check if the e-invoice is already generated or not

### DIFF
--- a/india_compliance/exceptions.py
+++ b/india_compliance/exceptions.py
@@ -6,6 +6,12 @@ class GSPServerError(frappe.ValidationError):
     title = "GSP/GST Server Error"
 
 
+class EInvoiceAlreadyGenerated(frappe.ValidationError):
+    """Raised when e-Invoice has already been generated for the document."""
+
+    pass
+
+
 class GSPLimitExceededError(GSPServerError):
     message = "GSP/GST account limit exceeded"
     http_status_code = 429

--- a/india_compliance/exceptions.py
+++ b/india_compliance/exceptions.py
@@ -1,4 +1,5 @@
 import frappe
+from frappe import ValidationError
 
 
 class GSPServerError(frappe.ValidationError):
@@ -31,3 +32,19 @@ class InvalidOTPError(Exception):
 class InvalidAuthTokenError(Exception):
     def __init__(self, message="Invalid Auth Token", *args, **kwargs):
         super().__init__(message, *args, **kwargs)
+
+
+class NotApplicableError(ValidationError):
+    """
+    Raised when e-Invoice/e-Waybill is not applicable for the document.
+    """
+
+    pass
+
+
+class AlreadyGeneratedError(ValidationError):
+    """
+    Raised when e-Invoice/e-Waybill has already been generated for the document.
+    """
+
+    pass

--- a/india_compliance/exceptions.py
+++ b/india_compliance/exceptions.py
@@ -1,8 +1,7 @@
-import frappe
 from frappe import ValidationError
 
 
-class GSPServerError(frappe.ValidationError):
+class GSPServerError(ValidationError):
     message = "GSP/GST server is down"
     title = "GSP/GST Server Error"
 

--- a/india_compliance/exceptions.py
+++ b/india_compliance/exceptions.py
@@ -6,12 +6,6 @@ class GSPServerError(frappe.ValidationError):
     title = "GSP/GST Server Error"
 
 
-class EInvoiceAlreadyGenerated(frappe.ValidationError):
-    """Raised when e-Invoice has already been generated for the document."""
-
-    pass
-
-
 class GSPLimitExceededError(GSPServerError):
     message = "GSP/GST account limit exceeded"
     http_status_code = 429

--- a/india_compliance/gst_india/constants/custom_fields.py
+++ b/india_compliance/gst_india/constants/custom_fields.py
@@ -1743,7 +1743,7 @@ e_waybill_status_field = {
     "label": "e-Waybill Status",
     "fieldtype": "Select",
     "insert_after": "ewaybill",
-    "options": "\nPending\nGenerated\nAuto-Retry\nCancelled\nNot Applicable\nManually Generated\nManually Cancelled",
+    "options": "\nPending\nGenerated\nManually Generated\nAuto-Retry\nCancelled\nManually Cancelled\nFailed\nNot Applicable",
     "print_hide": 1,
     "no_copy": 1,
     "translatable": 1,

--- a/india_compliance/gst_india/overrides/sales_invoice.py
+++ b/india_compliance/gst_india/overrides/sales_invoice.py
@@ -180,7 +180,6 @@ def on_submit(doc, method=None):
             enqueue_after_commit=True,
             queue="short",
             docname=doc.name,
-            throw=False,
         )
 
         return

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -205,6 +205,7 @@ def validate_mandatory_fields(doc, fields, error_message=None, throw=True):
         frappe.throw(
             error_message.format(bold(_(doc.meta.get_label(field)))),
             title=_("Missing Required Field"),
+            exc=frappe.MandatoryError,
         )
 
 

--- a/india_compliance/gst_india/report/e_invoice_summary/e_invoice_summary.py
+++ b/india_compliance/gst_india/report/e_invoice_summary/e_invoice_summary.py
@@ -26,7 +26,7 @@ def validate_filters(filters=None):
 
     if not settings.enable_e_invoice:
         frappe.throw(
-            _("e-Invoice is not enabled for your company."),
+            _("e-Invoice is not enabled in GST Settings"),
             title=_("Invalid Filter"),
         )
 

--- a/india_compliance/gst_india/report/gst_sales_register/test_sales_register.py
+++ b/india_compliance/gst_india/report/gst_sales_register/test_sales_register.py
@@ -651,7 +651,9 @@ class TestSalesRegister(IntegrationTestCase):
         cls.create_test_records()
 
     @classmethod
-    @change_settings("GST Settings", {"enable_overseas_transactions": 1})
+    @change_settings(
+        "GST Settings", {"enable_overseas_transactions": 1, "enable_e_waybill": 0}
+    )
     def create_test_records(cls):
         for invoice in INVOICES:
             create_sales_invoice(**invoice)

--- a/india_compliance/gst_india/utils/__init__.py
+++ b/india_compliance/gst_india/utils/__init__.py
@@ -1246,3 +1246,8 @@ def set_einvoice_status(doc, status):
         return
 
     doc.db_set("einvoice_status", status)
+
+
+@execute_in_new_transaction
+def set_ewaybill_status(doc, status):
+    doc.db_set("e_waybill_status", status)

--- a/india_compliance/gst_india/utils/__init__.py
+++ b/india_compliance/gst_india/utils/__init__.py
@@ -1245,9 +1245,9 @@ def set_einvoice_status(doc, status):
     if doc.doctype != "Sales Invoice":
         return
 
-    frappe.set_value(doc.doctype, doc.name, "einvoice_status", status)
+    doc.db_set("einvoice_status", status)
 
 
 @execute_in_new_transaction
 def set_ewaybill_status(doc, status):
-    frappe.set_value(doc.doctype, doc.name, "e_waybill_status", status)
+    doc.db_set("e_waybill_status", status)

--- a/india_compliance/gst_india/utils/__init__.py
+++ b/india_compliance/gst_india/utils/__init__.py
@@ -44,6 +44,7 @@ from india_compliance.gst_india.constants import (
     TIMEZONE,
     UOM_MAP,
 )
+from india_compliance.utils import execute_in_new_transaction
 
 
 def get_state(state_number):
@@ -1237,3 +1238,11 @@ def _get_duplicate_gstin_party(gstin, party_type, party=None):
         }
 
     return list(duplicates_dict.values())
+
+
+@execute_in_new_transaction
+def set_einvoice_status(doc, status):
+    if doc.doctype != "Sales Invoice":
+        return
+
+    doc.db_set("einvoice_status", status)

--- a/india_compliance/gst_india/utils/__init__.py
+++ b/india_compliance/gst_india/utils/__init__.py
@@ -1245,9 +1245,9 @@ def set_einvoice_status(doc, status):
     if doc.doctype != "Sales Invoice":
         return
 
-    doc.db_set("einvoice_status", status)
+    frappe.set_value(doc.doctype, doc.name, "einvoice_status", status)
 
 
 @execute_in_new_transaction
 def set_ewaybill_status(doc, status):
-    doc.db_set("e_waybill_status", status)
+    frappe.set_value(doc.doctype, doc.name, "e_waybill_status", status)

--- a/india_compliance/gst_india/utils/e_invoice.py
+++ b/india_compliance/gst_india/utils/e_invoice.py
@@ -200,12 +200,12 @@ def generate_e_invoice(docname, throw: bool = True, force: bool = False):
         handle_server_errors(settings, doc, "e-Invoice", e)
         return
 
-    except (AlreadyGeneratedError, NotApplicableError) as e:
+    except (AlreadyGeneratedError, NotApplicableError):
         # Don't set status to Failed for these errors
         # - AlreadyGeneratedError: IRN already exists, no action needed
         # - NotApplicableError: e-Invoice not applicable, not a failure
         if throw:
-            raise e
+            raise
 
         frappe.clear_last_message()
         return
@@ -214,7 +214,7 @@ def generate_e_invoice(docname, throw: bool = True, force: bool = False):
         set_einvoice_status(doc, "Failed")
 
         if throw:
-            raise e
+            raise
 
         if frappe.request:
             frappe.clear_last_message()
@@ -229,9 +229,9 @@ def generate_e_invoice(docname, throw: bool = True, force: bool = False):
 
         return
 
-    except Exception as e:
+    except Exception:
         set_einvoice_status(doc, "Failed")
-        raise e
+        raise
 
     return log_and_process_e_invoice_generation(doc, result, api.sandbox_mode)
 

--- a/india_compliance/gst_india/utils/e_invoice.py
+++ b/india_compliance/gst_india/utils/e_invoice.py
@@ -15,7 +15,7 @@ from frappe.utils import (
     random_string,
 )
 
-from india_compliance.exceptions import GSPServerError
+from india_compliance.exceptions import EInvoiceAlreadyGenerated, GSPServerError
 from india_compliance.gst_india.api_classes.nic.e_invoice import EInvoiceAPI
 from india_compliance.gst_india.api_classes.taxpayer_base import otp_handler
 from india_compliance.gst_india.api_classes.taxpayer_e_invoice import (
@@ -123,6 +123,14 @@ def generate_e_invoice(docname, throw: bool = True, force: bool = False):
     doc = load_doc("Sales Invoice", docname, "submit")
 
     settings = frappe.get_cached_doc("GST Settings")
+
+    if doc.irn:
+        frappe.throw(
+            _("e-Invoice has already been generated for Sales Invoice {0}").format(
+                frappe.bold(doc.name)
+            ),
+            EInvoiceAlreadyGenerated,
+        )
 
     try:
         if (
@@ -492,18 +500,18 @@ def validate_e_invoice_applicability(doc, gst_settings=None, throw=True):
         if throw:
             frappe.throw(error)
 
+    if doc.irn:
+        raise EInvoiceAlreadyGenerated(
+            _("e-Invoice has already been generated for Sales Invoice {0}").format(
+                frappe.bold(doc.name)
+            )
+        )
+
     if doc.company_gstin == doc.billing_address_gstin:
         return _throw(
             _(
                 "e-Invoice is not applicable for invoices with same company and billing"
                 " GSTIN"
-            )
-        )
-
-    if doc.irn:
-        return _throw(
-            _("e-Invoice has already been generated for Sales Invoice {0}").format(
-                frappe.bold(doc.name)
             )
         )
 

--- a/india_compliance/gst_india/utils/e_invoice.py
+++ b/india_compliance/gst_india/utils/e_invoice.py
@@ -15,7 +15,11 @@ from frappe.utils import (
     random_string,
 )
 
-from india_compliance.exceptions import GSPServerError
+from india_compliance.exceptions import (
+    AlreadyGeneratedError,
+    GSPServerError,
+    NotApplicableError,
+)
 from india_compliance.gst_india.api_classes.nic.e_invoice import EInvoiceAPI
 from india_compliance.gst_india.api_classes.taxpayer_base import otp_handler
 from india_compliance.gst_india.api_classes.taxpayer_e_invoice import (
@@ -97,17 +101,6 @@ def generate_e_invoices(docnames, force=False):
         try:
             generate_e_invoice(docname, throw=False, force=force)
 
-        except GSPServerError:
-            frappe.db.set_value(
-                "Sales Invoice",
-                {"name": ("in", docnames), "irn": ("is", "not set")},
-                "einvoice_status",
-                "Auto-Retry",
-            )
-
-            log_error()
-            frappe.clear_last_message()
-
         except Exception:
             log_error()
             frappe.clear_last_message()
@@ -128,7 +121,8 @@ def generate_e_invoice(docname, throw: bool = True, force: bool = False):
         frappe.throw(
             _("e-Invoice has already been generated for Sales Invoice {0}").format(
                 frappe.bold(doc.name)
-            )
+            ),
+            exc=AlreadyGeneratedError,
         )
 
     try:
@@ -193,6 +187,16 @@ def generate_e_invoice(docname, throw: bool = True, force: bool = False):
 
     except GSPServerError as e:
         handle_server_errors(settings, doc, "e-Invoice", e)
+        return
+
+    except (AlreadyGeneratedError, NotApplicableError) as e:
+        # Don't set status to Failed for these errors
+        # - AlreadyGeneratedError: IRN already exists, no action needed
+        # - NotApplicableError: e-Invoice not applicable, not a failure
+        if throw:
+            raise e
+
+        frappe.clear_last_message()
         return
 
     except frappe.ValidationError as e:
@@ -495,15 +499,16 @@ def _log_e_invoice(log_data):
 
 
 def validate_e_invoice_applicability(doc, gst_settings=None, throw=True):
-    def _throw(error):
+    def _throw(error, exc=NotApplicableError):
         if throw:
-            frappe.throw(error)
+            frappe.throw(error, exc=exc)
 
     if doc.irn:
         return _throw(
             _("e-Invoice has already been generated for Sales Invoice {0}").format(
                 frappe.bold(doc.name)
-            )
+            ),
+            exc=AlreadyGeneratedError,
         )
 
     if doc.company_gstin == doc.billing_address_gstin:
@@ -564,6 +569,7 @@ def validate_taxable_item(doc, throw=True):
 
     frappe.throw(
         _("e-Invoice is not applicable for invoice with only Nil-Rated/Exempted items"),
+        exc=NotApplicableError,
     )
 
 

--- a/india_compliance/gst_india/utils/e_invoice.py
+++ b/india_compliance/gst_india/utils/e_invoice.py
@@ -118,25 +118,15 @@ def generate_e_invoice(docname, throw: bool = True, force: bool = False):
 
     settings = frappe.get_cached_doc("GST Settings")
 
-    if doc.irn:
-        message = _(
-            "e-Invoice has already been generated for Sales Invoice {0}"
-        ).format(frappe.bold(doc.name))
-
-        if throw:
-            frappe.throw(message, exc=AlreadyGeneratedError)
-
-        if frappe.request:
-            frappe.msgprint(
-                message,
-                _("Warning"),
-                indicator="yellow",
-                alert=True,
+    try:
+        if doc.irn:
+            frappe.throw(
+                _("e-Invoice has already been generated for Sales Invoice {0}").format(
+                    frappe.bold(doc.name)
+                ),
+                exc=AlreadyGeneratedError,
             )
 
-        return
-
-    try:
         if (
             not force
             and settings.enable_retry_einv_ewb_generation
@@ -200,14 +190,24 @@ def generate_e_invoice(docname, throw: bool = True, force: bool = False):
         handle_server_errors(settings, doc, "e-Invoice", e)
         return
 
-    except (AlreadyGeneratedError, NotApplicableError):
-        # Don't set status to Failed for these errors
-        # - AlreadyGeneratedError: IRN already exists, no action needed
-        # - NotApplicableError: e-Invoice not applicable, not a failure
+    except AlreadyGeneratedError as e:
         if throw:
             raise
 
-        frappe.clear_last_message()
+        if frappe.request:
+            frappe.clear_last_message()
+            frappe.msgprint(str(e), _("Warning"), indicator="yellow", alert=True)
+
+        return
+
+    except NotApplicableError as e:
+        if throw:
+            raise
+
+        if frappe.request:
+            frappe.clear_last_message()
+            frappe.msgprint(str(e), _("e-Invoice Not Applicable"))
+
         return
 
     except (frappe.ValidationError, frappe.MandatoryError) as e:

--- a/india_compliance/gst_india/utils/e_invoice.py
+++ b/india_compliance/gst_india/utils/e_invoice.py
@@ -50,6 +50,7 @@ from india_compliance.gst_india.utils import (
     load_doc,
     parse_datetime,
     send_updated_doc,
+    set_einvoice_status,
     update_onload,
 )
 from india_compliance.gst_india.utils.e_waybill import (
@@ -199,26 +200,27 @@ def generate_e_invoice(docname, throw: bool = True, force: bool = False):
         frappe.clear_last_message()
         return
 
-    except frappe.ValidationError as e:
-        doc.db_set({"einvoice_status": "Failed"})
+    except (frappe.ValidationError, frappe.MandatoryError) as e:
+        set_einvoice_status(doc, "Failed")
 
         if throw:
             raise e
 
-        frappe.clear_last_message()
-        frappe.msgprint(
-            _(
-                "e-Invoice auto-generation failed with error:<br>{0}<br><br>"
-                "Please rectify this issue and generate e-Invoice manually."
-            ).format(str(e)),
-            _("Warning"),
-            indicator="yellow",
-        )
+        if frappe.request:
+            frappe.clear_last_message()
+            frappe.msgprint(
+                _(
+                    "e-Invoice auto-generation failed with error:<br>{0}<br><br>"
+                    "Please rectify this issue and generate e-Invoice manually."
+                ).format(str(e)),
+                _("Error Generating e-Invoice"),
+                indicator="red",
+            )
 
         return
 
     except Exception as e:
-        doc.db_set({"einvoice_status": "Failed"})
+        set_einvoice_status(doc, "Failed")
         raise e
 
     return log_and_process_e_invoice_generation(doc, result, api.sandbox_mode)

--- a/india_compliance/gst_india/utils/e_invoice.py
+++ b/india_compliance/gst_india/utils/e_invoice.py
@@ -123,15 +123,18 @@ def generate_e_invoice(docname, throw: bool = True, force: bool = False):
             "e-Invoice has already been generated for Sales Invoice {0}"
         ).format(frappe.bold(doc.name))
 
-        if not throw and frappe.request:
-            return frappe.msgprint(
+        if throw:
+            frappe.throw(message, exc=AlreadyGeneratedError)
+
+        if frappe.request:
+            frappe.msgprint(
                 message,
                 _("Warning"),
                 indicator="yellow",
                 alert=True,
             )
 
-        frappe.throw(message, exc=AlreadyGeneratedError)
+        return
 
     try:
         if (

--- a/india_compliance/gst_india/utils/e_invoice.py
+++ b/india_compliance/gst_india/utils/e_invoice.py
@@ -99,7 +99,7 @@ def generate_e_invoices(docnames, force=False):
 
     for docname in docnames:
         try:
-            generate_e_invoice(docname, throw=False, force=force)
+            generate_e_invoice(docname, force=force)
 
         except Exception:
             log_error()

--- a/india_compliance/gst_india/utils/e_invoice.py
+++ b/india_compliance/gst_india/utils/e_invoice.py
@@ -119,12 +119,19 @@ def generate_e_invoice(docname, throw: bool = True, force: bool = False):
     settings = frappe.get_cached_doc("GST Settings")
 
     if doc.irn:
-        frappe.throw(
-            _("e-Invoice has already been generated for Sales Invoice {0}").format(
-                frappe.bold(doc.name)
-            ),
-            exc=AlreadyGeneratedError,
-        )
+        message = _(
+            "e-Invoice has already been generated for Sales Invoice {0}"
+        ).format(frappe.bold(doc.name))
+
+        if not throw and frappe.request:
+            return frappe.msgprint(
+                message,
+                _("Warning"),
+                indicator="yellow",
+                alert=True,
+            )
+
+        frappe.throw(message, exc=AlreadyGeneratedError)
 
     try:
         if (

--- a/india_compliance/gst_india/utils/e_invoice.py
+++ b/india_compliance/gst_india/utils/e_invoice.py
@@ -15,7 +15,7 @@ from frappe.utils import (
     random_string,
 )
 
-from india_compliance.exceptions import EInvoiceAlreadyGenerated, GSPServerError
+from india_compliance.exceptions import GSPServerError
 from india_compliance.gst_india.api_classes.nic.e_invoice import EInvoiceAPI
 from india_compliance.gst_india.api_classes.taxpayer_base import otp_handler
 from india_compliance.gst_india.api_classes.taxpayer_e_invoice import (
@@ -128,8 +128,7 @@ def generate_e_invoice(docname, throw: bool = True, force: bool = False):
         frappe.throw(
             _("e-Invoice has already been generated for Sales Invoice {0}").format(
                 frappe.bold(doc.name)
-            ),
-            EInvoiceAlreadyGenerated,
+            )
         )
 
     try:
@@ -501,7 +500,7 @@ def validate_e_invoice_applicability(doc, gst_settings=None, throw=True):
             frappe.throw(error)
 
     if doc.irn:
-        raise EInvoiceAlreadyGenerated(
+        return _throw(
             _("e-Invoice has already been generated for Sales Invoice {0}").format(
                 frappe.bold(doc.name)
             )

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -7,6 +7,7 @@ from frappe.desk.form.load import get_docinfo, run_onload
 from frappe.utils import (
     add_days,
     add_to_date,
+    escape_html,
     format_date,
     get_datetime,
     get_datetime_str,
@@ -542,8 +543,10 @@ def update_transporter(*, doctype, docname, values):
         " {old_transporter_id} to {new_transporter_id}."
     ).format(
         user=frappe.bold(get_fullname()),
-        old_transporter_id=frappe.bold(old_transporter_id or "<empty>"),
-        new_transporter_id=frappe.bold(values.gst_transporter_id or "<empty>"),
+        old_transporter_id=frappe.bold(escape_html(old_transporter_id or "<empty>")),
+        new_transporter_id=frappe.bold(
+            escape_html(values.gst_transporter_id or "<empty>")
+        ),
     )
 
     log_and_process_e_waybill(

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -1358,11 +1358,11 @@ class EWaybillData(GSTTransactionData):
                 )
 
         # Atleast one item with HSN code of goods is required
-        for item in self.doc.items:
-            if not item.gst_hsn_code.startswith("99"):
-                break
+        has_atleast_one_goods_item = any(
+            not item.gst_hsn_code.startswith("99") for item in self.doc.items
+        )
 
-        else:
+        if not has_atleast_one_goods_item:
             frappe.throw(
                 _(
                     "e-Waybill cannot be generated because all items have service HSN"

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -16,7 +16,11 @@ from frappe.utils import (
 )
 from frappe.utils.file_manager import save_file
 
-from india_compliance.exceptions import GSPServerError
+from india_compliance.exceptions import (
+    AlreadyGeneratedError,
+    GSPServerError,
+    NotApplicableError,
+)
 from india_compliance.gst_india.api_classes.nic.e_invoice import EInvoiceAPI
 from india_compliance.gst_india.api_classes.nic.e_waybill import EWaybillAPI
 from india_compliance.gst_india.constants import (
@@ -148,6 +152,14 @@ def generate_e_waybill(*, doctype, docname, values=None, force: bool = False):
 def _generate_e_waybill(doc, throw=True, force=False):
     settings = frappe.get_cached_doc("GST Settings")
 
+    if doc.ewaybill:
+        frappe.throw(
+            _("e-Waybill has already been generated for {0} {1}").format(
+                _(doc.doctype), frappe.bold(doc.name)
+            ),
+            exc=AlreadyGeneratedError,
+        )
+
     try:
         if (
             not force
@@ -211,7 +223,17 @@ def _generate_e_waybill(doc, throw=True, force=False):
         handle_server_errors(settings, doc, "e-Waybill", e)
         return
 
+    except (AlreadyGeneratedError, NotApplicableError) as e:
+        if throw:
+            raise e
+
+        frappe.clear_last_message()
+        return
+
     except frappe.ValidationError as e:
+        if doc.doctype == "Sales Invoice":
+            doc.db_set({"e_waybill_status": "Failed"})
+
         if throw:
             raise e
 
@@ -225,6 +247,11 @@ def _generate_e_waybill(doc, throw=True, force=False):
             indicator="yellow",
         )
         return
+
+    except Exception as e:
+        if doc.doctype == "Sales Invoice":
+            doc.db_set({"e_waybill_status": "Failed"})
+        raise e
 
     if result.error_code == "604":
         error_message = (
@@ -1280,7 +1307,8 @@ class EWaybillData(GSTTransactionData):
             frappe.throw(
                 _("e-Waybill already generated for {0} {1}").format(
                     _(self.doc.doctype), frappe.bold(self.doc.name)
-                )
+                ),
+                exc=AlreadyGeneratedError,
             )
 
         self.validate_applicability()
@@ -1288,7 +1316,10 @@ class EWaybillData(GSTTransactionData):
 
     def validate_settings(self):
         if not self.settings.enable_e_waybill:
-            frappe.throw(_("Please enable e-Waybill in GST Settings"))
+            frappe.throw(
+                _("Please enable e-Waybill in GST Settings"),
+                exc=NotApplicableError,
+            )
 
     def validate_applicability(self):
         """
@@ -1321,6 +1352,7 @@ class EWaybillData(GSTTransactionData):
                     " codes"
                 ),
                 title=_("Invalid Data"),
+                exc=NotApplicableError,
             )
 
         if not self.doc.gst_transporter_id:
@@ -1345,6 +1377,7 @@ class EWaybillData(GSTTransactionData):
                     " company GSTIN"
                 ),
                 title=_("Invalid Data"),
+                exc=NotApplicableError,
             )
 
     def validate_bill_no_for_purchase(self):
@@ -1357,6 +1390,7 @@ class EWaybillData(GSTTransactionData):
             frappe.throw(
                 _("Bill No is mandatory to generate e-Waybill for Purchase Invoice"),
                 title=_("Invalid Data"),
+                exc=frappe.MandatoryError,
             )
 
     def validate_doctype_for_e_waybill(self):
@@ -1366,6 +1400,7 @@ class EWaybillData(GSTTransactionData):
                     self.doc.doctype
                 ),
                 title=_("Unsupported DocType"),
+                exc=NotApplicableError,
             )
 
     def validate_if_e_waybill_is_set(self):

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -154,25 +154,15 @@ def generate_e_waybill(*, doctype, docname, values=None, force: bool = False):
 def _generate_e_waybill(doc, throw=True, force=False):
     settings = frappe.get_cached_doc("GST Settings")
 
-    if doc.ewaybill:
-        message = _("e-Waybill has already been generated for {0} {1}").format(
-            _(doc.doctype), frappe.bold(doc.name)
-        )
-
-        if throw:
-            frappe.throw(message, exc=AlreadyGeneratedError)
-
-        if frappe.request:
-            frappe.msgprint(
-                message,
-                _("Warning"),
-                indicator="yellow",
-                alert=True,
+    try:
+        if doc.ewaybill:
+            frappe.throw(
+                _("e-Waybill has already been generated for {0} {1}").format(
+                    _(doc.doctype), frappe.bold(doc.name)
+                ),
+                exc=AlreadyGeneratedError,
             )
 
-            return
-
-    try:
         if (
             not force
             and settings.enable_retry_einv_ewb_generation
@@ -235,11 +225,24 @@ def _generate_e_waybill(doc, throw=True, force=False):
         handle_server_errors(settings, doc, "e-Waybill", e)
         return
 
-    except (AlreadyGeneratedError, NotApplicableError):
+    except AlreadyGeneratedError as e:
         if throw:
             raise
 
-        frappe.clear_last_message()
+        if frappe.request:
+            frappe.clear_last_message()
+            frappe.msgprint(str(e), _("Warning"), indicator="yellow", alert=True)
+
+        return
+
+    except NotApplicableError as e:
+        if throw:
+            raise
+
+        if frappe.request:
+            frappe.clear_last_message()
+            frappe.msgprint(str(e), _("e-Waybill Not Applicable"))
+
         return
 
     except (frappe.ValidationError, frappe.MandatoryError) as e:

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -235,9 +235,9 @@ def _generate_e_waybill(doc, throw=True, force=False):
         handle_server_errors(settings, doc, "e-Waybill", e)
         return
 
-    except (AlreadyGeneratedError, NotApplicableError) as e:
+    except (AlreadyGeneratedError, NotApplicableError):
         if throw:
-            raise e
+            raise
 
         frappe.clear_last_message()
         return
@@ -247,7 +247,7 @@ def _generate_e_waybill(doc, throw=True, force=False):
             set_ewaybill_status(doc, "Failed")
 
         if throw:
-            raise e
+            raise
 
         if frappe.request:
             frappe.clear_last_message()
@@ -262,11 +262,11 @@ def _generate_e_waybill(doc, throw=True, force=False):
 
         return
 
-    except Exception as e:
+    except Exception:
         if doc.doctype == "Sales Invoice":
             set_ewaybill_status(doc, "Failed")
 
-        raise e
+        raise
 
     if result.error_code == "604":
         error_message = (

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -50,6 +50,7 @@ from india_compliance.gst_india.utils import (
     load_doc,
     parse_datetime,
     send_updated_doc,
+    set_ewaybill_status,
     update_onload,
 )
 from india_compliance.gst_india.utils.transaction_data import GSTTransactionData
@@ -154,12 +155,22 @@ def _generate_e_waybill(doc, throw=True, force=False):
     settings = frappe.get_cached_doc("GST Settings")
 
     if doc.ewaybill:
-        frappe.throw(
-            _("e-Waybill has already been generated for {0} {1}").format(
-                _(doc.doctype), frappe.bold(doc.name)
-            ),
-            exc=AlreadyGeneratedError,
+        message = _("e-Waybill has already been generated for {0} {1}").format(
+            _(doc.doctype), frappe.bold(doc.name)
         )
+
+        if throw:
+            frappe.throw(message, exc=AlreadyGeneratedError)
+
+        if frappe.request:
+            frappe.msgprint(
+                message,
+                _("Warning"),
+                indicator="yellow",
+                alert=True,
+            )
+
+            return
 
     try:
         if (
@@ -231,27 +242,30 @@ def _generate_e_waybill(doc, throw=True, force=False):
         frappe.clear_last_message()
         return
 
-    except frappe.ValidationError as e:
+    except (frappe.ValidationError, frappe.MandatoryError) as e:
         if doc.doctype == "Sales Invoice":
-            doc.db_set({"e_waybill_status": "Failed"})
+            set_ewaybill_status(doc, "Failed")
 
         if throw:
             raise e
 
-        frappe.clear_last_message()
-        frappe.msgprint(
-            _(
-                "e-Waybill auto-generation failed with error:<br>{0}<br><br>"
-                "Please rectify this issue and generate e-Waybill manually."
-            ).format(str(e)),
-            _("Warning"),
-            indicator="yellow",
-        )
+        if frappe.request:
+            frappe.clear_last_message()
+            frappe.msgprint(
+                _(
+                    "e-Waybill auto-generation failed with error:<br>{0}<br><br>"
+                    "Please rectify this issue and generate e-Waybill manually."
+                ).format(str(e)),
+                _("Warning"),
+                indicator="yellow",
+            )
+
         return
 
     except Exception as e:
         if doc.doctype == "Sales Invoice":
-            doc.db_set({"e_waybill_status": "Failed"})
+            set_ewaybill_status(doc, "Failed")
+
         raise e
 
     if result.error_code == "604":

--- a/india_compliance/gst_india/utils/transaction_data.py
+++ b/india_compliance/gst_india/utils/transaction_data.py
@@ -191,7 +191,11 @@ class GSTTransactionData:
     def validate_mode_of_transport(self, throw=True):
         def _throw(error):
             if throw:
-                frappe.throw(error, title=_("Invalid Transporter Details"))
+                frappe.throw(
+                    error,
+                    title=_("Invalid Transporter Details"),
+                    exc=frappe.MandatoryError,
+                )
 
         if not (mode_of_transport := self.doc.mode_of_transport):
             return _throw(

--- a/india_compliance/patches.txt
+++ b/india_compliance/patches.txt
@@ -4,7 +4,7 @@ india_compliance.patches.v15.remove_duplicate_web_template
 
 [post_model_sync]
 india_compliance.patches.v14.set_default_for_overridden_accounts_setting
-execute:from india_compliance.gst_india.setup import create_custom_fields; create_custom_fields() #67
+execute:from india_compliance.gst_india.setup import create_custom_fields; create_custom_fields() #68
 execute:from india_compliance.gst_india.setup import create_property_setters; create_property_setters() #11
 execute:from india_compliance.income_tax_india.setup import create_custom_fields; create_custom_fields() #4
 india_compliance.patches.post_install.remove_old_fields #2

--- a/india_compliance/utils/__init__.py
+++ b/india_compliance/utils/__init__.py
@@ -14,7 +14,8 @@ def execute_in_new_transaction(fn):
             return result
 
         finally:
-            frappe.db.close()
-            frappe.local.db = _db
+            if frappe.local.db is not _db:
+                frappe.db.close()
+                frappe.local.db = _db
 
     return wrapper

--- a/india_compliance/utils/__init__.py
+++ b/india_compliance/utils/__init__.py
@@ -4,6 +4,9 @@ import frappe
 
 
 def execute_in_new_transaction(fn):
+    if frappe.flags.in_test:
+        return fn
+
     @wraps(fn)
     def wrapper(*args, **kwargs):
         _db = frappe.local.db

--- a/india_compliance/utils/__init__.py
+++ b/india_compliance/utils/__init__.py
@@ -1,0 +1,20 @@
+from functools import wraps
+
+import frappe
+
+
+def execute_in_new_transaction(fn):
+    @wraps(fn)
+    def wrapper(*args, **kwargs):
+        _db = frappe.local.db
+        try:
+            frappe.connect(set_admin_as_user=False)
+            result = fn(*args, **kwargs)
+            frappe.db.commit()  # nosemgrep
+            return result
+
+        finally:
+            frappe.db.close()
+            frappe.local.db = _db
+
+    return wrapper

--- a/india_compliance/utils/change_log_utils.py
+++ b/india_compliance/utils/change_log_utils.py
@@ -1,6 +1,6 @@
 import frappe
 from frappe import _
-from frappe.utils import get_date_str, get_fullname
+from frappe.utils import escape_html, get_date_str, get_fullname
 
 
 def create_change_log_comment(
@@ -68,7 +68,7 @@ def create_change_log_comment(
     # Build table
     table_rows = "".join(
         [
-            f"<tr><td>{frappe.bold(_(label))}</td><td>{old_val}</td><td>{new_val}</td></tr>"
+            f"<tr><td>{frappe.bold(_(label))}</td><td>{escape_html(old_val)}</td><td>{escape_html(new_val)}</td></tr>"
             for label, old_val, new_val in changed_fields
         ]
     )


### PR DESCRIPTION
- if the e-invoice is already created and again for the same invoice we trigger generating e-invoice by anymeans (i.e. bulk), it was setting the `e-invoice status` as `Failed`

Support Tickets:
- https://support.frappe.io/helpdesk/tickets/49475
- https://support.frappe.io/helpdesk/tickets/56930
- https://support.frappe.io/helpdesk/tickets/57094

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit "Already Generated" and "Not Applicable" flows to skip completed or inapplicable documents; isolated transactions for status updates.

* **Bug Fixes**
  * Prevent duplicate e‑Invoice/e‑Waybill generation; failures now mark status "Failed" and present clear messages.

* **UI / Configuration**
  * Reordered e‑Waybill status options and added "Failed"; improved HTML-escaping in logs and messages.

* **Behavior Change**
  * Background enqueue for e‑Invoice may now surface errors instead of suppressing them.

* **Chores**
  * Incremented post-sync patch reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->