### PR TITLE
fix: do not update or validate gst details for non-gst transactions

### DIFF
--- a/india_compliance/gst_india/overrides/test_transaction.py
+++ b/india_compliance/gst_india/overrides/test_transaction.py
@@ -22,9 +22,10 @@ from erpnext.stock.doctype.purchase_receipt.purchase_receipt import (
     update_regional_gl_entries,
 )
 
-from india_compliance.gst_india.constants import SALES_DOCTYPES
+from india_compliance.gst_india.constants import GST_TAX_TYPES, SALES_DOCTYPES
 from india_compliance.gst_india.overrides.transaction import (
     DOCTYPES_WITH_GST_DETAIL,
+    ItemGSTDetails,
     validate_item_tax_template,
 )
 from india_compliance.gst_india.utils.tests import (
@@ -1033,6 +1034,47 @@ class TestTransaction(IntegrationTestCase):
             re.compile(r"^(.*Tax amount should be negative for GST Account.*)$"),
             doc.save,
         )
+
+    def test_item_gst_details_for_non_gst_transactions(self):
+        """
+        Test Non-GST Transactions can be processed without errors.
+        """
+        if self.doctype not in DOCTYPES_WITH_GST_DETAIL:
+            return
+
+        doc = create_transaction(
+            **self.transaction_details,
+            is_in_state=True,
+            do_not_submit=True,
+        )
+        for item in doc.items:
+            for tax in ["cgst", "sgst"]:
+                self.assertNotEqual(item.get(f"{tax}_rate"), 0)
+                self.assertNotEqual(item.get(f"{tax}_amount"), 0)
+
+        doc.is_opening = "Yes"  # opening transaction
+        doc.save()
+
+        # validate item gst details
+        for item in doc.items:
+            for tax in GST_TAX_TYPES:
+                self.assertEqual(item.get(f"{tax}_rate"), 0)
+                self.assertEqual(item.get(f"{tax}_amount"), 0)
+
+    def test_none_taxable_values(self):
+        """
+        For Non-GST Transactions (POS Merge Log) taxable value can be none
+        """
+        doc = create_transaction(
+            **self.transaction_details,
+            is_in_state=True,
+            is_opening="Yes",
+            do_not_save=True,
+        )
+        for item in doc.items:
+            item.taxable_value = None
+
+        ItemGSTDetails().update(doc)
 
 
 def create_refund_transaction():

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -1160,6 +1160,11 @@ class ItemGSTDetails:
             return
 
         self.get_item_defaults()
+        self.set_item_defaults()
+
+        if ignore_gst_validations(doc):
+            return
+
         self.set_tax_amount_precisions(doc.doctype)
         self.set_temp_item_wise_tax_detail_object()
 
@@ -1180,7 +1185,6 @@ class ItemGSTDetails:
         Update Item Tax Details
         """
         tax_differences = defaultdict(float)
-        self.set_item_defaults()
 
         for tax_row in self.doc.taxes:
             if not self.is_gst_tax_row(tax_row):
@@ -1700,6 +1704,9 @@ def update_gst_details(doc, method=None):
 
 
 def validate_item_tax_template(doc):
+    if ignore_gst_validations(doc):
+        return
+
     if not doc.items or not doc.taxes:
         return
 


### PR DESCRIPTION
Issue: The `update gst details` was being called for non-GST transactions, causing the error.


Steps to replicate:

- Create a POS Invoice for non-india company
- Create a closing entry
- Submit it.
An error will be raised.

Root Cause: `update_taxable_values` was not executed for non-gst transaction, but `update_gst_details` was called with taxable value as `None`.
```
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 115, in application
    response = frappe.api.handle(request)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/api/__init__.py", line 52, in handle
    data = endpoint(**arguments)
           ^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/api/v1.py", line 40, in handle_rpc_call
    return frappe.handler.handle()
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/handler.py", line 52, in handle
    data = execute_cmd(cmd)
           ^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/handler.py", line 85, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/__init__.py", line 1754, in call
    return fn(*args, **newargs)
           ^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/utils/typing_validations.py", line 32, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/desk/form/save.py", line 37, in savedocs
    doc.submit()
  File "apps/frappe/frappe/utils/typing_validations.py", line 32, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 1097, in submit
    return self._submit()
           ^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 1080, in _submit
    return self.save()
           ^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 378, in save
    return self._save(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 431, in _save
    self.run_post_save_methods()
  File "apps/frappe/frappe/model/document.py", line 1180, in run_post_save_methods
    self.run_method("on_submit")
  File "apps/frappe/frappe/model/document.py", line 1011, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 1371, in composer
    return composed(self, method, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 1353, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
                              ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 1008, in fn
    return method_object(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/erpnext/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.py", line 126, in on_submit
    consolidate_pos_invoices(closing_entry=self)
  File "apps/erpnext/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.py", line 509, in consolidate_pos_invoices
    create_merge_logs(invoice_by_customer, closing_entry)
  File "apps/erpnext/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.py", line 596, in create_merge_logs
    merge_log.submit()
  File "apps/frappe/frappe/utils/typing_validations.py", line 32, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 1097, in submit
    return self._submit()
           ^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 1080, in _submit
    return self.save()
           ^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 378, in save
    return self._save(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 431, in _save
    self.run_post_save_methods()
  File "apps/frappe/frappe/model/document.py", line 1180, in run_post_save_methods
    self.run_method("on_submit")
  File "apps/frappe/frappe/model/document.py", line 1011, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 1371, in composer
    return composed(self, method, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 1353, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
                              ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 1008, in fn
    return method_object(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/erpnext/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.py", line 125, in on_submit
    sales_invoice_doc = self.process_merging_into_sales_invoice(sales)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/erpnext/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.py", line 156, in process_merging_into_sales_invoice
    sales_invoice.save()
  File "apps/frappe/frappe/model/document.py", line 378, in save
    return self._save(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 400, in _save
    return self.insert()
           ^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 309, in insert
    self.run_before_save_methods()
  File "apps/frappe/frappe/model/document.py", line 1141, in run_before_save_methods
    self.run_method("before_save")
  File "apps/frappe/frappe/model/document.py", line 1011, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 1371, in composer
    return composed(self, method, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 1355, in runner
    add_to_return_value(self, f(self, method, *args, **kwargs))
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/india_compliance/india_compliance/gst_india/overrides/transaction.py", line 1897, in update_gst_details
    ItemGSTDetails().update(doc)
  File "apps/india_compliance/india_compliance/gst_india/overrides/transaction.py", line 1321, in update
    self.validate_item_gst_details()
  File "apps/india_compliance/india_compliance/gst_india/overrides/transaction.py", line 1523, in validate_item_gst_details
    expected_amt = self.get_item_tax_amount(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/india_compliance/india_compliance/gst_india/overrides/transaction.py", line 1594, in get_item_tax_amount
    multiplier = item.qty if tax == "cess_non_advol" else item.taxable_value / 100
                                                          ~~~~~~~~~~~~~~~~~~~^~~~~
TypeError: unsupported operand type(s) for /: 'NoneType' and 'int'

```

closes: https://github.com/resilient-tech/india-compliance/issues/3797
closes: https://github.com/resilient-tech/india-compliance/issues/3758



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved GST field reset behavior for non-GST transactions
  * Improved GST validation control flow for better transaction processing

* **Tests**
  * Added comprehensive test coverage for GST transaction scenarios

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->