### PR TITLE
fix: pass all kwargs to `get_subcontracting_receipt_references`

### DIFF
--- a/india_compliance/gst_india/overrides/subcontracting_transaction.py
+++ b/india_compliance/gst_india/overrides/subcontracting_transaction.py
@@ -405,7 +405,14 @@ def get_relevant_references(filters=None):
     if isinstance(filters, str):
         filters = frappe.parse_json(filters)
 
-    receipt_returns = get_subcontracting_receipt_references(filters=filters)
+    receipt_returns = get_subcontracting_receipt_references(
+        filters=filters,
+        doctype=None,
+        txt=None,
+        searchfield=None,
+        start=None,
+        page_len=None,
+    )
     stock_entries = get_stock_entry_references(
         filters=filters, only_linked_references=True
     )


### PR DESCRIPTION
Resolves: https://support.frappe.io/helpdesk/tickets/58799

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code optimization to improve code clarity and maintainability. No user-facing changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->