### PR TITLE
fix: change output dictionary to frappe._dict() in after_mapping_subcontracting_order

### DIFF
--- a/india_compliance/gst_india/overrides/subcontracting_transaction.py
+++ b/india_compliance/gst_india/overrides/subcontracting_transaction.py
@@ -69,7 +69,7 @@ def after_mapping_subcontracting_order(doc, method, source_doc):
     args = {"company": doc.company, "tax_category": tax_category}
 
     for item in doc.items:
-        out = {}
+        out = frappe._dict()
         item_doc = frappe.get_cached_doc("Item", item.item_code)
         get_item_tax_template(args, item_doc, out)
         item.item_tax_template = out.get("item_tax_template")


### PR DESCRIPTION
In ERPNext v16, the function get_item_tax_template has been updated to assign values using dot notation (e.g., out.item_tax_template = value).