### PR TITLE
fix: Unpacking of NoneType returned from frappe.get_cached_value()

### DIFF
--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -175,9 +175,12 @@ def get_tds_amount(doc):
 
 def is_indian_registered_company(doc):
     if not doc.get("company_gstin"):
-        country, gst_category = frappe.get_cached_value(
+        result=frappe.get_cached_value(
             "Company", doc.company, ("country", "gst_category")
         )
+        if result is None:
+            frappe.throw(_("{0} Company does not exist").format(doc.company), frappe.DoesNotExistError)
+        country, gst_category = result
 
         if country != "India" or gst_category == "Unregistered":
             return False
@@ -767,6 +770,8 @@ def validate_overseas_gst_category(doc):
 
 def get_regional_round_off_accounts(company, account_list):
     country = frappe.get_cached_value("Company", company, "country")
+    if country is None:
+        frappe.throw(_("Country does not exist"),frappe.DoesNotExistError)
     if country != "India" or not frappe.get_cached_value(
         "GST Settings", "GST Settings", "round_off_gst_values"
     ):
@@ -1508,6 +1513,9 @@ def set_reverse_charge_as_per_gst_settings(doc):
         ("enable_rcm_for_unregistered_supplier", "rcm_threshold"),
         as_dict=1,
     )
+
+    if gst_settings is None:
+        frappe.throw(_("GST Settings does not exist"),frappe.DoesNotExistError)
 
     if (
         not gst_settings.enable_rcm_for_unregistered_supplier

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -773,10 +773,12 @@ def validate_overseas_gst_category(doc):
 
 def get_regional_round_off_accounts(company, account_list):
     country = frappe.get_cached_value("Company", company, "country")
-    
+
     if country is None:
-        frappe.throw(_("Company {0} does not exist").format(company), frappe.DoesNotExistError)
-    
+        frappe.throw(
+            _("Company {0} does not exist").format(company), frappe.DoesNotExistError
+        )
+
     if country != "India" or not frappe.get_cached_value(
         "GST Settings", "GST Settings", "round_off_gst_values"
     ):

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -1517,9 +1517,6 @@ def set_reverse_charge_as_per_gst_settings(doc):
         as_dict=1,
     )
 
-    if gst_settings is None:
-        frappe.throw(_("GST Settings does not exist"), frappe.DoesNotExistError)
-
     if (
         not gst_settings.enable_rcm_for_unregistered_supplier
         or not doc.gst_category == "Unregistered"

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -774,7 +774,7 @@ def validate_overseas_gst_category(doc):
 def get_regional_round_off_accounts(company, account_list):
     country = frappe.get_cached_value("Company", company, "country")
     if country is None:
-        frappe.throw(_("Country does not exist"), frappe.DoesNotExistError)
+        frappe.throw(_("Company does not exist"), frappe.DoesNotExistError)
     if country != "India" or not frappe.get_cached_value(
         "GST Settings", "GST Settings", "round_off_gst_values"
     ):

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -180,7 +180,7 @@ def is_indian_registered_company(doc):
         )
         if result is None:
             frappe.throw(
-                _("{0} Company does not exist").format(doc.company),
+                _("Company {0} does not exist").format(doc.company),
                 frappe.DoesNotExistError,
             )
         country, gst_category = result
@@ -773,8 +773,10 @@ def validate_overseas_gst_category(doc):
 
 def get_regional_round_off_accounts(company, account_list):
     country = frappe.get_cached_value("Company", company, "country")
+    
     if country is None:
-        frappe.throw(_("Company does not exist"), frappe.DoesNotExistError)
+        frappe.throw(_("Company {0} does not exist").format(company), frappe.DoesNotExistError)
+    
     if country != "India" or not frappe.get_cached_value(
         "GST Settings", "GST Settings", "round_off_gst_values"
     ):

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -175,11 +175,14 @@ def get_tds_amount(doc):
 
 def is_indian_registered_company(doc):
     if not doc.get("company_gstin"):
-        result=frappe.get_cached_value(
+        result = frappe.get_cached_value(
             "Company", doc.company, ("country", "gst_category")
         )
         if result is None:
-            frappe.throw(_("{0} Company does not exist").format(doc.company), frappe.DoesNotExistError)
+            frappe.throw(
+                _("{0} Company does not exist").format(doc.company),
+                frappe.DoesNotExistError,
+            )
         country, gst_category = result
 
         if country != "India" or gst_category == "Unregistered":
@@ -771,7 +774,7 @@ def validate_overseas_gst_category(doc):
 def get_regional_round_off_accounts(company, account_list):
     country = frappe.get_cached_value("Company", company, "country")
     if country is None:
-        frappe.throw(_("Country does not exist"),frappe.DoesNotExistError)
+        frappe.throw(_("Country does not exist"), frappe.DoesNotExistError)
     if country != "India" or not frappe.get_cached_value(
         "GST Settings", "GST Settings", "round_off_gst_values"
     ):
@@ -1515,7 +1518,7 @@ def set_reverse_charge_as_per_gst_settings(doc):
     )
 
     if gst_settings is None:
-        frappe.throw(_("GST Settings does not exist"),frappe.DoesNotExistError)
+        frappe.throw(_("GST Settings does not exist"), frappe.DoesNotExistError)
 
     if (
         not gst_settings.enable_rcm_for_unregistered_supplier

--- a/india_compliance/gst_india/utils/transaction_data.py
+++ b/india_compliance/gst_india/utils/transaction_data.py
@@ -451,7 +451,10 @@ class GSTTransactionData:
         )
 
         if address is None:
-            frappe.throw(_("Address {0} does not exist").format(address_name), frappe.DoesNotExistError)
+            frappe.throw(
+                _("Address {0} does not exist").format(address_name),
+                frappe.DoesNotExistError,
+            )
 
         if address.gst_state_number == "97":  # For Other Territory
             address.pincode = "999999"

--- a/india_compliance/gst_india/utils/transaction_data.py
+++ b/india_compliance/gst_india/utils/transaction_data.py
@@ -450,6 +450,9 @@ class GSTTransactionData:
             as_dict=True,
         )
 
+        if address is None:
+            frappe.throw(_("Address does not exist"),frappe.DoesNotExistError)
+
         if address.gst_state_number == "97":  # For Other Territory
             address.pincode = "999999"
 

--- a/india_compliance/gst_india/utils/transaction_data.py
+++ b/india_compliance/gst_india/utils/transaction_data.py
@@ -451,7 +451,7 @@ class GSTTransactionData:
         )
 
         if address is None:
-            frappe.throw(_("Address does not exist"), frappe.DoesNotExistError)
+            frappe.throw(_("Address {0} does not exist").format(address_name), frappe.DoesNotExistError)
 
         if address.gst_state_number == "97":  # For Other Territory
             address.pincode = "999999"

--- a/india_compliance/gst_india/utils/transaction_data.py
+++ b/india_compliance/gst_india/utils/transaction_data.py
@@ -451,7 +451,7 @@ class GSTTransactionData:
         )
 
         if address is None:
-            frappe.throw(_("Address does not exist"),frappe.DoesNotExistError)
+            frappe.throw(_("Address does not exist"), frappe.DoesNotExistError)
 
         if address.gst_state_number == "97":  # For Other Territory
             address.pincode = "999999"


### PR DESCRIPTION
**frappe.get_cached_value() returns NoneType when DoesNotExistError is thrown by get_cached_doc().**

```
def get_cached_value(doctype: str, name: str, fieldname: str = "name", as_dict: bool = False) -> Any:
  try:
    doc = get_cached_doc(doctype, name)
  except DoesNotExistError:
    clear_last_message()
    return
```


**Earlier while using frappe.get_cached_value(), there was no checking done on the return value before unpacking, if the returned value is a NoneType or not. this may cause NoneType not iterable error.**

```
@frappe.whitelist(allow_guest=True)
def get_period_date_ranges(period, fiscal_year=None, year_start_date=None):
  from dateutil.relativedelta import relativedelta

  if not year_start_date:
    year_start_date, year_end_date = frappe.get_cached_value(
      "Fiscal Year", fiscal_year, ["year_start_date", "year_end_date"]
    )

  increment = {"Monthly": 1, "Quarterly": 3, "Half-Yearly": 6, "Yearly": 12}.get(period)

```

**To solve this, checks like below are added:**

```
result = ...
if result is None:
    frappe.throw(_("Fiscal year does not exist"), frappe.DoesNotExistError)

year_start_date, year_end_date = result
```