### PR TITLE
fix: correct taxable amount when group by invoice in GST Purchase Register

### DIFF
--- a/india_compliance/gst_india/utils/gstr3b/gstr3b_data.py
+++ b/india_compliance/gst_india/utils/gstr3b/gstr3b_data.py
@@ -61,6 +61,7 @@ DOCTYPE_CONDITION_MAP = {
 }
 
 AMOUNT_FIELDS = (
+    "taxable_value",
     "igst_amount",
     "cgst_amount",
     "sgst_amount",


### PR DESCRIPTION
Issue: The taxable value was not getting summed when the group by invoice was selected.


Frappe Support Issue: https://support.frappe.io/desk/hd-ticket/60930