### PR TITLE
fix(asset depreciation): calculate WDV depreciation using depreciable…

### DIFF
--- a/india_compliance/income_tax_india/overrides/asset_depreciation_schedule.py
+++ b/india_compliance/income_tax_india/overrides/asset_depreciation_schedule.py
@@ -82,7 +82,7 @@ def get_wdv_or_dd_depr_amount(
 
     if fb_row.frequency_of_depreciation == 12:
         if schedule_date < start_date_of_next_fiscal_year:
-            depreciation_amount = flt(asset.gross_purchase_amount) * (
+            depreciation_amount = flt(depreciable_value) * (
                 flt(rate_of_depreciation) / 100
             )
         else:
@@ -112,9 +112,7 @@ def get_wdv_or_dd_depr_amount(
 
         if schedule_date < start_date_of_next_fiscal_year:
             depreciation_amount = (
-                flt(asset.gross_purchase_amount)
-                * (flt(rate_of_depreciation) / 100)
-                * fraction
+                flt(depreciable_value) * (flt(rate_of_depreciation) / 100) * fraction
             )
         else:
             depreciation_amount = (


### PR DESCRIPTION
**Issue:** 
When an Asset is created, and later an Asset Value Adjustment is made to set a new asset value, the depreciation schedule gets recalculated by considering the original gross_purchase_amount instead of the updated depreciable value.

**Steps to Reproduce:**
1) Create an Asset with a depreciation method as "WDV".
2) Create an Asset Value Adjustment and update the asset value.
3) Observe that the Depreciation Schedule is recalculated with the initial asset value.

**Before:**

https://github.com/user-attachments/assets/9852ca64-093c-4e20-a9a7-b153131ac371

**After:**

https://github.com/user-attachments/assets/a040dbb0-a38e-4a6e-bfe7-8377051adb0e

