### PR TITLE
fix: audit trail mca notification broken link

### DIFF
--- a/india_compliance/audit_trail/constants/custom_fields.py
+++ b/india_compliance/audit_trail/constants/custom_fields.py
@@ -14,7 +14,7 @@ CUSTOM_FIELDS = {
             "label": "Enable Audit Trail",
             "description": (
                 "In accordance with <a"
-                " href='https://www.mca.gov.in/Ministry/pdf/AccountsAmendmentRules_24032021.pdf'"
+                " href='https://egazette.gov.in/WriteReadData/2021/226081.pdf'"
                 " target='_blank'> MCA Notification dated 24-03-2021</a>, enabling this"
                 " feature will ensure that each change made to the books of account"
                 " gets recorded. Once enabled, this feature cannot be disabled."

--- a/india_compliance/public/js/audit_trail_notification.js
+++ b/india_compliance/public/js/audit_trail_notification.js
@@ -12,7 +12,7 @@ $(document).on("app_ready", async function() {
 
             In accordance with
             <a
-              href='https://www.mca.gov.in/Ministry/pdf/AccountsAmendmentRules_24032021.pdf'
+              href='https://egazette.gov.in/WriteReadData/2021/226081.pdf'
               target='_blank'
             >MCA Notification dated 24-03-2021</a>,
             all companies registered in India are required to maintain an Audit Trail

--- a/india_compliance/public/js/setup_wizard.js
+++ b/india_compliance/public/js/setup_wizard.js
@@ -100,7 +100,7 @@ function update_erpnext_slides_settings() {
         label: __("Enable Audit Trail"),
         description: __(
             `In accordance with <a
-              href='https://www.mca.gov.in/Ministry/pdf/AccountsAmendmentRules_24032021.pdf'
+              href='https://egazette.gov.in/WriteReadData/2021/226081.pdf'
               target='_blank'
             > MCA Notification dated 24-03-2021</a>.<br>
             Once enabled, Audit Trail cannot be disabled.`,


### PR DESCRIPTION
Current link is broken, changed it to the e-gazette link, hoping they won't change the file paths.