### PR TITLE
feat: allow BOE for Import of Goods from SEZ

### DIFF
--- a/india_compliance/gst_india/client_scripts/purchase_invoice.js
+++ b/india_compliance/gst_india/client_scripts/purchase_invoice.js
@@ -24,13 +24,11 @@ frappe.ui.form.on(DOCTYPE, {
 
     onload(frm) {
         toggle_reverse_charge(frm);
-        toggle_boe_applicability(frm);
     },
 
     gst_category(frm) {
         validate_gst_hsn_code(frm);
         toggle_reverse_charge(frm);
-        toggle_boe_applicability(frm);
     },
 
     async after_save(frm) {
@@ -75,10 +73,6 @@ frappe.ui.form.on(DOCTYPE, {
         }
     },
 
-    is_boe_applicable(frm) {
-        frm.doc._user_set_boe_applicable = 1;
-    },
-
     before_save(frm) {
         // hack: values set in frm.doc are not available after save
         if (frm._inward_supply) frm.doc._inward_supply = frm._inward_supply;
@@ -107,17 +101,14 @@ frappe.ui.form.on("Purchase Invoice Item", {
     item_code(frm) {
         validate_gst_hsn_code(frm);
         toggle_reverse_charge(frm);
-        toggle_boe_applicability(frm);
     },
 
     items_remove(frm) {
         toggle_reverse_charge(frm);
-        toggle_boe_applicability(frm);
     },
 
     gst_hsn_code(frm) {
         validate_gst_hsn_code(frm);
-        toggle_boe_applicability(frm);
     },
 });
 
@@ -129,13 +120,6 @@ function toggle_reverse_charge(frm) {
         is_read_only = 1;
 
     frm.set_df_property("is_reverse_charge", "read_only", is_read_only);
-}
-
-function toggle_boe_applicability(frm) {
-    const hidden =
-        is_import_gst_category(frm.doc.gst_category) && !has_goods_items(frm) ? 1 : 0;
-
-    frm.set_df_property("is_boe_applicable", "hidden", hidden);
 }
 
 function validate_gst_hsn_code(frm) {

--- a/india_compliance/gst_india/client_scripts/purchase_invoice.js
+++ b/india_compliance/gst_india/client_scripts/purchase_invoice.js
@@ -22,11 +22,15 @@ frappe.ui.form.on(DOCTYPE, {
         india_compliance.setup_itc_claim_period_query(frm);
     },
 
-    onload: toggle_reverse_charge,
+    onload(frm) {
+        toggle_reverse_charge(frm);
+        toggle_boe_applicability(frm);
+    },
 
     gst_category(frm) {
         validate_gst_hsn_code(frm);
         toggle_reverse_charge(frm);
+        toggle_boe_applicability(frm);
     },
 
     async after_save(frm) {
@@ -71,7 +75,11 @@ frappe.ui.form.on(DOCTYPE, {
         }
     },
 
-    before_save: function (frm) {
+    is_boe_applicable(frm) {
+        frm.doc._user_set_boe_applicable = 1;
+    },
+
+    before_save(frm) {
         // hack: values set in frm.doc are not available after save
         if (frm._inward_supply) frm.doc._inward_supply = frm._inward_supply;
     },
@@ -99,26 +107,35 @@ frappe.ui.form.on("Purchase Invoice Item", {
     item_code(frm) {
         validate_gst_hsn_code(frm);
         toggle_reverse_charge(frm);
+        toggle_boe_applicability(frm);
     },
 
-    items_remove: toggle_reverse_charge,
+    items_remove(frm) {
+        toggle_reverse_charge(frm);
+        toggle_boe_applicability(frm);
+    },
 
-    gst_hsn_code: validate_gst_hsn_code,
+    gst_hsn_code(frm) {
+        validate_gst_hsn_code(frm);
+        toggle_boe_applicability(frm);
+    },
 });
 
 function toggle_reverse_charge(frm) {
     let is_read_only = 0;
     if (!is_import_gst_category(frm.doc.gst_category)) is_read_only = 0;
     // has_goods_item
-    else if (
-        frm.doc.items.length > 0 &&
-        frm.doc.items.some(
-            item => item.gst_hsn_code && !item.gst_hsn_code.startsWith("99"),
-        )
-    )
+    else if (has_goods_items(frm))
         is_read_only = 1;
 
     frm.set_df_property("is_reverse_charge", "read_only", is_read_only);
+}
+
+function toggle_boe_applicability(frm) {
+    const hidden =
+        is_import_gst_category(frm.doc.gst_category) && !has_goods_items(frm) ? 1 : 0;
+
+    frm.set_df_property("is_boe_applicable", "hidden", hidden);
 }
 
 function validate_gst_hsn_code(frm) {
@@ -135,6 +152,15 @@ function validate_gst_hsn_code(frm) {
             ]),
         );
     }
+}
+
+function has_goods_items(frm) {
+    return (
+        frm.doc.items.length > 0 &&
+        frm.doc.items.some(
+            item => item.gst_hsn_code && !item.gst_hsn_code.startsWith("99"),
+        )
+    );
 }
 
 function is_import_gst_category(gst_category) {

--- a/india_compliance/gst_india/client_scripts/purchase_invoice.js
+++ b/india_compliance/gst_india/client_scripts/purchase_invoice.js
@@ -1,4 +1,6 @@
 const DOCTYPE = "Purchase Invoice";
+const IMPORT_GST_CATEGORIES = ["Overseas", "SEZ"];
+
 setup_e_waybill_actions(DOCTYPE);
 
 frappe.ui.form.on(DOCTYPE, {
@@ -52,22 +54,21 @@ frappe.ui.form.on(DOCTYPE, {
             show_sandbox_mode_indicator();
 
         if (
-            frm.doc.docstatus !== 1 ||
-            frm.doc.gst_category !== "Overseas" ||
-            frm.doc.__onload?.bill_of_entry_exists
-        )
-            return;
-
-        frm.add_custom_button(
-            __("Bill of Entry"),
-            () => {
-                frappe.model.open_mapped_doc({
-                    method: "india_compliance.gst_india.doctype.bill_of_entry.bill_of_entry.make_bill_of_entry",
-                    frm: frm,
-                });
-            },
-            __("Create"),
-        );
+            frm.doc.docstatus === 1 &&
+            is_import_gst_category(frm.doc.gst_category) &&
+            frm.doc.__onload?.has_pending_boe_qty
+        ) {
+            frm.add_custom_button(
+                __("Bill of Entry"),
+                () => {
+                    frappe.model.open_mapped_doc({
+                        method: "india_compliance.gst_india.doctype.bill_of_entry.bill_of_entry.make_bill_of_entry",
+                        frm: frm,
+                    });
+                },
+                __("Create"),
+            );
+        }
     },
 
     before_save: function (frm) {
@@ -107,7 +108,7 @@ frappe.ui.form.on("Purchase Invoice Item", {
 
 function toggle_reverse_charge(frm) {
     let is_read_only = 0;
-    if (frm.doc.gst_category !== "Overseas") is_read_only = 0;
+    if (!is_import_gst_category(frm.doc.gst_category)) is_read_only = 0;
     // has_goods_item
     else if (
         frm.doc.items.length > 0 &&
@@ -122,12 +123,20 @@ function toggle_reverse_charge(frm) {
 
 function validate_gst_hsn_code(frm) {
     if (
-        frm.doc.gst_category !== "Overseas" ||
+        !is_import_gst_category(frm.doc.gst_category) ||
         !india_compliance.is_indian_registered_company(frm.doc.company)
     )
         return;
 
     if (frm.doc.items.some(item => item.item_name && !item.gst_hsn_code)) {
-        frappe.throw(__("GST HSN Code is mandatory for Overseas Purchase Invoice."));
+        frappe.throw(
+            __("GST HSN Code is mandatory for {0} Purchase Invoice.", [
+                frm.doc.gst_category,
+            ]),
+        );
     }
+}
+
+function is_import_gst_category(gst_category) {
+    return IMPORT_GST_CATEGORIES.includes(gst_category);
 }

--- a/india_compliance/gst_india/client_scripts/purchase_invoice.js
+++ b/india_compliance/gst_india/client_scripts/purchase_invoice.js
@@ -55,7 +55,7 @@ frappe.ui.form.on(DOCTYPE, {
 
         if (
             frm.doc.docstatus === 1 &&
-            is_import_gst_category(frm.doc.gst_category) &&
+            frm.doc.itc_classification === "Import Of Goods" &&
             frm.doc.__onload?.has_pending_boe_qty
         ) {
             frm.add_custom_button(

--- a/india_compliance/gst_india/client_scripts/purchase_invoice.js
+++ b/india_compliance/gst_india/client_scripts/purchase_invoice.js
@@ -57,7 +57,7 @@ frappe.ui.form.on(DOCTYPE, {
 
         if (
             frm.doc.docstatus === 1 &&
-            frm.doc.itc_classification === "Import Of Goods" &&
+            frm.doc.is_boe_applicable &&
             frm.doc.__onload?.has_pending_boe_qty
         ) {
             frm.add_custom_button(

--- a/india_compliance/gst_india/constants/__init__.py
+++ b/india_compliance/gst_india/constants/__init__.py
@@ -1484,3 +1484,4 @@ ORIGINAL_VS_AMENDED = (
 E_INVOICE_MASTER_CODES_URL = "https://einvoice1.gst.gov.in/Others/MasterCodes"
 
 VALID_HSN_LENGTHS = (4, 6, 8)
+SERVICE_HSN_PREFIX = "99"

--- a/india_compliance/gst_india/constants/__init__.py
+++ b/india_compliance/gst_india/constants/__init__.py
@@ -61,6 +61,7 @@ EXPORT_TYPES = (
 )
 
 TAXABLE_GST_TREATMENTS = ("Taxable", "Zero-Rated")
+IMPORT_GST_CATEGORIES = ("Overseas", "SEZ")
 
 
 STATE_NUMBERS = {

--- a/india_compliance/gst_india/constants/custom_fields.py
+++ b/india_compliance/gst_india/constants/custom_fields.py
@@ -1039,6 +1039,7 @@ CUSTOM_FIELDS = {
             "label": "Pending BOE Qty",
             "fieldtype": "Float",
             "insert_after": "rejected_qty",
+            "read_only": 1,
         },
     ],
     "Purchase Receipt": [

--- a/india_compliance/gst_india/constants/custom_fields.py
+++ b/india_compliance/gst_india/constants/custom_fields.py
@@ -1039,6 +1039,7 @@ CUSTOM_FIELDS = {
             "insert_after": "is_reverse_charge",
             "print_hide": 1,
             "default": 0,
+            "read_only": 1,
             "depends_on": 'eval:doc.itc_classification === "Import Of Goods"',
         },
     ],

--- a/india_compliance/gst_india/constants/custom_fields.py
+++ b/india_compliance/gst_india/constants/custom_fields.py
@@ -1039,8 +1039,7 @@ CUSTOM_FIELDS = {
             "insert_after": "is_reverse_charge",
             "print_hide": 1,
             "default": 0,
-            "allow_on_submit": 1,
-            "depends_on": 'eval:doc.gst_category == "Overseas" || doc.gst_category == "SEZ"',
+            "depends_on": 'eval:doc.itc_classification === "Import Of Goods"',
         },
     ],
     "Purchase Invoice Item": [

--- a/india_compliance/gst_india/constants/custom_fields.py
+++ b/india_compliance/gst_india/constants/custom_fields.py
@@ -1032,6 +1032,16 @@ CUSTOM_FIELDS = {
             "description": "GSTR-3B period for claiming ITC (MMYYYY) or 'Deferred' to postpone.",
             "allow_on_submit": 1,
         },
+        {
+            "fieldname": "is_boe_applicable",
+            "label": "Is BOE Applicable",
+            "fieldtype": "Check",
+            "insert_after": "is_reverse_charge",
+            "print_hide": 1,
+            "default": 0,
+            "allow_on_submit": 1,
+            "depends_on": 'eval:doc.gst_category == "Overseas" || doc.gst_category == "SEZ"',
+        },
     ],
     "Purchase Invoice Item": [
         {

--- a/india_compliance/gst_india/doctype/bill_of_entry/bill_of_entry.py
+++ b/india_compliance/gst_india/doctype/bill_of_entry/bill_of_entry.py
@@ -13,6 +13,7 @@ from erpnext.accounts.general_ledger import make_gl_entries, make_reverse_gl_ent
 from erpnext.controllers.accounts_controller import AccountsController
 from erpnext.stock.get_item_details import ItemDetailsCtx, _get_item_tax_template
 
+from india_compliance.gst_india.constants import IMPORT_GST_CATEGORIES
 from india_compliance.gst_india.overrides.ineligible_itc import (
     update_landed_cost_voucher_for_gst_expense,
     update_regional_gl_entries,
@@ -184,11 +185,11 @@ class BillofEntry(Document):
                     ).format(invoice.name)
                 )
 
-            if invoice.gst_category != "Overseas":
+            if invoice.gst_category not in IMPORT_GST_CATEGORIES:
                 frappe.throw(
                     _(
-                        "GST Category must be set to Overseas in Purchase Invoice {0} to create"
-                        " a Bill of Entry"
+                        "GST Category must be set to Overseas / SEZ in Purchase Invoice"
+                        " {0} to create a Bill of Entry"
                     ).format(invoice.name)
                 )
 
@@ -545,7 +546,7 @@ def make_bill_of_entry(source_name: str, target_doc: str | None = None):
                 "field_no_map": ["posting_date"],
                 "validation": {
                     "docstatus": ["=", 1],
-                    "gst_category": ["=", "Overseas"],
+                    "gst_category": ["in", list(IMPORT_GST_CATEGORIES)],
                 },
             },
             "Purchase Invoice Item": {
@@ -838,7 +839,7 @@ def fetch_pending_boe_invoices(
         filters={
             **filters,
             "docstatus": 1,
-            "gst_category": "Overseas",
+            "gst_category": ["in", list(IMPORT_GST_CATEGORIES)],
             "pending_boe_qty": [">", 0],
         },
         fields=["name", "company", "company_gstin"],

--- a/india_compliance/gst_india/doctype/bill_of_entry/bill_of_entry.py
+++ b/india_compliance/gst_india/doctype/bill_of_entry/bill_of_entry.py
@@ -808,6 +808,7 @@ def get_pi_items(purchase_invoices):
             pi_item.name.as_("pi_detail"),
         )
         .where(pi_item.parent.isin(purchase_invoices))
+        .where(pi.is_boe_applicable == 1)
         .where(pi_item.pending_boe_qty > 0)
         .run(as_dict=True)
     )
@@ -840,6 +841,7 @@ def fetch_pending_boe_invoices(
             **filters,
             "docstatus": 1,
             "gst_category": ["in", list(IMPORT_GST_CATEGORIES)],
+            "is_boe_applicable": 1,
             "pending_boe_qty": [">", 0],
         },
         fields=["name", "company", "company_gstin"],

--- a/india_compliance/gst_india/doctype/bill_of_entry/test_bill_of_entry.py
+++ b/india_compliance/gst_india/doctype/bill_of_entry/test_bill_of_entry.py
@@ -448,15 +448,17 @@ class TestBillofEntry(IntegrationTestCase):
         pi.reload()
         self.assertEqual(pi.items[0].pending_boe_qty, 2)
 
-    def test_unchecked_boe_applicable_excludes_invoice_from_boe(self):
+    def test_boe_not_applicable_excludes_invoice_from_boe(self):
+        """
+        An Import Of Service invoice (is_boe_applicable auto-set to 0) must not
+        appear in get_pi_items or fetch_pending_boe_invoices.
+        """
         pi = create_purchase_invoice(
             supplier="_Test Foreign Supplier",
-            update_stock=1,
-            do_not_save=True,
+            item_code="_Test Service Item",
             do_not_submit=True,
         )
-        pi.is_boe_applicable = 0
-        pi.insert()
+        self.assertEqual(pi.is_boe_applicable, 0)
         pi.submit()
 
         pi.reload()

--- a/india_compliance/gst_india/doctype/bill_of_entry/test_bill_of_entry.py
+++ b/india_compliance/gst_india/doctype/bill_of_entry/test_bill_of_entry.py
@@ -10,6 +10,7 @@ from frappe.tests import IntegrationTestCase
 from frappe.utils import today
 
 from india_compliance.gst_india.doctype.bill_of_entry.bill_of_entry import (
+    fetch_pending_boe_invoices,
     get_pi_items,
     make_bill_of_entry,
     make_journal_entry_for_payment,
@@ -446,3 +447,29 @@ class TestBillofEntry(IntegrationTestCase):
         boe.cancel()
         pi.reload()
         self.assertEqual(pi.items[0].pending_boe_qty, 2)
+
+    def test_unchecked_boe_applicable_excludes_invoice_from_boe(self):
+        pi = create_purchase_invoice(
+            supplier="_Test Foreign Supplier",
+            update_stock=1,
+            do_not_save=True,
+            do_not_submit=True,
+        )
+        pi.is_boe_applicable = 0
+        pi.insert()
+        pi.submit()
+
+        pi.reload()
+        self.assertEqual(pi.items[0].pending_boe_qty, 0)
+        self.assertEqual(get_pi_items([pi.name]), [])
+
+        pending_invoices = fetch_pending_boe_invoices(
+            doctype="Purchase Invoice",
+            txt="",
+            searchfield="name",
+            start=0,
+            page_len=20,
+            filters={},
+        )
+
+        self.assertNotIn(pi.name, [invoice.name for invoice in pending_invoices])

--- a/india_compliance/gst_india/doctype/bill_of_entry/test_bill_of_entry.py
+++ b/india_compliance/gst_india/doctype/bill_of_entry/test_bill_of_entry.py
@@ -416,3 +416,33 @@ class TestBillofEntry(IntegrationTestCase):
 
         pi.reload()
         self.assertEqual(pi.items[0].pending_boe_qty, 0)
+
+    def test_sez_pending_boe_qty(self):
+        """
+        SEZ goods invoice: pending_boe_qty decrements on BOE submit,
+        restores on cancel, and handles partial BOE correctly.
+        """
+        pi = create_purchase_invoice(
+            supplier="_Test Registered Supplier",
+            update_stock=1,
+            qty=2,
+            do_not_submit=True,
+            do_not_save=True,
+        )
+        pi.gst_category = "SEZ"
+        pi.insert()
+        pi.submit()
+
+        boe = make_bill_of_entry(pi.name)
+        boe.bill_of_entry_no = "SEZ-BOE-002"
+        boe.bill_of_entry_date = today()
+        boe.items[0].qty = 1
+        boe.save()
+        boe.submit()
+
+        pi.reload()
+        self.assertEqual(pi.items[0].pending_boe_qty, 1)
+
+        boe.cancel()
+        pi.reload()
+        self.assertEqual(pi.items[0].pending_boe_qty, 2)

--- a/india_compliance/gst_india/doctype/bill_of_entry/test_bill_of_entry.py
+++ b/india_compliance/gst_india/doctype/bill_of_entry/test_bill_of_entry.py
@@ -378,3 +378,41 @@ class TestBillofEntry(IntegrationTestCase):
         # ITC claim period should be set to posting period by default
         expected_period = format_period(boe.posting_date)
         self.assertEqual(boe.itc_claim_period, expected_period)
+
+    def test_create_bill_of_entry_for_sez_goods_only(self):
+        """
+        SEZ goods-only invoice should allow BOE creation
+        """
+        pi = create_purchase_invoice(
+            supplier="_Test Registered Supplier",
+            update_stock=1,
+            do_not_submit=True,
+            do_not_save=True,
+        )
+        pi.gst_category = "SEZ"
+        pi.insert()
+        pi.submit()
+
+        pi.reload()
+        self.assertEqual(pi.items[0].pending_boe_qty, 1)
+
+        boe = make_bill_of_entry(pi.name)
+        self.assertEqual(len(boe.items), 1)
+        self.assertEqual(boe.items[0].pi_detail, pi.items[0].name)
+
+    def test_sez_service_invoice_no_boe(self):
+        """
+        SEZ service-only invoice should have pending_boe_qty = 0
+        """
+        pi = create_purchase_invoice(
+            supplier="_Test Registered Supplier",
+            item_code="_Test Service Item",
+            do_not_submit=True,
+            do_not_save=True,
+        )
+        pi.gst_category = "SEZ"
+        pi.insert()
+        pi.submit()
+
+        pi.reload()
+        self.assertEqual(pi.items[0].pending_boe_qty, 0)

--- a/india_compliance/gst_india/doctype/gstr_3b_report/gstr_3b_report.py
+++ b/india_compliance/gst_india/doctype/gstr_3b_report/gstr_3b_report.py
@@ -12,6 +12,7 @@ from openpyxl.cell.cell import MergedCell
 import frappe
 from frappe import _
 from frappe.model.document import Document
+from frappe.query_builder import Case
 from frappe.query_builder.functions import IfNull, Sum
 from frappe.utils import cint, cstr, flt, get_first_day, get_last_day
 
@@ -339,31 +340,38 @@ class GSTR3BReport(Document):
         boe = frappe.qb.DocType("Bill of Entry")
         boe_taxes = frappe.qb.DocType("India Compliance Taxes and Charges")
 
-        def _get_tax_amount(account_type):
-            query = (
-                frappe.qb.from_(boe)
-                .select(Sum(boe_taxes.tax_amount))
-                .join(boe_taxes)
-                .on(boe_taxes.parent == boe.name)
-                .where(
-                    boe.company_gstin.eq(self.gst_details.get("gstin"))
-                    & boe.docstatus.eq(1)
-                    & boe_taxes.gst_tax_type.eq(account_type)
-                )
-                .where(boe_taxes.parenttype == "Bill of Entry")
+        query = (
+            frappe.qb.from_(boe)
+            .join(boe_taxes)
+            .on(boe_taxes.parent == boe.name)
+            .select(
+                Sum(
+                    Case()
+                    .when(boe_taxes.gst_tax_type == "igst", boe_taxes.tax_amount)
+                    .else_(0)
+                ).as_("iamt"),
+                Sum(
+                    Case()
+                    .when(
+                        boe_taxes.gst_tax_type.isin(["cess", "cess_non_advol"]),
+                        boe_taxes.tax_amount,
+                    )
+                    .else_(0)
+                ).as_("csamt"),
             )
-
-            query = self.apply_itc_period_filter(
-                query,
-                boe,
+            .where(
+                boe.company_gstin.eq(self.gst_details.get("gstin"))
+                & boe.docstatus.eq(1)
             )
+            .where(boe_taxes.parenttype == "Bill of Entry")
+        )
 
-            return query.run()[0][0] or 0
+        query = self.apply_itc_period_filter(query, boe)
 
-        igst, cess = _get_tax_amount("igst"), _get_tax_amount("cess")
-        itc_details.setdefault("Import Of Goods", {"iamt": 0, "csamt": 0})
-        itc_details["Import Of Goods"]["iamt"] += igst
-        itc_details["Import Of Goods"]["csamt"] += cess
+        for row in query.run(as_dict=True):
+            itc_details.setdefault("Import Of Goods", {"iamt": 0, "csamt": 0})
+            itc_details["Import Of Goods"]["iamt"] += row.iamt or 0
+            itc_details["Import Of Goods"]["csamt"] += row.csamt or 0
 
     def set_reclaim_of_itc_reversal(self):
         journal_entry = frappe.qb.DocType("Journal Entry")
@@ -412,7 +420,11 @@ class GSTR3BReport(Document):
             )
             .where(pi.company == self.company)
             .where(pi.company_gstin == self.gst_details.get("gstin"))
-            .where(pi.gst_category != "Overseas")
+            .where(
+                IfNull(pi.itc_classification, "").notin(
+                    ["Import Of Goods", "Import Of Service"]
+                )
+            )
         )
 
         query = self.apply_itc_period_filter(query, pi)

--- a/india_compliance/gst_india/doctype/gstr_3b_report/gstr_3b_report.py
+++ b/india_compliance/gst_india/doctype/gstr_3b_report/gstr_3b_report.py
@@ -419,11 +419,6 @@ class GSTR3BReport(Document):
             )
             .where(pi.company == self.company)
             .where(pi.company_gstin == self.gst_details.get("gstin"))
-            .where(
-                IfNull(pi.itc_classification, "").notin(
-                    ["Import Of Goods", "Import Of Service"]
-                )
-            )
         )
 
         query = self.apply_itc_period_filter(query, pi)

--- a/india_compliance/gst_india/doctype/gstr_3b_report/gstr_3b_report.py
+++ b/india_compliance/gst_india/doctype/gstr_3b_report/gstr_3b_report.py
@@ -16,7 +16,11 @@ from frappe.query_builder import Case
 from frappe.query_builder.functions import IfNull, Sum
 from frappe.utils import cint, cstr, flt, get_first_day, get_last_day
 
-from india_compliance.gst_india.constants import INVOICE_DOCTYPES, STATE_NUMBERS
+from india_compliance.gst_india.constants import (
+    INVOICE_DOCTYPES,
+    STATE_NUMBERS,
+    TAXABLE_GST_TREATMENTS,
+)
 from india_compliance.gst_india.overrides.transaction import is_inter_state_supply
 from india_compliance.gst_india.report.gstr_3b_details.gstr_3b_details import (
     IneligibleITC,
@@ -414,7 +418,7 @@ class GSTR3BReport(Document):
             .where(pi.is_opening == "No")
             .where(pi.company_gstin != IfNull(pi.supplier_gstin, ""))
             .where(
-                (pi_item.gst_treatment != "Taxable")
+                (pi_item.gst_treatment.notin(TAXABLE_GST_TREATMENTS))
                 | (pi.gst_category == "Registered Composition")
             )
             .where(pi.company == self.company)

--- a/india_compliance/gst_india/doctype/gstr_3b_report/gstr_3b_report.py
+++ b/india_compliance/gst_india/doctype/gstr_3b_report/gstr_3b_report.py
@@ -315,6 +315,7 @@ class GSTR3BReport(Document):
                     IfNull(purchase_invoice.ineligibility_reason, "")
                     != "ITC restricted due to PoS rules"
                 )  # Ignore as it is Ineligible for ITC
+                & (purchase_invoice.is_boe_applicable == 0)
             )
             .groupby(purchase_invoice.itc_classification)
         )

--- a/india_compliance/gst_india/doctype/gstr_3b_report/gstr_3b_report.py
+++ b/india_compliance/gst_india/doctype/gstr_3b_report/gstr_3b_report.py
@@ -359,10 +359,9 @@ class GSTR3BReport(Document):
                     .else_(0)
                 ).as_("csamt"),
             )
-            .where(
-                boe.company_gstin.eq(self.gst_details.get("gstin"))
-                & boe.docstatus.eq(1)
-            )
+            .where(boe.company_gstin.eq(self.gst_details.get("gstin")))
+            .where(boe.docstatus.eq(1))
+            .where(boe.company.eq(self.company))
             .where(boe_taxes.parenttype == "Bill of Entry")
         )
 

--- a/india_compliance/gst_india/doctype/gstr_3b_report/test_gstr_3b_report.py
+++ b/india_compliance/gst_india/doctype/gstr_3b_report/test_gstr_3b_report.py
@@ -7,9 +7,17 @@ import frappe
 from frappe.tests import IntegrationTestCase, change_settings
 from frappe.utils import get_month, getdate
 
+from india_compliance.gst_india.doctype.bill_of_entry.bill_of_entry import (
+    make_bill_of_entry,
+)
 from india_compliance.gst_india.doctype.gstr_3b_report.gstr_3b_report import (
     GSTR3BExcelExporter,
 )
+from india_compliance.gst_india.overrides.test_transaction import create_cess_accounts
+from india_compliance.gst_india.report.gstr_3b_details.gstr_3b_details import (
+    GSTR3B_Inward_Nil_Exempt,
+)
+from india_compliance.gst_india.utils import get_gst_accounts_by_type
 from india_compliance.gst_india.utils.tests import (
     create_purchase_invoice,
     create_sales_invoice,
@@ -27,6 +35,7 @@ class TestGSTR3BReport(IntegrationTestCase):
             "Purchase Invoice",
             "GSTR 3B Report",
             "Journal Entry",
+            "Bill of Entry",
         ):
             frappe.db.delete(doctype, filters=filters)
 
@@ -226,6 +235,135 @@ class TestGSTR3BReport(IntegrationTestCase):
         self.assertEqual(output["itc_elg"]["itc_rev"][0]["samt"], 9.0)
         self.assertEqual(output["itc_elg"]["itc_net"]["camt"], -9.0)
         self.assertEqual(output["itc_elg"]["itc_net"]["samt"], -9.0)
+
+    @change_settings("GST Settings", {"enable_overseas_transactions": 1})
+    def test_inward_nil_non_gst_report_includes_sez_services(self):
+        pi = create_purchase_invoice(
+            supplier="_Test Registered Supplier",
+            do_not_save=1,
+            do_not_submit=1,
+            item_code="_Test Service Item",
+        )
+        pi.gst_category = "SEZ"
+        pi.insert()
+        pi.submit()
+
+        today = getdate()
+
+        report = GSTR3B_Inward_Nil_Exempt(
+            {
+                "company": "_Test Indian Registered Company",
+                "company_gstin": "24AAQCA8719H1ZC",
+                "year": today.year,
+                "month_or_quarter": get_month(today),
+            }
+        )
+
+        rows = report.get_inward_nil_exempt()
+        self.assertIn(pi.name, [row.voucher_no for row in rows])
+
+    @change_settings("GST Settings", {"enable_overseas_transactions": 1})
+    def test_inward_nil_non_gst_report_excludes_overseas_import_services(self):
+        pi = create_purchase_invoice(
+            supplier="_Test Foreign Supplier",
+            do_not_save=1,
+            do_not_submit=1,
+            item_code="_Test Service Item",
+        )
+        pi.insert()
+        pi.submit()
+
+        self.assertEqual(pi.itc_classification, "Import Of Service")
+
+        today = getdate()
+
+        report = GSTR3B_Inward_Nil_Exempt(
+            {
+                "company": "_Test Indian Registered Company",
+                "company_gstin": "24AAQCA8719H1ZC",
+                "year": today.year,
+                "month_or_quarter": get_month(today),
+            }
+        )
+
+        rows = report.get_inward_nil_exempt()
+        self.assertNotIn(pi.name, [row.voucher_no for row in rows])
+
+    @change_settings("GST Settings", {"enable_overseas_transactions": 1})
+    def test_gstr_3b_report_includes_boe_in_import_of_goods(self):
+        pi = create_purchase_invoice(supplier="_Test Foreign Supplier", update_stock=1)
+
+        boe = make_bill_of_entry(pi.name)
+        boe.items[0].customs_duty = 100
+        boe.bill_of_entry_no = "BOE-001"
+        boe.bill_of_entry_date = getdate()
+        boe.save()
+        boe.submit()
+
+        today = getdate()
+
+        report = frappe.get_doc(
+            {
+                "doctype": "GSTR 3B Report",
+                "company": "_Test Indian Registered Company",
+                "company_gstin": "24AAQCA8719H1ZC",
+                "year": today.year,
+                "month_or_quarter": get_month(today),
+            }
+        ).insert()
+
+        output = json.loads(report.json_output)
+        itc_available = {
+            row["ty"]: row for row in output.get("itc_elg", {}).get("itc_avl", [])
+        }
+
+        self.assertEqual(itc_available["IMPG"].get("iamt"), 36.0)
+        self.assertEqual(itc_available["IMPG"].get("csamt"), 0.0)
+
+    @change_settings("GST Settings", {"enable_overseas_transactions": 1})
+    def test_gstr_3b_report_includes_boe_cess_non_advol_in_csamt(self):
+        pi = create_purchase_invoice(supplier="_Test Foreign Supplier", update_stock=1)
+
+        boe = make_bill_of_entry(pi.name)
+        boe.items[0].customs_duty = 100
+        boe.bill_of_entry_no = "BOE-002"
+        boe.bill_of_entry_date = getdate()
+
+        create_cess_accounts()
+        gst_accounts = get_gst_accounts_by_type(boe.company, "Input")
+        boe.append(
+            "taxes",
+            {
+                "charge_type": "On Item Quantity",
+                "account_head": gst_accounts.cess_non_advol_account,
+                "rate": 20,
+                "cost_center": "Main - _TIRC",
+                "item_wise_tax_rates": {},
+            },
+        )
+
+        boe.save()
+        boe.submit()
+
+        today = getdate()
+
+        report = frappe.get_doc(
+            {
+                "doctype": "GSTR 3B Report",
+                "company": "_Test Indian Registered Company",
+                "company_gstin": "24AAQCA8719H1ZC",
+                "year": today.year,
+                "month_or_quarter": get_month(today),
+            }
+        ).insert()
+
+        output = json.loads(report.json_output)
+        itc_available = {
+            row["ty"]: row for row in output.get("itc_elg", {}).get("itc_avl", [])
+        }
+
+        self.assertEqual(itc_available["IMPG"].get("iamt"), 36.0)
+        self.assertEqual(itc_available["IMPG"].get("csamt"), 20.0)
 
 
 def create_sales_invoices():

--- a/india_compliance/gst_india/doctype/gstr_3b_report/test_gstr_3b_report.py
+++ b/india_compliance/gst_india/doctype/gstr_3b_report/test_gstr_3b_report.py
@@ -368,15 +368,16 @@ class TestGSTR3BReport(IntegrationTestCase):
     @change_settings("GST Settings", {"enable_overseas_transactions": 1})
     def test_itc_from_pi_when_boe_not_applicable(self):
         """When is_boe_applicable=0, ITC should be reported from Purchase Invoice directly"""
+        # Use SEZ registered supplier: has GSTIN + itc_classification = Import Of Goods
+        # GST taxes on PI → is_boe_applicable auto-set to 0 (no BOE needed)
         pi = create_purchase_invoice(
-            supplier="_Test Foreign Supplier",
+            supplier="_Test Registered Supplier",
             update_stock=1,
             is_out_state=True,
             do_not_save=1,
             do_not_submit=1,
         )
-        # Manually set is_boe_applicable=0 to skip BOE path
-        pi.is_boe_applicable = 0
+        pi.gst_category = "SEZ"
         pi.insert()
         pi.submit()
 

--- a/india_compliance/gst_india/doctype/gstr_3b_report/test_gstr_3b_report.py
+++ b/india_compliance/gst_india/doctype/gstr_3b_report/test_gstr_3b_report.py
@@ -365,6 +365,80 @@ class TestGSTR3BReport(IntegrationTestCase):
         self.assertEqual(itc_available["IMPG"].get("iamt"), 36.0)
         self.assertEqual(itc_available["IMPG"].get("csamt"), 20.0)
 
+    @change_settings("GST Settings", {"enable_overseas_transactions": 1})
+    def test_itc_from_pi_when_boe_not_applicable(self):
+        """When is_boe_applicable=0, ITC should be reported from Purchase Invoice directly"""
+        pi = create_purchase_invoice(
+            supplier="_Test Foreign Supplier",
+            update_stock=1,
+            is_out_state=True,
+            do_not_save=1,
+            do_not_submit=1,
+        )
+        # Manually set is_boe_applicable=0 to skip BOE path
+        pi.is_boe_applicable = 0
+        pi.insert()
+        pi.submit()
+
+        expected_iamt = sum((item.igst_amount or 0) for item in pi.items)
+        self.assertGreater(expected_iamt, 0)
+
+        today = getdate()
+
+        report = frappe.get_doc(
+            {
+                "doctype": "GSTR 3B Report",
+                "company": "_Test Indian Registered Company",
+                "company_gstin": "24AAQCA8719H1ZC",
+                "year": today.year,
+                "month_or_quarter": get_month(today),
+            }
+        ).insert()
+
+        output = json.loads(report.json_output)
+        itc_available = {
+            row["ty"]: row for row in output.get("itc_elg", {}).get("itc_avl", [])
+        }
+
+        # ITC should be reported from Purchase Invoice
+        self.assertEqual(itc_available["IMPG"].get("iamt"), expected_iamt)
+        self.assertEqual(itc_available["IMPG"].get("csamt"), 0.0)
+
+    @change_settings("GST Settings", {"enable_overseas_transactions": 1})
+    def test_itc_from_boe_when_boe_applicable(self):
+        """When is_boe_applicable=1, ITC should come from BOE, not from Purchase Invoice"""
+        pi = create_purchase_invoice(supplier="_Test Foreign Supplier", update_stock=1)
+        # PI auto-defaults is_boe_applicable=1 (no GST charged)
+        self.assertEqual(pi.is_boe_applicable, 1)
+
+        boe = make_bill_of_entry(pi.name)
+        boe.items[0].customs_duty = 100
+        boe.bill_of_entry_no = "BOE-004"
+        boe.bill_of_entry_date = getdate()
+        boe.save()
+        boe.submit()
+
+        today = getdate()
+
+        report = frappe.get_doc(
+            {
+                "doctype": "GSTR 3B Report",
+                "company": "_Test Indian Registered Company",
+                "company_gstin": "24AAQCA8719H1ZC",
+                "year": today.year,
+                "month_or_quarter": get_month(today),
+            }
+        ).insert()
+
+        output = json.loads(report.json_output)
+        itc_available = {
+            row["ty"]: row for row in output.get("itc_elg", {}).get("itc_avl", [])
+        }
+
+        # ITC should come from BOE (customs duty 100 * 36% = 36)
+        self.assertEqual(itc_available["IMPG"].get("iamt"), 36.0)
+        self.assertEqual(itc_available["IMPG"].get("csamt"), 0.0)
+
 
 def create_sales_invoices():
     create_sales_invoice(is_in_state=True)

--- a/india_compliance/gst_india/overrides/purchase_invoice.py
+++ b/india_compliance/gst_india/overrides/purchase_invoice.py
@@ -31,7 +31,7 @@ from india_compliance.gst_india.utils.itc_claim import (
 
 
 def onload(doc, method=None):
-    if doc.docstatus == 1 and is_import_of_goods(doc):
+    if doc.docstatus == 1 and doc.itc_classification == "Import Of Goods":
         doc.set_onload(
             "has_pending_boe_qty",
             any(item.pending_boe_qty > 0 for item in doc.items),

--- a/india_compliance/gst_india/overrides/purchase_invoice.py
+++ b/india_compliance/gst_india/overrides/purchase_invoice.py
@@ -3,7 +3,11 @@ from frappe import _
 from frappe.model.meta import get_field_precision
 from frappe.utils import flt
 
-from india_compliance.gst_india.constants import GST_TAX_TYPES, VALID_HSN_LENGTHS
+from india_compliance.gst_india.constants import (
+    GST_TAX_TYPES,
+    IMPORT_GST_CATEGORIES,
+    VALID_HSN_LENGTHS,
+)
 from india_compliance.gst_india.overrides.sales_invoice import (
     update_dashboard_with_gst_logs,
 )
@@ -12,7 +16,13 @@ from india_compliance.gst_india.overrides.transaction import (
     ignore_gst_validations,
     validate_transaction,
 )
-from india_compliance.gst_india.utils import is_api_enabled, validate_invoice_number
+from india_compliance.gst_india.utils import (
+    are_services_supplied,
+    is_api_enabled,
+    is_import_of_goods,
+    is_import_of_services,
+    validate_invoice_number,
+)
 from india_compliance.gst_india.utils.e_waybill import get_e_waybill_info
 from india_compliance.gst_india.utils.itc_claim import (
     _is_gstr3b_filed,
@@ -22,10 +32,10 @@ from india_compliance.gst_india.utils.itc_claim import (
 
 
 def onload(doc, method=None):
-    if doc.docstatus == 1 and doc.gst_category == "Overseas":
+    if doc.docstatus == 1 and is_import_of_goods(doc):
         doc.set_onload(
-            "bill_of_entry_exists",
-            not any(item.pending_boe_qty > 0 for item in doc.items),
+            "has_pending_boe_qty",
+            any(item.pending_boe_qty > 0 for item in doc.items),
         )
 
     if doc.docstatus == 1 and doc.get("itc_claim_period"):
@@ -57,6 +67,7 @@ def validate(doc, method=None):
         return
 
     validate_hsn_codes(doc)
+    validate_import_items(doc)
     if doc.is_reverse_charge and not doc.supplier_gstin:
         validate_invoice_number(doc)
 
@@ -100,8 +111,10 @@ def set_reconciliation_status(doc):
 
 
 def set_pending_boe_qty(doc):
+    boe_applicable = is_import_of_goods(doc)
+
     for item in doc.items:
-        item.pending_boe_qty = item.qty
+        item.pending_boe_qty = item.qty if boe_applicable else 0
 
 
 def is_b2b_invoice(doc):
@@ -113,21 +126,32 @@ def is_b2b_invoice(doc):
     )
 
 
-def set_itc_classification(doc):
-    if doc.gst_category == "Overseas":
-        for item in doc.items:
-            if not item.gst_hsn_code.startswith("99"):
-                doc.itc_classification = "Import Of Goods"
-                break
-        else:
-            doc.itc_classification = "Import Of Service"
+def validate_import_items(doc):
+    if not is_import_of_goods(doc):
+        return
 
+    has_services = are_services_supplied(doc)
+
+    if has_services:
+        frappe.throw(
+            _(
+                "Cannot have both goods and services in a single {0} Purchase"
+                " Invoice. Please create separate invoices for goods and services as"
+                " they have different tax treatments."
+            ).format(doc.gst_category),
+            title=_("Invalid Items"),
+        )
+
+
+def set_itc_classification(doc):
+    if is_import_of_goods(doc):
+        doc.itc_classification = "Import Of Goods"
+    elif is_import_of_services(doc):
+        doc.itc_classification = "Import Of Service"
     elif doc.is_reverse_charge:
         doc.itc_classification = "ITC on Reverse Charge"
-
     elif doc.gst_category == "Input Service Distributor" and doc.is_internal_transfer():
         doc.itc_classification = "Input Service Distributor"
-
     else:
         doc.itc_classification = "All Other ITC"
 
@@ -276,12 +300,14 @@ def validate_reverse_charge(doc):
 
 def validate_hsn_codes(doc):
     # To determine whether BOE is applicable or not.
-    if doc.gst_category != "Overseas":
+    if doc.gst_category not in IMPORT_GST_CATEGORIES:
         return
 
     _validate_hsn_codes(
         doc,
         valid_hsn_length=VALID_HSN_LENGTHS,
         throw=True,
-        message=_("GST HSN Code is mandatory for Overseas Purchase Invoice.<br>"),
+        message=_("GST HSN Code is mandatory for {0} Purchase Invoice.<br>").format(
+            doc.gst_category
+        ),
     )

--- a/india_compliance/gst_india/overrides/purchase_invoice.py
+++ b/india_compliance/gst_india/overrides/purchase_invoice.py
@@ -32,7 +32,7 @@ from india_compliance.gst_india.utils.itc_claim import (
 
 
 def onload(doc, method=None):
-    if doc.docstatus == 1 and doc.itc_classification == "Import Of Goods":
+    if doc.docstatus == 1 and doc.is_boe_applicable:
         doc.set_onload(
             "has_pending_boe_qty",
             any(item.pending_boe_qty > 0 for item in doc.items),

--- a/india_compliance/gst_india/overrides/purchase_invoice.py
+++ b/india_compliance/gst_india/overrides/purchase_invoice.py
@@ -129,7 +129,7 @@ def set_boe_applicability(doc):
     doc.is_boe_applicable = boe_applicability
     frappe.msgprint(
         _("{0} has been {1}.").format(
-            get_label(doc, "is_boe_applicable"),
+            frappe.bold(_(doc.meta.get_label("is_boe_applicable"))),
             _("enabled") if boe_applicability else _("disabled"),
         ),
         alert=True,
@@ -276,10 +276,6 @@ def get_tax_amount(taxes, gst_tax_type):
         for tax in taxes
         if tax.gst_tax_type == gst_tax_type
     )
-
-
-def get_label(doc, fieldname):
-    return frappe.bold(_(doc.meta.get_label(fieldname)))
 
 
 def set_ineligibility_reason(doc, show_alert=True):

--- a/india_compliance/gst_india/overrides/purchase_invoice.py
+++ b/india_compliance/gst_india/overrides/purchase_invoice.py
@@ -111,10 +111,8 @@ def set_reconciliation_status(doc):
 
 
 def set_pending_boe_qty(doc):
-    boe_applicable = is_boe_applicable(doc)
-
     for item in doc.items:
-        item.pending_boe_qty = item.qty if boe_applicable else 0
+        item.pending_boe_qty = item.qty if doc.is_boe_applicable else 0
 
 
 def set_boe_applicability(doc):
@@ -128,17 +126,12 @@ def set_boe_applicability(doc):
 
     doc.is_boe_applicable = boe_applicability
     frappe.msgprint(
-        _("{0} has been {1}.").format(
-            frappe.bold(_(doc.meta.get_label("is_boe_applicable"))),
-            _("enabled") if boe_applicability else _("disabled"),
+        _("Bill of Entry is now {0} for this invoice.").format(
+            _("required") if boe_applicability else _("not required")
         ),
         alert=True,
         indicator="blue",
     )
-
-
-def is_boe_applicable(doc):
-    return doc.itc_classification == "Import Of Goods" and doc.is_boe_applicable
 
 
 def is_b2b_invoice(doc):
@@ -152,7 +145,6 @@ def is_b2b_invoice(doc):
 
 def set_itc_classification(doc):
     # If the document contains single goods item then it will be categorized as Import of Goods,
-
     if is_import_of_goods(doc):
         doc.itc_classification = "Import Of Goods"
     elif is_import_of_services(doc):

--- a/india_compliance/gst_india/overrides/purchase_invoice.py
+++ b/india_compliance/gst_india/overrides/purchase_invoice.py
@@ -17,7 +17,6 @@ from india_compliance.gst_india.overrides.transaction import (
     validate_transaction,
 )
 from india_compliance.gst_india.utils import (
-    are_services_supplied,
     is_api_enabled,
     is_import_of_goods,
     is_import_of_services,
@@ -67,7 +66,6 @@ def validate(doc, method=None):
         return
 
     validate_hsn_codes(doc)
-    validate_import_items(doc)
     if doc.is_reverse_charge and not doc.supplier_gstin:
         validate_invoice_number(doc)
 
@@ -126,24 +124,9 @@ def is_b2b_invoice(doc):
     )
 
 
-def validate_import_items(doc):
-    if not is_import_of_goods(doc):
-        return
-
-    has_services = are_services_supplied(doc)
-
-    if has_services:
-        frappe.throw(
-            _(
-                "Cannot have both goods and services in a single {0} Purchase"
-                " Invoice. Please create separate invoices for goods and services as"
-                " they have different tax treatments."
-            ).format(doc.gst_category),
-            title=_("Invalid Items"),
-        )
-
-
 def set_itc_classification(doc):
+    # If the document contains single goods item then it will be categorized as Import of Goods,
+
     if is_import_of_goods(doc):
         doc.itc_classification = "Import Of Goods"
     elif is_import_of_services(doc):

--- a/india_compliance/gst_india/overrides/purchase_invoice.py
+++ b/india_compliance/gst_india/overrides/purchase_invoice.py
@@ -72,18 +72,13 @@ def validate(doc, method=None):
 
     set_ineligibility_reason(doc)
     set_itc_classification(doc)
-    validate_boe_applicability(doc)
-    validate_import_of_goods(doc)
+    set_boe_applicability(doc)
     validate_reverse_charge(doc)
     validate_supplier_invoice_number(doc)
     validate_with_inward_supply(doc)
     set_or_validate_itc_claim_period(doc)
     set_reconciliation_status(doc)
     set_pending_boe_qty(doc)
-
-
-def before_insert(doc, method=None):
-    set_boe_applicability(doc)
 
 
 def before_update_after_submit(doc, method=None):
@@ -123,14 +118,23 @@ def set_pending_boe_qty(doc):
 
 
 def set_boe_applicability(doc):
-    if doc.gst_category not in IMPORT_GST_CATEGORIES:
-        doc.is_boe_applicable = 0
+    if doc.itc_classification != "Import Of Goods":
+        boe_applicability = 0
+    else:
+        boe_applicability = 0 if has_gst_taxes(doc) else 1
+
+    if doc.is_boe_applicable == boe_applicability:
         return
 
-    if doc.get("_user_set_boe_applicable"):
-        return
-
-    doc.is_boe_applicable = 1
+    doc.is_boe_applicable = boe_applicability
+    frappe.msgprint(
+        _("{0} has been {1}.").format(
+            get_label(doc, "is_boe_applicable"),
+            _("enabled") if boe_applicability else _("disabled"),
+        ),
+        alert=True,
+        indicator="blue",
+    )
 
 
 def is_boe_applicable(doc):
@@ -305,43 +309,6 @@ def validate_reverse_charge(doc):
         return
 
     frappe.throw(_("Reverse Charge is not applicable on Import of Goods"))
-
-
-def validate_import_of_goods(doc):
-    if doc.itc_classification != "Import Of Goods":
-        return
-
-    gst_taxes = has_gst_taxes(doc)
-    if gst_taxes and doc.is_boe_applicable:
-        frappe.throw(
-            _(
-                "GST taxes cannot be applied when {0} is enabled."
-                " Either remove the GST taxes or uncheck {0}."
-            ).format(get_label(doc, "is_boe_applicable"))
-        )
-
-    if not gst_taxes and not doc.is_boe_applicable:
-        frappe.msgprint(
-            _(
-                "No GST taxes applied on this {0} invoice."
-                "If taxes are applicable, either apply GST taxes or enable {1}."
-            ).format(
-                frappe.bold(_("Import Of Goods")),
-                get_label(doc, "is_boe_applicable"),
-            ),
-            alert=True,
-            indicator="orange",
-        )
-
-
-def validate_boe_applicability(doc):
-    if not doc.is_boe_applicable:
-        return
-
-    if doc.itc_classification == "Import Of Goods":
-        return
-
-    doc.is_boe_applicable = 0
 
 
 def validate_hsn_codes(doc):

--- a/india_compliance/gst_india/overrides/purchase_invoice.py
+++ b/india_compliance/gst_india/overrides/purchase_invoice.py
@@ -116,18 +116,18 @@ def set_pending_boe_qty(doc):
 
 
 def set_boe_applicability(doc):
-    if doc.itc_classification != "Import Of Goods":
-        boe_applicability = 0
-    else:
-        boe_applicability = 0 if has_gst_taxes(doc) else 1
+    boe_applicability = 0
+
+    if doc.itc_classification == "Import Of Goods" and not has_gst_taxes(doc):
+        boe_applicability = 1
 
     if doc.is_boe_applicable == boe_applicability:
         return
 
     doc.is_boe_applicable = boe_applicability
     frappe.msgprint(
-        _("Bill of Entry is now {0} for this invoice.").format(
-            _("required") if boe_applicability else _("not required")
+        _("Bill of Entry can {0} for this invoice.").format(
+            _("be generated") if boe_applicability else _("not be generated")
         ),
         alert=True,
         indicator="blue",

--- a/india_compliance/gst_india/overrides/purchase_invoice.py
+++ b/india_compliance/gst_india/overrides/purchase_invoice.py
@@ -17,6 +17,7 @@ from india_compliance.gst_india.overrides.transaction import (
     validate_transaction,
 )
 from india_compliance.gst_india.utils import (
+    has_gst_taxes,
     is_api_enabled,
     is_import_of_goods,
     is_import_of_services,
@@ -71,12 +72,18 @@ def validate(doc, method=None):
 
     set_ineligibility_reason(doc)
     set_itc_classification(doc)
+    validate_boe_applicability(doc)
+    validate_import_of_goods(doc)
     validate_reverse_charge(doc)
     validate_supplier_invoice_number(doc)
     validate_with_inward_supply(doc)
     set_or_validate_itc_claim_period(doc)
     set_reconciliation_status(doc)
     set_pending_boe_qty(doc)
+
+
+def before_insert(doc, method=None):
+    set_boe_applicability(doc)
 
 
 def before_update_after_submit(doc, method=None):
@@ -109,10 +116,25 @@ def set_reconciliation_status(doc):
 
 
 def set_pending_boe_qty(doc):
-    boe_applicable = is_import_of_goods(doc)
+    boe_applicable = is_boe_applicable(doc)
 
     for item in doc.items:
         item.pending_boe_qty = item.qty if boe_applicable else 0
+
+
+def set_boe_applicability(doc):
+    if doc.gst_category not in IMPORT_GST_CATEGORIES:
+        doc.is_boe_applicable = 0
+        return
+
+    if doc.get("_user_set_boe_applicable"):
+        return
+
+    doc.is_boe_applicable = 1
+
+
+def is_boe_applicable(doc):
+    return doc.itc_classification == "Import Of Goods" and doc.is_boe_applicable
 
 
 def is_b2b_invoice(doc):
@@ -252,6 +274,10 @@ def get_tax_amount(taxes, gst_tax_type):
     )
 
 
+def get_label(doc, fieldname):
+    return frappe.bold(_(doc.meta.get_label(fieldname)))
+
+
 def set_ineligibility_reason(doc, show_alert=True):
     doc.ineligibility_reason = ""
 
@@ -279,6 +305,43 @@ def validate_reverse_charge(doc):
         return
 
     frappe.throw(_("Reverse Charge is not applicable on Import of Goods"))
+
+
+def validate_import_of_goods(doc):
+    if doc.itc_classification != "Import Of Goods":
+        return
+
+    gst_taxes = has_gst_taxes(doc)
+    if gst_taxes and doc.is_boe_applicable:
+        frappe.throw(
+            _(
+                "GST taxes cannot be applied when {0} is enabled."
+                " Either remove the GST taxes or uncheck {0}."
+            ).format(get_label(doc, "is_boe_applicable"))
+        )
+
+    if not gst_taxes and not doc.is_boe_applicable:
+        frappe.msgprint(
+            _(
+                "No GST taxes applied on this {0} invoice."
+                "If taxes are applicable, either apply GST taxes or enable {1}."
+            ).format(
+                frappe.bold(_("Import Of Goods")),
+                get_label(doc, "is_boe_applicable"),
+            ),
+            alert=True,
+            indicator="orange",
+        )
+
+
+def validate_boe_applicability(doc):
+    if not doc.is_boe_applicable:
+        return
+
+    if doc.itc_classification == "Import Of Goods":
+        return
+
+    doc.is_boe_applicable = 0
 
 
 def validate_hsn_codes(doc):

--- a/india_compliance/gst_india/overrides/test_purchase_invoice.py
+++ b/india_compliance/gst_india/overrides/test_purchase_invoice.py
@@ -20,6 +20,119 @@ with mock.patch("frappe.db"), mock.patch("frappe.new_doc"), mock.patch(
 
 class TestPurchaseInvoice(IntegrationTestCase):
     @change_settings("GST Settings", {"enable_overseas_transactions": 1})
+    def test_boe_applicable_disallows_gst_taxes(self):
+        pinv = create_purchase_invoice(
+            supplier="_Test Foreign Supplier",
+            do_not_save=1,
+            do_not_submit=1,
+        )
+
+        pinv.taxes = []
+        pinv.append(
+            "taxes",
+            {
+                "charge_type": "On Net Total",
+                "account_head": "Input Tax IGST - _TIRC",
+                "rate": 18,
+                "description": "Input Tax IGST",
+                "cost_center": "Main - _TIRC",
+                "tax_amount": 18,
+                "base_tax_amount": 18,
+                "base_tax_amount_after_discount_amount": 18,
+                "gst_tax_type": "igst",
+            },
+        )
+
+        self.assertRaisesRegex(
+            frappe.exceptions.ValidationError,
+            "GST taxes cannot be applied when.*BOE Applicable.*is enabled",
+            pinv.save,
+        )
+
+    @change_settings("GST Settings", {"enable_overseas_transactions": 1})
+    def test_import_of_goods_with_gst_taxes_and_boe_unchecked_is_allowed(self):
+        pinv = create_purchase_invoice(
+            supplier="_Test Foreign Supplier",
+            do_not_save=1,
+            do_not_submit=1,
+        )
+
+        pinv.is_boe_applicable = 0
+        pinv.taxes = []
+        pinv.append(
+            "taxes",
+            {
+                "charge_type": "On Net Total",
+                "account_head": "Input Tax IGST - _TIRC",
+                "rate": 18,
+                "description": "Input Tax IGST",
+                "cost_center": "Main - _TIRC",
+                "tax_amount": 18,
+                "base_tax_amount": 18,
+                "base_tax_amount_after_discount_amount": 18,
+                "gst_tax_type": "igst",
+            },
+        )
+
+        pinv.save()
+
+        self.assertEqual(pinv.itc_classification, "Import Of Goods")
+        self.assertEqual(pinv.is_boe_applicable, 0)
+        self.assertEqual(pinv.items[0].pending_boe_qty, 0)
+
+    @change_settings("GST Settings", {"enable_overseas_transactions": 1})
+    def test_boe_applicability_default_and_override(self):
+        pinv = create_purchase_invoice(
+            supplier="_Test Foreign Supplier",
+            do_not_submit=1,
+        )
+        self.assertEqual(pinv.itc_classification, "Import Of Goods")
+        self.assertEqual(pinv.is_boe_applicable, 1)
+        self.assertEqual(pinv.items[0].pending_boe_qty, pinv.items[0].qty)
+
+        # User overrides after insert
+        pinv.is_boe_applicable = 0
+        pinv.save()
+
+        self.assertEqual(pinv.itc_classification, "Import Of Goods")
+        self.assertEqual(pinv.is_boe_applicable, 0)
+        self.assertEqual(pinv.items[0].pending_boe_qty, 0)
+
+        # User override should not be auto-reset on subsequent saves.
+        pinv.save()
+        self.assertEqual(pinv.is_boe_applicable, 0)
+        self.assertEqual(pinv.items[0].pending_boe_qty, 0)
+
+    @change_settings("GST Settings", {"enable_overseas_transactions": 1})
+    def test_boe_applicability_user_override_before_insert(self):
+        """User unchecks is_boe_applicable before first save — flag prevents before_insert override."""
+        pinv = create_purchase_invoice(
+            supplier="_Test Foreign Supplier",
+            do_not_save=1,
+            do_not_submit=1,
+        )
+        pinv.is_boe_applicable = 0
+        pinv._user_set_boe_applicable = 1
+        pinv.insert()
+
+        self.assertEqual(pinv.itc_classification, "Import Of Goods")
+        self.assertEqual(pinv.is_boe_applicable, 0)
+        self.assertEqual(pinv.items[0].pending_boe_qty, 0)
+
+    @change_settings("GST Settings", {"enable_overseas_transactions": 1})
+    def test_boe_applicability_auto_uncheck_when_not_import_of_goods(self):
+        """is_boe_applicable should auto-uncheck when itc_classification is not Import Of Goods."""
+        pinv = create_purchase_invoice(
+            supplier="_Test Foreign Supplier",
+            item_code="_Test Service Item",
+            do_not_submit=1,
+        )
+        # before_insert sets is_boe_applicable=1 for import category,
+        # but validate auto-unchecks it because itc_classification is Import Of Service
+        self.assertEqual(pinv.itc_classification, "Import Of Service")
+        self.assertEqual(pinv.is_boe_applicable, 0)
+
+    @change_settings("GST Settings", {"enable_overseas_transactions": 1})
     def test_itc_classification(self):
         pinv = create_purchase_invoice(
             supplier="_Test Foreign Supplier",

--- a/india_compliance/gst_india/overrides/test_purchase_invoice.py
+++ b/india_compliance/gst_india/overrides/test_purchase_invoice.py
@@ -33,29 +33,15 @@ class TestPurchaseInvoice(IntegrationTestCase):
 
     @change_settings("GST Settings", {"enable_overseas_transactions": 1})
     def test_boe_applicability_auto_set_with_gst_taxes(self):
-        """Import Of Goods with GST taxes → is_boe_applicable auto-set to 0."""
+        """Import Of Goods (SEZ) with GST taxes → is_boe_applicable auto-set to 0."""
+        # Use SEZ registered supplier: has GSTIN + itc_classification = Import Of Goods
         pinv = create_purchase_invoice(
-            supplier="_Test Foreign Supplier",
+            supplier="_Test Registered Supplier",
             do_not_save=1,
             do_not_submit=1,
+            is_out_state=True,
         )
-
-        pinv.taxes = []
-        pinv.append(
-            "taxes",
-            {
-                "charge_type": "On Net Total",
-                "account_head": "Input Tax IGST - _TIRC",
-                "rate": 18,
-                "description": "Input Tax IGST",
-                "cost_center": "Main - _TIRC",
-                "tax_amount": 18,
-                "base_tax_amount": 18,
-                "base_tax_amount_after_discount_amount": 18,
-                "gst_tax_type": "igst",
-            },
-        )
-
+        pinv.gst_category = "SEZ"
         pinv.save()
 
         self.assertEqual(pinv.itc_classification, "Import Of Goods")

--- a/india_compliance/gst_india/overrides/test_purchase_invoice.py
+++ b/india_compliance/gst_india/overrides/test_purchase_invoice.py
@@ -20,100 +20,43 @@ with mock.patch("frappe.db"), mock.patch("frappe.new_doc"), mock.patch(
 
 class TestPurchaseInvoice(IntegrationTestCase):
     @change_settings("GST Settings", {"enable_overseas_transactions": 1})
-    def test_boe_applicable_disallows_gst_taxes(self):
-        pinv = create_purchase_invoice(
-            supplier="_Test Foreign Supplier",
-            do_not_save=1,
-            do_not_submit=1,
-        )
-
-        pinv.taxes = []
-        pinv.append(
-            "taxes",
-            {
-                "charge_type": "On Net Total",
-                "account_head": "Input Tax IGST - _TIRC",
-                "rate": 18,
-                "description": "Input Tax IGST",
-                "cost_center": "Main - _TIRC",
-                "tax_amount": 18,
-                "base_tax_amount": 18,
-                "base_tax_amount_after_discount_amount": 18,
-                "gst_tax_type": "igst",
-            },
-        )
-
-        self.assertRaisesRegex(
-            frappe.exceptions.ValidationError,
-            "GST taxes cannot be applied when.*BOE Applicable.*is enabled",
-            pinv.save,
-        )
-
-    @change_settings("GST Settings", {"enable_overseas_transactions": 1})
-    def test_import_of_goods_with_gst_taxes_and_boe_unchecked_is_allowed(self):
-        pinv = create_purchase_invoice(
-            supplier="_Test Foreign Supplier",
-            do_not_save=1,
-            do_not_submit=1,
-        )
-
-        pinv.is_boe_applicable = 0
-        pinv.taxes = []
-        pinv.append(
-            "taxes",
-            {
-                "charge_type": "On Net Total",
-                "account_head": "Input Tax IGST - _TIRC",
-                "rate": 18,
-                "description": "Input Tax IGST",
-                "cost_center": "Main - _TIRC",
-                "tax_amount": 18,
-                "base_tax_amount": 18,
-                "base_tax_amount_after_discount_amount": 18,
-                "gst_tax_type": "igst",
-            },
-        )
-
-        pinv.save()
-
-        self.assertEqual(pinv.itc_classification, "Import Of Goods")
-        self.assertEqual(pinv.is_boe_applicable, 0)
-        self.assertEqual(pinv.items[0].pending_boe_qty, 0)
-
-    @change_settings("GST Settings", {"enable_overseas_transactions": 1})
-    def test_boe_applicability_default_and_override(self):
+    def test_boe_applicability_auto_set_without_gst_taxes(self):
+        """Import Of Goods without GST taxes → is_boe_applicable auto-set to 1."""
         pinv = create_purchase_invoice(
             supplier="_Test Foreign Supplier",
             do_not_submit=1,
         )
+
         self.assertEqual(pinv.itc_classification, "Import Of Goods")
         self.assertEqual(pinv.is_boe_applicable, 1)
         self.assertEqual(pinv.items[0].pending_boe_qty, pinv.items[0].qty)
 
-        # User overrides after insert
-        pinv.is_boe_applicable = 0
-        pinv.save()
-
-        self.assertEqual(pinv.itc_classification, "Import Of Goods")
-        self.assertEqual(pinv.is_boe_applicable, 0)
-        self.assertEqual(pinv.items[0].pending_boe_qty, 0)
-
-        # User override should not be auto-reset on subsequent saves.
-        pinv.save()
-        self.assertEqual(pinv.is_boe_applicable, 0)
-        self.assertEqual(pinv.items[0].pending_boe_qty, 0)
-
     @change_settings("GST Settings", {"enable_overseas_transactions": 1})
-    def test_boe_applicability_user_override_before_insert(self):
-        """User unchecks is_boe_applicable before first save — flag prevents before_insert override."""
+    def test_boe_applicability_auto_set_with_gst_taxes(self):
+        """Import Of Goods with GST taxes → is_boe_applicable auto-set to 0."""
         pinv = create_purchase_invoice(
             supplier="_Test Foreign Supplier",
             do_not_save=1,
             do_not_submit=1,
         )
-        pinv.is_boe_applicable = 0
-        pinv._user_set_boe_applicable = 1
-        pinv.insert()
+
+        pinv.taxes = []
+        pinv.append(
+            "taxes",
+            {
+                "charge_type": "On Net Total",
+                "account_head": "Input Tax IGST - _TIRC",
+                "rate": 18,
+                "description": "Input Tax IGST",
+                "cost_center": "Main - _TIRC",
+                "tax_amount": 18,
+                "base_tax_amount": 18,
+                "base_tax_amount_after_discount_amount": 18,
+                "gst_tax_type": "igst",
+            },
+        )
+
+        pinv.save()
 
         self.assertEqual(pinv.itc_classification, "Import Of Goods")
         self.assertEqual(pinv.is_boe_applicable, 0)
@@ -121,14 +64,13 @@ class TestPurchaseInvoice(IntegrationTestCase):
 
     @change_settings("GST Settings", {"enable_overseas_transactions": 1})
     def test_boe_applicability_auto_uncheck_when_not_import_of_goods(self):
-        """is_boe_applicable should auto-uncheck when itc_classification is not Import Of Goods."""
+        """is_boe_applicable should be 0 when itc_classification is not Import Of Goods."""
         pinv = create_purchase_invoice(
             supplier="_Test Foreign Supplier",
             item_code="_Test Service Item",
             do_not_submit=1,
         )
-        # before_insert sets is_boe_applicable=1 for import category,
-        # but validate auto-unchecks it because itc_classification is Import Of Service
+        # Service item → itc_classification = Import Of Service → is_boe_applicable auto-set to 0
         self.assertEqual(pinv.itc_classification, "Import Of Service")
         self.assertEqual(pinv.is_boe_applicable, 0)
 

--- a/india_compliance/gst_india/overrides/test_purchase_invoice.py
+++ b/india_compliance/gst_india/overrides/test_purchase_invoice.py
@@ -49,6 +49,26 @@ class TestPurchaseInvoice(IntegrationTestCase):
         self.assertEqual(pinv.items[0].pending_boe_qty, 0)
 
     @change_settings("GST Settings", {"enable_overseas_transactions": 1})
+    def test_sez_goods_import_with_zero_gst_rates(self):
+        """SEZ goods import should save even when GST tax rows exist with zero rates."""
+        pinv = create_purchase_invoice(
+            supplier="_Test Registered Supplier",
+            do_not_save=1,
+            do_not_submit=1,
+            is_out_state=True,
+        )
+        pinv.gst_category = "SEZ"
+
+        for tax in pinv.taxes:
+            tax.rate = 0
+
+        pinv.save()
+
+        self.assertEqual(pinv.itc_classification, "Import Of Goods")
+        self.assertEqual(pinv.items[0].gst_treatment, "Taxable")
+        self.assertEqual(pinv.items[0].igst_rate, 0)
+
+    @change_settings("GST Settings", {"enable_overseas_transactions": 1})
     def test_boe_applicability_auto_uncheck_when_not_import_of_goods(self):
         """is_boe_applicable should be 0 when itc_classification is not Import Of Goods."""
         pinv = create_purchase_invoice(

--- a/india_compliance/gst_india/overrides/test_purchase_invoice.py
+++ b/india_compliance/gst_india/overrides/test_purchase_invoice.py
@@ -10,7 +10,7 @@ from india_compliance.gst_india.utils.itc_claim import (
     format_period,
     update_gstr3b_filing_status,
 )
-from india_compliance.gst_india.utils.tests import append_item, create_purchase_invoice
+from india_compliance.gst_india.utils.tests import create_purchase_invoice
 
 with mock.patch("frappe.db"), mock.patch("frappe.new_doc"), mock.patch(
     "frappe.get_doc"
@@ -93,34 +93,6 @@ class TestPurchaseInvoice(IntegrationTestCase):
         self.assertRaisesRegex(
             frappe.exceptions.ValidationError,
             "Reverse Charge is not applicable on Import of Goods",
-            pinv.save,
-        )
-
-    @change_settings("GST Settings", {"enable_overseas_transactions": 1})
-    def test_both_goods_and_services_in_same_import_invoice(self):
-        pinv = create_purchase_invoice(
-            supplier="_Test Foreign Supplier",
-            do_not_save=1,
-            item_code="_Test Service Item",
-        )
-        append_item(pinv)  # adds a goods item
-        self.assertRaisesRegex(
-            frappe.exceptions.ValidationError,
-            "Cannot have both goods and services",
-            pinv.save,
-        )
-
-        # SEZ: mixed goods and services should throw
-        pinv = create_purchase_invoice(
-            supplier="_Test Registered Supplier",
-            do_not_save=1,
-            item_code="_Test Service Item",
-        )
-        pinv.gst_category = "SEZ"
-        append_item(pinv)  # adds a goods item
-        self.assertRaisesRegex(
-            frappe.exceptions.ValidationError,
-            "Cannot have both goods and services",
             pinv.save,
         )
 

--- a/india_compliance/gst_india/overrides/test_purchase_invoice.py
+++ b/india_compliance/gst_india/overrides/test_purchase_invoice.py
@@ -29,7 +29,6 @@ class TestPurchaseInvoice(IntegrationTestCase):
         self.assertEqual(pinv.itc_classification, "Import Of Service")
         self.assertEqual(pinv.items[0].gst_treatment, "Taxable")
 
-        # Overseas goods-only invoice
         pinv = create_purchase_invoice(
             supplier="_Test Foreign Supplier",
             do_not_submit=1,

--- a/india_compliance/gst_india/overrides/test_purchase_invoice.py
+++ b/india_compliance/gst_india/overrides/test_purchase_invoice.py
@@ -28,9 +28,31 @@ class TestPurchaseInvoice(IntegrationTestCase):
         )
         self.assertEqual(pinv.itc_classification, "Import Of Service")
 
-        append_item(pinv)
+        # Overseas goods-only invoice
+        pinv = create_purchase_invoice(
+            supplier="_Test Foreign Supplier",
+            do_not_submit=1,
+        )
+        self.assertEqual(pinv.itc_classification, "Import Of Goods")
+
+        pinv = create_purchase_invoice(
+            supplier="_Test Registered Supplier",
+            do_not_submit=1,
+            do_not_save=1,
+        )
+        pinv.gst_category = "SEZ"
         pinv.save()
         self.assertEqual(pinv.itc_classification, "Import Of Goods")
+
+        pinv = create_purchase_invoice(
+            supplier="_Test Registered Supplier",
+            do_not_submit=1,
+            do_not_save=1,
+            item_code="_Test Service Item",
+        )
+        pinv.gst_category = "SEZ"
+        pinv.save()
+        self.assertEqual(pinv.itc_classification, "All Other ITC")
 
         pinv = create_purchase_invoice(
             supplier="_Test Registered Supplier",
@@ -69,6 +91,34 @@ class TestPurchaseInvoice(IntegrationTestCase):
         self.assertRaisesRegex(
             frappe.exceptions.ValidationError,
             "Reverse Charge is not applicable on Import of Goods",
+            pinv.save,
+        )
+
+    @change_settings("GST Settings", {"enable_overseas_transactions": 1})
+    def test_both_goods_and_services_in_same_import_invoice(self):
+        pinv = create_purchase_invoice(
+            supplier="_Test Foreign Supplier",
+            do_not_save=1,
+            item_code="_Test Service Item",
+        )
+        append_item(pinv)  # adds a goods item
+        self.assertRaisesRegex(
+            frappe.exceptions.ValidationError,
+            "Cannot have both goods and services",
+            pinv.save,
+        )
+
+        # SEZ: mixed goods and services should throw
+        pinv = create_purchase_invoice(
+            supplier="_Test Registered Supplier",
+            do_not_save=1,
+            item_code="_Test Service Item",
+        )
+        pinv.gst_category = "SEZ"
+        append_item(pinv)  # adds a goods item
+        self.assertRaisesRegex(
+            frappe.exceptions.ValidationError,
+            "Cannot have both goods and services",
             pinv.save,
         )
 

--- a/india_compliance/gst_india/overrides/test_purchase_invoice.py
+++ b/india_compliance/gst_india/overrides/test_purchase_invoice.py
@@ -27,6 +27,7 @@ class TestPurchaseInvoice(IntegrationTestCase):
             item_code="_Test Service Item",
         )
         self.assertEqual(pinv.itc_classification, "Import Of Service")
+        self.assertEqual(pinv.items[0].gst_treatment, "Taxable")
 
         # Overseas goods-only invoice
         pinv = create_purchase_invoice(
@@ -34,6 +35,7 @@ class TestPurchaseInvoice(IntegrationTestCase):
             do_not_submit=1,
         )
         self.assertEqual(pinv.itc_classification, "Import Of Goods")
+        self.assertEqual(pinv.items[0].gst_treatment, "Taxable")
 
         pinv = create_purchase_invoice(
             supplier="_Test Registered Supplier",
@@ -43,6 +45,7 @@ class TestPurchaseInvoice(IntegrationTestCase):
         pinv.gst_category = "SEZ"
         pinv.save()
         self.assertEqual(pinv.itc_classification, "Import Of Goods")
+        self.assertEqual(pinv.items[0].gst_treatment, "Taxable")
 
         pinv = create_purchase_invoice(
             supplier="_Test Registered Supplier",

--- a/india_compliance/gst_india/overrides/test_purchase_invoice.py
+++ b/india_compliance/gst_india/overrides/test_purchase_invoice.py
@@ -10,7 +10,7 @@ from india_compliance.gst_india.utils.itc_claim import (
     format_period,
     update_gstr3b_filing_status,
 )
-from india_compliance.gst_india.utils.tests import create_purchase_invoice
+from india_compliance.gst_india.utils.tests import append_item, create_purchase_invoice
 
 with mock.patch("frappe.db"), mock.patch("frappe.new_doc"), mock.patch(
     "frappe.get_doc"
@@ -95,6 +95,29 @@ class TestPurchaseInvoice(IntegrationTestCase):
             "Reverse Charge is not applicable on Import of Goods",
             pinv.save,
         )
+
+    @change_settings("GST Settings", {"enable_overseas_transactions": 1})
+    def test_service_and_goods_import_invoice_itc_classification(self):
+        test_cases = (
+            ("Overseas", "_Test Foreign Supplier"),
+            ("SEZ", "_Test Registered Supplier"),
+        )
+
+        for gst_category, supplier in test_cases:
+            pinv = create_purchase_invoice(
+                supplier=supplier,
+                do_not_submit=1,
+                do_not_save=1,
+                item_code="_Test Service Item",
+            )
+            pinv.gst_category = gst_category
+            append_item(pinv)
+            pinv.save()
+
+            self.assertEqual(pinv.itc_classification, "Import Of Goods")
+            self.assertEqual(len(pinv.items), 2)
+            self.assertEqual(pinv.items[0].gst_treatment, "Taxable")
+            self.assertEqual(pinv.items[1].gst_treatment, "Taxable")
 
     def test_validate_invoice_length(self):
         # No error for registered supplier

--- a/india_compliance/gst_india/overrides/test_transaction.py
+++ b/india_compliance/gst_india/overrides/test_transaction.py
@@ -806,6 +806,33 @@ class TestTransaction(IntegrationTestCase):
         )
 
     @change_settings("GST Settings", {"enable_overseas_transactions": 1})
+    def test_import_service_purchase_invoice_is_taxable(self):
+        if self.doctype != "Purchase Invoice":
+            return
+
+        doc = create_transaction(
+            **self.transaction_details,
+            supplier="_Test Foreign Supplier",
+            item_code="_Test Service Item",
+            do_not_submit=True,
+        )
+
+        self.assertEqual(doc.itc_classification, "Import Of Service")
+        self.assertEqual(doc.items[0].gst_treatment, "Taxable")
+
+    def test_regular_purchase_without_gst_taxes_is_nil_rated(self):
+        if self.is_sales_doctype:
+            return
+
+        doc = create_transaction(
+            **self.transaction_details,
+            supplier="_Test Registered Supplier",
+            do_not_submit=True,
+        )
+
+        self.assertEqual(doc.items[0].gst_treatment, "Nil-Rated")
+
+    @change_settings("GST Settings", {"enable_overseas_transactions": 1})
     def test_gst_treatment_for_exports(self):
         if not self.is_sales_doctype:
             return

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -31,8 +31,6 @@ from india_compliance.gst_india.utils import (
     get_hsn_settings,
     get_place_of_supply,
     get_place_of_supply_options,
-    is_import_of_goods,
-    is_import_of_services,
     is_overseas_doc,
     join_list_with_custom_separators,
     validate_gst_category,
@@ -1442,11 +1440,15 @@ class ItemGSTTreatment:
 
         has_gst_accounts = any(row.gst_tax_type in TAX_TYPES for row in self.doc.taxes)
 
+        if self.doc.get("itc_classification") in (
+            "Import Of Goods",
+            "Import Of Service",
+        ):
+            self.set_for_import_transactions()
+            return
+
         if not has_gst_accounts:
-            if is_import_of_goods(self.doc) or is_import_of_services(self.doc):
-                self.set_for_import_transactions()
-            else:
-                self.set_for_no_taxes()
+            self.set_for_no_taxes()
             return
 
         self.update_gst_treatment_map()

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -12,6 +12,7 @@ from india_compliance.gst_india.constants import (
     GST_RCM_TAX_TYPES,
     GST_REFUND_TAX_TYPES,
     GST_TAX_TYPES,
+    IMPORT_GST_CATEGORIES,
     SALES_DOCTYPES,
     STATE_NUMBERS,
     SUBCONTRACTING_DOCTYPES,
@@ -31,6 +32,7 @@ from india_compliance.gst_india.utils import (
     get_hsn_settings,
     get_place_of_supply,
     get_place_of_supply_options,
+    has_gst_taxes,
     is_overseas_doc,
     join_list_with_custom_separators,
     validate_gst_category,
@@ -909,6 +911,11 @@ def get_gst_details(
             party_details.update(is_reverse_charge)
             gst_details.update(is_reverse_charge)
 
+    if doctype == "Purchase Invoice":
+        gst_details.is_boe_applicable = cint(
+            party_details.get("gst_category") in IMPORT_GST_CATEGORIES
+        )
+
     if doctype == "Payment Entry":
         return gst_details
 
@@ -1438,8 +1445,6 @@ class ItemGSTTreatment:
             self.set_for_overseas()
             return
 
-        has_gst_accounts = any(row.gst_tax_type in TAX_TYPES for row in self.doc.taxes)
-
         if self.doc.get("itc_classification") in (
             "Import Of Goods",
             "Import Of Service",
@@ -1447,7 +1452,7 @@ class ItemGSTTreatment:
             self.set_for_import_transactions()
             return
 
-        if not has_gst_accounts:
+        if not has_gst_taxes(self.doc):
             self.set_for_no_taxes()
             return
 

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -1735,6 +1735,10 @@ def validate_item_tax_template(doc):
     if not doc.items or not doc.taxes:
         return
 
+    is_import_transaction = doc.get("itc_classification") in (
+        "Import Of Goods",
+        "Import Of Service",
+    )
     non_taxable_items_with_tax = []
     taxable_items_with_no_tax = []
 
@@ -1751,6 +1755,8 @@ def validate_item_tax_template(doc):
             non_taxable_items_with_tax.append(item.idx)
 
         if not is_gst_applied and item.gst_treatment in TAXABLE_GST_TREATMENTS:
+            if is_import_transaction:
+                continue
             taxable_items_with_no_tax.append(item.idx)
 
     # Case: Zero Tax template with taxes or missing GST Accounts

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -12,7 +12,6 @@ from india_compliance.gst_india.constants import (
     GST_RCM_TAX_TYPES,
     GST_REFUND_TAX_TYPES,
     GST_TAX_TYPES,
-    IMPORT_GST_CATEGORIES,
     SALES_DOCTYPES,
     STATE_NUMBERS,
     SUBCONTRACTING_DOCTYPES,
@@ -911,11 +910,6 @@ def get_gst_details(
             party_details.update(is_reverse_charge)
             gst_details.update(is_reverse_charge)
 
-    if doctype == "Purchase Invoice":
-        gst_details.is_boe_applicable = cint(
-            party_details.get("gst_category") in IMPORT_GST_CATEGORIES
-        )
-
     if doctype == "Payment Entry":
         return gst_details
 
@@ -1449,6 +1443,7 @@ class ItemGSTTreatment:
             "Import Of Goods",
             "Import Of Service",
         ):
+            # NOTE: possible treatment can be nil rated or taxable depending on the taxes applied
             self.set_for_import_transactions()
             return
 

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -1443,7 +1443,12 @@ class ItemGSTTreatment:
             "Import Of Goods",
             "Import Of Service",
         ):
-            # NOTE: possible treatment can be nil rated or taxable depending on the taxes applied
+            # NOTE: Import transactions are treated as "Taxable" since the supply is taxable
+            # under GST even when no GST is charged directly (e.g. Import Of Goods settled
+            # via BOE) But there is one more possibliity of classifying import transactions
+            # as "Nil-Rated" when GST is not charged in invoice (unclear case, needs more clarity).
+            # For now, we are treating all import transactions as "Taxable" to avoid any missing GST issues in returns.
+            # This can be revisited if needed.
             self.set_for_import_transactions()
             return
 

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -31,6 +31,8 @@ from india_compliance.gst_india.utils import (
     get_hsn_settings,
     get_place_of_supply,
     get_place_of_supply_options,
+    is_import_of_goods,
+    is_import_of_services,
     is_overseas_doc,
     join_list_with_custom_separators,
     validate_gst_category,
@@ -1441,7 +1443,10 @@ class ItemGSTTreatment:
         has_gst_accounts = any(row.gst_tax_type in TAX_TYPES for row in self.doc.taxes)
 
         if not has_gst_accounts:
-            self.set_for_no_taxes()
+            if is_import_of_goods(self.doc) or is_import_of_services(self.doc):
+                self.set_for_import_transactions()
+            else:
+                self.set_for_no_taxes()
             return
 
         self.update_gst_treatment_map()
@@ -1450,6 +1455,10 @@ class ItemGSTTreatment:
     def set_for_overseas(self):
         for item in self.doc.items:
             item.gst_treatment = "Zero-Rated"
+
+    def set_for_import_transactions(self):
+        for item in self.doc.items:
+            item.gst_treatment = "Taxable"
 
     def set_for_no_taxes(self):
         for item in self.doc.items:

--- a/india_compliance/gst_india/report/gst_account_wise_summary/gst_account_wise_summary.py
+++ b/india_compliance/gst_india/report/gst_account_wise_summary/gst_account_wise_summary.py
@@ -309,7 +309,7 @@ class AccountWiseSummary:
                 .when(doc.ineligibility_reason == "ITC restricted due to PoS rules", 1)
                 .else_(0)
                 # From BOE
-            ).where(IfNull(doc.itc_classification, "") != "Import of Goods")
+            ).where(IfNull(doc.itc_classification, "") != "Import Of Goods")
 
         query = self.get_query_with_common_filters(query, doc, self.filters)
 

--- a/india_compliance/gst_india/report/gst_account_wise_summary/gst_account_wise_summary.py
+++ b/india_compliance/gst_india/report/gst_account_wise_summary/gst_account_wise_summary.py
@@ -309,7 +309,7 @@ class AccountWiseSummary:
                 .when(doc.ineligibility_reason == "ITC restricted due to PoS rules", 1)
                 .else_(0)
                 # From BOE
-            ).where(IfNull(doc.itc_classification, "") != "Import Of Goods")
+            ).where(doc.is_boe_applicable == 0)
 
         query = self.get_query_with_common_filters(query, doc, self.filters)
 

--- a/india_compliance/gst_india/report/gst_account_wise_summary/test_gst_account_wise_summary.py
+++ b/india_compliance/gst_india/report/gst_account_wise_summary/test_gst_account_wise_summary.py
@@ -1,0 +1,59 @@
+import frappe
+from frappe.tests import IntegrationTestCase, change_settings
+from frappe.utils import getdate
+
+from india_compliance.gst_india.doctype.bill_of_entry.bill_of_entry import (
+    make_bill_of_entry,
+)
+from india_compliance.gst_india.report.gst_account_wise_summary.gst_account_wise_summary import (
+    execute,
+)
+from india_compliance.gst_india.utils.tests import create_purchase_invoice
+
+COMPANY = "_Test Indian Registered Company"
+COMPANY_GSTIN = "24AAQCA8719H1ZC"
+
+
+def _filters(posting_date):
+    return frappe._dict(
+        {
+            "company": COMPANY,
+            "company_gstin": COMPANY_GSTIN,
+            "date_range": [posting_date, posting_date],
+            "voucher_type": "Purchase",
+        }
+    )
+
+
+class TestGSTAccountWiseSummary(IntegrationTestCase):
+    def setUp(self):
+        filters = {"company": COMPANY}
+        for doctype in ("Purchase Invoice", "Bill of Entry"):
+            frappe.db.delete(doctype, filters=filters)
+
+    @classmethod
+    def tearDownClass(cls):
+        frappe.db.rollback()
+
+    @change_settings("GST Settings", {"enable_overseas_transactions": 1})
+    def test_import_of_goods_itc_from_boe(self):
+        pi = create_purchase_invoice(supplier="_Test Foreign Supplier", update_stock=1)
+        expense_account = pi.items[0].expense_account
+
+        boe = make_bill_of_entry(pi.name)
+        boe.items[0].customs_duty = 100
+        boe.bill_of_entry_no = "BOE-ACCT-001"
+        boe.bill_of_entry_date = getdate()
+        boe.save()
+        boe.submit()
+
+        _, data = execute(_filters(getdate()))
+
+        row = next(
+            (r for r in data if r.get("account_name") == expense_account),
+            None,
+        )
+        self.assertIsNotNone(row)
+        self.assertEqual(row["total_amount"], 200.0)
+        self.assertEqual(row["total_itc"], 36.0)
+        self.assertEqual(row["total_itc_availed"], 36.0)

--- a/india_compliance/gst_india/report/gst_purchase_register/test_gst_purchase_register.py
+++ b/india_compliance/gst_india/report/gst_purchase_register/test_gst_purchase_register.py
@@ -2,22 +2,26 @@
 # See license.txt
 
 import frappe
-from frappe.tests import IntegrationTestCase
+from frappe.tests import IntegrationTestCase, change_settings
 from frappe.utils import getdate
 
+from india_compliance.gst_india.doctype.bill_of_entry.bill_of_entry import (
+    make_bill_of_entry,
+)
 from india_compliance.gst_india.report.gst_purchase_register.gst_purchase_register import (
     execute,
 )
+from india_compliance.gst_india.utils.tests import create_purchase_invoice
 
-REVERSAL_OF_ITC = "Reversal Of ITC"
-RECLAIM_OF_ITC_REVERSAL = "Reclaim of ITC Reversal"
+COMPANY = "_Test Indian Registered Company"
+COMPANY_GSTIN = "24AAQCA8719H1ZC"
 
 
 def _filters(posting_date, **kwargs):
     return frappe._dict(
         {
-            "company": "_Test Indian Registered Company",
-            "company_gstin": "24AAQCA8719H1ZC",
+            "company": COMPANY,
+            "company_gstin": COMPANY_GSTIN,
             "date_range": [posting_date, posting_date],
             "sub_section": "4",
             "summary_by": "Invoice Wise",
@@ -27,37 +31,94 @@ def _filters(posting_date, **kwargs):
     )
 
 
-class TestGSTPurchaseRegisterITCJournalEntries(IntegrationTestCase):
+class TestGSTPurchaseRegister(IntegrationTestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+
         cls.today = getdate()
-        cls.reversal_je = create_itc_reversal_journal_entry(cls.today)
-        cls.reversal_je_others = create_itc_reversal_journal_entry(
+        cls._create_itc_reversal_42_43()
+        cls._create_itc_reversal_others()
+        cls._create_itc_reclaim()
+        cls._create_sez_service_pi()
+        cls._create_overseas_import_service_pi()
+        cls._create_boe_import_goods()
+
+    @classmethod
+    def _create_itc_reversal_42_43(cls):
+        cls.reversal_je = _create_journal_entry(
             cls.today,
+            voucher_type="Reversal Of ITC",
+            ineligibility_reason="As per rules 42 & 43 of CGST Rules",
+            tax_amount=9,
+        )
+
+    @classmethod
+    def _create_itc_reversal_others(cls):
+        cls.reversal_je_others = _create_journal_entry(
+            cls.today,
+            voucher_type="Reversal Of ITC",
             ineligibility_reason="Others",
             tax_amount=6,
         )
-        cls.reclaim_je = create_itc_reclaim_journal_entry(cls.today)
+
+    @classmethod
+    def _create_itc_reclaim(cls):
+        cls.reclaim_je = _create_journal_entry(
+            cls.today,
+            voucher_type="Reclaim of ITC Reversal",
+            tax_amount=9,
+        )
+
+    @classmethod
+    @change_settings("GST Settings", {"enable_overseas_transactions": 1})
+    def _create_sez_service_pi(cls):
+        pi = create_purchase_invoice(
+            supplier="_Test Registered Supplier",
+            item_code="_Test Service Item",
+            do_not_save=True,
+            do_not_submit=True,
+        )
+        pi.gst_category = "SEZ"
+        pi.insert()
+        pi.submit()
+        cls.sez_service_pi = pi
+
+    @classmethod
+    @change_settings("GST Settings", {"enable_overseas_transactions": 1})
+    def _create_overseas_import_service_pi(cls):
+        cls.overseas_import_service_pi = create_purchase_invoice(
+            supplier="_Test Foreign Supplier",
+            item_code="_Test Service Item",
+        )
+
+    @classmethod
+    @change_settings("GST Settings", {"enable_overseas_transactions": 1})
+    def _create_boe_import_goods(cls):
+        boe_pi = create_purchase_invoice(
+            supplier="_Test Foreign Supplier",
+            update_stock=1,
+        )
+        cls.boe_pi = boe_pi
+        boe = make_bill_of_entry(boe_pi.name)
+        boe.items[0].customs_duty = 100
+        boe.bill_of_entry_no = "BOE-PR-001"
+        boe.bill_of_entry_date = cls.today
+        boe.save()
+        boe.submit()
+        cls.boe = boe
 
     @classmethod
     def tearDownClass(cls):
         frappe.db.rollback()
 
     def test_reversal_of_itc_je_is_in_purchase_register(self):
-        self.assertEqual(
-            frappe.db.get_value("Journal Entry", self.reversal_je.name, "voucher_type"),
-            REVERSAL_OF_ITC,
-        )
-
         _, data = execute(_filters(self.today))
 
-        reversal_rows = [
-            row for row in data if row.get("voucher_no") == self.reversal_je.name
-        ]
-
-        row = reversal_rows[0]
-        self.assertEqual(row["ineligibility_type"], REVERSAL_OF_ITC)
+        row = next(
+            (r for r in data if r.get("voucher_no") == self.reversal_je.name), None
+        )
+        self.assertEqual(row["ineligibility_type"], "Reversal Of ITC")
         self.assertEqual(
             row["invoice_sub_category"],
             "As per rules 42 & 43 of CGST Rules and section 17(5)",
@@ -67,40 +128,25 @@ class TestGSTPurchaseRegisterITCJournalEntries(IntegrationTestCase):
         self.assertEqual(row["total_tax"], 18.0)
 
     def test_reclaim_of_itc_reversal_je_is_in_purchase_register(self):
-        self.assertEqual(
-            frappe.db.get_value("Journal Entry", self.reclaim_je.name, "voucher_type"),
-            RECLAIM_OF_ITC_REVERSAL,
-        )
-
         _, data = execute(_filters(self.today))
 
-        reclaim_rows = [
-            row for row in data if row.get("voucher_no") == self.reclaim_je.name
-        ]
-
-        row = reclaim_rows[0]
-        self.assertEqual(row["ineligibility_type"], RECLAIM_OF_ITC_REVERSAL)
-        self.assertEqual(row["invoice_sub_category"], RECLAIM_OF_ITC_REVERSAL)
+        row = next(
+            (r for r in data if r.get("voucher_no") == self.reclaim_je.name), None
+        )
+        self.assertEqual(row["ineligibility_type"], "Reclaim of ITC Reversal")
+        self.assertEqual(row["invoice_sub_category"], "Reclaim of ITC Reversal")
         self.assertEqual(row["cgst_amount"], 9.0)
         self.assertEqual(row["sgst_amount"], 9.0)
         self.assertEqual(row["total_tax"], 18.0)
 
     def test_reversal_of_itc_others_je_is_in_purchase_register(self):
-        self.assertEqual(
-            frappe.db.get_value(
-                "Journal Entry", self.reversal_je_others.name, "voucher_type"
-            ),
-            REVERSAL_OF_ITC,
-        )
-
         _, data = execute(_filters(self.today))
 
-        reversal_rows = [
-            row for row in data if row.get("voucher_no") == self.reversal_je_others.name
-        ]
-
-        row = reversal_rows[0]
-        self.assertEqual(row["ineligibility_type"], REVERSAL_OF_ITC)
+        row = next(
+            (r for r in data if r.get("voucher_no") == self.reversal_je_others.name),
+            None,
+        )
+        self.assertEqual(row["ineligibility_type"], "Reversal Of ITC")
         self.assertEqual(row["invoice_sub_category"], "Others")
         self.assertEqual(row["cgst_amount"], 6.0)
         self.assertEqual(row["sgst_amount"], 6.0)
@@ -116,7 +162,6 @@ class TestGSTPurchaseRegisterITCJournalEntries(IntegrationTestCase):
         reversal_row = by_description.get(
             "As per rules 42 & 43 of CGST Rules and section 17(5)"
         )
-        self.assertIsNotNone(reversal_row)
         self.assertEqual(reversal_row["cgst_amount"], 9.0)
         self.assertEqual(reversal_row["sgst_amount"], 9.0)
 
@@ -125,61 +170,119 @@ class TestGSTPurchaseRegisterITCJournalEntries(IntegrationTestCase):
         self.assertEqual(others_row["cgst_amount"], 6.0)
         self.assertEqual(others_row["sgst_amount"], 6.0)
 
-        reclaim_row = by_description.get(RECLAIM_OF_ITC_REVERSAL)
+        reclaim_row = by_description.get("Reclaim of ITC Reversal")
         self.assertIsNotNone(reclaim_row)
         self.assertEqual(reclaim_row["cgst_amount"], 9.0)
         self.assertEqual(reclaim_row["sgst_amount"], 9.0)
 
+    def test_boe_in_section_4_as_import_of_goods(self):
+        _, data = execute(_filters(self.today, sub_section="4"))
 
-def create_itc_reversal_journal_entry(
-    posting_date,
-    ineligibility_reason="As per rules 42 & 43 of CGST Rules",
-    tax_amount=9,
+        row = next((r for r in data if r.get("voucher_no") == self.boe.name), None)
+        self.assertIsNotNone(row, "BOE should appear in section 4")
+
+        self.assertEqual(row["invoice_sub_category"], "Import Of Goods")
+        self.assertEqual(row["igst_amount"], 36.0)
+
+        voucher_nos = [r.get("voucher_no") for r in data]
+        self.assertNotIn(
+            self.boe_pi.name,
+            voucher_nos,
+            "Linked purchase invoice should be excluded when BOE exists",
+        )
+
+    def test_sez_service_pi_in_section_5(self):
+        self.assertEqual(self.sez_service_pi.items[0].gst_treatment, "Nil-Rated")
+        _, data = execute(_filters(self.today, sub_section="5"))
+
+        row = next(
+            (r for r in data if r.get("voucher_no") == self.sez_service_pi.name), None
+        )
+        self.assertIsNotNone(row, "SEZ service PI should appear in section 5")
+        self.assertEqual(
+            row["invoice_sub_category"], "Composition Scheme, Exempted, Nil Rated"
+        )
+
+    def test_overseas_import_service_pi_in_section_4(self):
+        self.assertEqual(
+            self.overseas_import_service_pi.itc_classification, "Import Of Service"
+        )
+        self.assertEqual(
+            self.overseas_import_service_pi.items[0].gst_treatment, "Taxable"
+        )
+
+        _, data = execute(_filters(self.today, sub_section="4"))
+
+        row = next(
+            (
+                r
+                for r in data
+                if r.get("voucher_no") == self.overseas_import_service_pi.name
+            ),
+            None,
+        )
+        self.assertIsNotNone(
+            row, "Overseas import service PI should appear in section 4"
+        )
+        self.assertEqual(row["invoice_sub_category"], "Import Of Service")
+
+    def test_overseas_import_service_pi_excluded_from_section_5(self):
+        _, data = execute(_filters(self.today, sub_section="5"))
+        voucher_nos = [row["voucher_no"] for row in data]
+
+        self.assertNotIn(
+            self.overseas_import_service_pi.name,
+            voucher_nos,
+            "Overseas import service PI should be excluded from section 5",
+        )
+
+
+def _create_journal_entry(
+    posting_date, voucher_type, tax_amount, ineligibility_reason=""
 ):
-    journal_entry = frappe.get_doc(
+
+    if voucher_type == "Reclaim of ITC Reversal":
+        accounts = [
+            {
+                "account": "GST Expense - _TIRC",
+                "credit_in_account_currency": tax_amount * 2,
+            },
+            {
+                "account": "Input Tax CGST - _TIRC",
+                "debit_in_account_currency": tax_amount,
+            },
+            {
+                "account": "Input Tax SGST - _TIRC",
+                "debit_in_account_currency": tax_amount,
+            },
+        ]
+    else:
+        accounts = [
+            {
+                "account": "GST Expense - _TIRC",
+                "debit_in_account_currency": tax_amount * 2,
+            },
+            {
+                "account": "Input Tax CGST - _TIRC",
+                "credit_in_account_currency": tax_amount,
+            },
+            {
+                "account": "Input Tax SGST - _TIRC",
+                "credit_in_account_currency": tax_amount,
+            },
+        ]
+
+    doc = frappe.get_doc(
         {
             "doctype": "Journal Entry",
-            "company": "_Test Indian Registered Company",
-            "company_gstin": "24AAQCA8719H1ZC",
+            "company": COMPANY,
+            "company_gstin": COMPANY_GSTIN,
             "posting_date": posting_date,
-            "voucher_type": REVERSAL_OF_ITC,
+            "voucher_type": voucher_type,
             "ineligibility_reason": ineligibility_reason,
-            "accounts": [
-                {
-                    "account": "GST Expense - _TIRC",
-                    "debit_in_account_currency": tax_amount * 2,
-                },
-                {
-                    "account": "Input Tax CGST - _TIRC",
-                    "credit_in_account_currency": tax_amount,
-                },
-                {
-                    "account": "Input Tax SGST - _TIRC",
-                    "credit_in_account_currency": tax_amount,
-                },
-            ],
+            "accounts": accounts,
         }
     )
-    journal_entry.insert()
-    journal_entry.submit()
-    return journal_entry
-
-
-def create_itc_reclaim_journal_entry(posting_date):
-    journal_entry = frappe.get_doc(
-        {
-            "doctype": "Journal Entry",
-            "company": "_Test Indian Registered Company",
-            "company_gstin": "24AAQCA8719H1ZC",
-            "posting_date": posting_date,
-            "voucher_type": RECLAIM_OF_ITC_REVERSAL,
-            "accounts": [
-                {"account": "GST Expense - _TIRC", "credit_in_account_currency": 18},
-                {"account": "Input Tax CGST - _TIRC", "debit_in_account_currency": 9},
-                {"account": "Input Tax SGST - _TIRC", "debit_in_account_currency": 9},
-            ],
-        }
-    )
-    journal_entry.insert()
-    journal_entry.submit()
-    return journal_entry
+    doc.insert()
+    doc.submit()
+    return doc

--- a/india_compliance/gst_india/report/gst_purchase_register/test_gst_purchase_register.py
+++ b/india_compliance/gst_india/report/gst_purchase_register/test_gst_purchase_register.py
@@ -241,7 +241,6 @@ class TestGSTPurchaseRegister(IntegrationTestCase):
 def _create_journal_entry(
     posting_date, voucher_type, tax_amount, ineligibility_reason=""
 ):
-
     if voucher_type == "Reclaim of ITC Reversal":
         accounts = [
             {

--- a/india_compliance/gst_india/report/gst_purchase_register/test_gst_purchase_register.py
+++ b/india_compliance/gst_india/report/gst_purchase_register/test_gst_purchase_register.py
@@ -162,6 +162,7 @@ class TestGSTPurchaseRegister(IntegrationTestCase):
         reversal_row = by_description.get(
             "As per rules 42 & 43 of CGST Rules and section 17(5)"
         )
+        self.assertIsNotNone(reversal_row)
         self.assertEqual(reversal_row["cgst_amount"], 9.0)
         self.assertEqual(reversal_row["sgst_amount"], 9.0)
 

--- a/india_compliance/gst_india/report/gstr_3b_details/gstr_3b_details.py
+++ b/india_compliance/gst_india/report/gstr_3b_details/gstr_3b_details.py
@@ -427,6 +427,7 @@ class GSTR3B_Inward_Nil_Exempt(BaseGSTR3BDetails):
                 ConstantColumn("Purchase Invoice").as_("voucher_type"),
                 purchase_invoice.name.as_("voucher_no"),
                 purchase_invoice.posting_date,
+                purchase_invoice.gst_category,
                 purchase_invoice.place_of_supply,
                 purchase_invoice.supplier_address,
                 Sum(purchase_invoice_item.taxable_value).as_("taxable_value"),
@@ -448,7 +449,11 @@ class GSTR3B_Inward_Nil_Exempt(BaseGSTR3BDetails):
                     purchase_invoice.company_gstin
                     != IfNull(purchase_invoice.supplier_gstin, "")
                 )
-                & (purchase_invoice.gst_category != "Overseas")
+                & (
+                    IfNull(purchase_invoice.itc_classification, "").notin(
+                        ["Import Of Goods", "Import Of Service"]
+                    )
+                )
             )
             .groupby(purchase_invoice.name)
         )

--- a/india_compliance/gst_india/report/gstr_3b_details/gstr_3b_details.py
+++ b/india_compliance/gst_india/report/gstr_3b_details/gstr_3b_details.py
@@ -8,6 +8,7 @@ from frappe.query_builder.custom import ConstantColumn
 from frappe.query_builder.functions import IfNull, LiteralValue, Sum
 from frappe.utils import cint, get_first_day, get_last_day
 
+from india_compliance.gst_india.constants import TAXABLE_GST_TREATMENTS
 from india_compliance.gst_india.utils import get_period
 from india_compliance.gst_india.utils.itc_claim import apply_period_filter
 
@@ -440,7 +441,7 @@ class GSTR3B_Inward_Nil_Exempt(BaseGSTR3BDetails):
                 & (purchase_invoice.is_opening == "No")
                 & (purchase_invoice.name == purchase_invoice_item.parent)
                 & (
-                    (purchase_invoice_item.gst_treatment != "Taxable")
+                    (purchase_invoice_item.gst_treatment.notin(TAXABLE_GST_TREATMENTS))
                     | (purchase_invoice.gst_category == "Registered Composition")
                 )
                 & (purchase_invoice.company == self.company)

--- a/india_compliance/gst_india/report/gstr_3b_details/gstr_3b_details.py
+++ b/india_compliance/gst_india/report/gstr_3b_details/gstr_3b_details.py
@@ -449,11 +449,6 @@ class GSTR3B_Inward_Nil_Exempt(BaseGSTR3BDetails):
                     purchase_invoice.company_gstin
                     != IfNull(purchase_invoice.supplier_gstin, "")
                 )
-                & (
-                    IfNull(purchase_invoice.itc_classification, "").notin(
-                        ["Import Of Goods", "Import Of Service"]
-                    )
-                )
             )
             .groupby(purchase_invoice.name)
         )

--- a/india_compliance/gst_india/report/gstr_3b_details/gstr_3b_details.py
+++ b/india_compliance/gst_india/report/gstr_3b_details/gstr_3b_details.py
@@ -185,6 +185,7 @@ class GSTR3B_ITC_Details(BaseGSTR3BDetails):
                     IfNull(purchase_invoice.ineligibility_reason, "")
                     != "ITC restricted due to PoS rules"
                 )  # Ignore as it is Ineligible for ITC
+                & (purchase_invoice.is_boe_applicable == 0)
             )
             .groupby(purchase_invoice_item.parent)
         )

--- a/india_compliance/gst_india/report/hsn_wise_summary_of_outward_supplies/hsn_wise_summary_of_outward_supplies.py
+++ b/india_compliance/gst_india/report/hsn_wise_summary_of_outward_supplies/hsn_wise_summary_of_outward_supplies.py
@@ -8,6 +8,7 @@ import frappe
 from frappe import _
 from frappe.utils import flt, getdate
 
+from india_compliance.gst_india.constants import SERVICE_HSN_PREFIX
 from india_compliance.gst_india.utils.gstr_1 import GSTR1_SubCategory
 from india_compliance.gst_india.utils.gstr_1.gstr_1_data import GSTR1Invoices
 
@@ -262,7 +263,7 @@ def map_uom(uom, data=None):
         if (
             data
             and (hsn_code := data.get("hsn_code") or "")
-            and hsn_code.startswith("99")
+            and hsn_code.startswith(SERVICE_HSN_PREFIX)
         ):
             return "NA"
 

--- a/india_compliance/gst_india/report/summary_of_itc_availed/summary_of_itc_availed.py
+++ b/india_compliance/gst_india/report/summary_of_itc_availed/summary_of_itc_availed.py
@@ -72,6 +72,7 @@ class ITCAvailedCategory:
         itc_classification = row.get("itc_classification")
         is_reverse_charge = row.get("is_reverse_charge")
 
+        # sequence of check is important because bill of entry dosen't have gst_category.
         if itc_classification == "Import Of Goods":
             return Category.IMPORT_GOODS
 

--- a/india_compliance/gst_india/report/summary_of_itc_availed/summary_of_itc_availed.py
+++ b/india_compliance/gst_india/report/summary_of_itc_availed/summary_of_itc_availed.py
@@ -9,6 +9,7 @@ from frappe.query_builder import Case
 from frappe.query_builder.custom import ConstantColumn
 from frappe.query_builder.functions import IfNull
 
+from india_compliance.gst_india.constants import SERVICE_HSN_PREFIX
 from india_compliance.gst_india.utils.itc_claim import (
     apply_period_filter as _apply_itc_period_filter,
 )
@@ -97,7 +98,7 @@ class ITCAvailedCategory:
         elif row.get("is_fixed_asset") == 1:
             return SubCategory.CAPITAL_GOODS
 
-        elif (row.get("gst_hsn_code") or "").startswith("99"):
+        elif (row.get("gst_hsn_code") or "").startswith(SERVICE_HSN_PREFIX):
             return SubCategory.INPUT_SERVICES
 
         return SubCategory.INPUTS

--- a/india_compliance/gst_india/report/summary_of_itc_availed/summary_of_itc_availed.py
+++ b/india_compliance/gst_india/report/summary_of_itc_availed/summary_of_itc_availed.py
@@ -5,7 +5,6 @@ from collections import defaultdict
 
 import frappe
 from frappe import _
-from frappe.query_builder import Case
 from frappe.query_builder.custom import ConstantColumn
 from frappe.query_builder.functions import IfNull
 
@@ -139,6 +138,7 @@ class ITCAvailedData:
             .where(
                 (doc.company_gstin != IfNull(doc.supplier_gstin, ""))
                 & (doc.is_opening == "No")
+                & (IfNull(doc.itc_classification, "") != "Import Of Goods")
             )
         )
 
@@ -158,9 +158,8 @@ class ITCAvailedData:
             .inner_join(item)
             .on(doc_item.item_code == item.item_code)
             .select(
-                Case("itc_classification")
-                .when(doc_item.gst_hsn_code.like("99%"), "Import Of Service")
-                .else_("Import Of Goods"),
+                ConstantColumn("Import Of Goods").as_("itc_classification"),
+                # TODO: Remove "Overseas" classification and use actual GST category once GST category is added for BOE in the system (currently BOEs are classified as "Overseas" in GST category to distinguish them from regular purchase invoices)
                 ConstantColumn("Overseas").as_("gst_category"),
                 item.is_fixed_asset,
             )

--- a/india_compliance/gst_india/report/summary_of_itc_availed/summary_of_itc_availed.py
+++ b/india_compliance/gst_india/report/summary_of_itc_availed/summary_of_itc_availed.py
@@ -75,6 +75,7 @@ class ITCAvailedCategory:
         if itc_classification == "Import Of Goods":
             return Category.IMPORT_GOODS
 
+        # Import classifications take precedence over RCM
         elif itc_classification == "Import Of Service":
             return Category.IMPORT_SERVICES
 

--- a/india_compliance/gst_india/report/summary_of_itc_availed/summary_of_itc_availed.py
+++ b/india_compliance/gst_india/report/summary_of_itc_availed/summary_of_itc_availed.py
@@ -72,17 +72,17 @@ class ITCAvailedCategory:
         itc_classification = row.get("itc_classification")
         is_reverse_charge = row.get("is_reverse_charge")
 
-        if gst_category == "Unregistered" and is_reverse_charge:
+        if itc_classification == "Import Of Goods":
+            return Category.IMPORT_GOODS
+
+        elif itc_classification == "Import Of Service":
+            return Category.IMPORT_SERVICES
+
+        elif gst_category == "Unregistered" and is_reverse_charge:
             return Category.UNREG_RCM
 
         elif gst_category != "Unregistered" and is_reverse_charge:
             return Category.REG_RCM
-
-        elif itc_classification == "Import Of Goods":
-            return Category.IMPORT_GOODS
-
-        elif itc_classification == "Import Of Service" and gst_category != "SEZ":
-            return Category.IMPORT_SERVICES
 
         elif itc_classification == "Input Service Distributor":
             return Category.ITC_FROM_ISD
@@ -159,8 +159,6 @@ class ITCAvailedData:
             .on(doc_item.item_code == item.item_code)
             .select(
                 ConstantColumn("Import Of Goods").as_("itc_classification"),
-                # TODO: Remove "Overseas" classification and use actual GST category once GST category is added for BOE in the system (currently BOEs are classified as "Overseas" in GST category to distinguish them from regular purchase invoices)
-                ConstantColumn("Overseas").as_("gst_category"),
                 item.is_fixed_asset,
             )
         )

--- a/india_compliance/gst_india/report/summary_of_itc_availed/summary_of_itc_availed.py
+++ b/india_compliance/gst_india/report/summary_of_itc_availed/summary_of_itc_availed.py
@@ -140,7 +140,7 @@ class ITCAvailedData:
             .where(
                 (doc.company_gstin != IfNull(doc.supplier_gstin, ""))
                 & (doc.is_opening == "No")
-                & (IfNull(doc.itc_classification, "") != "Import Of Goods")
+                & (doc.is_boe_applicable == 0)
             )
         )
 

--- a/india_compliance/gst_india/report/summary_of_itc_availed/summary_of_itc_availed.py
+++ b/india_compliance/gst_india/report/summary_of_itc_availed/summary_of_itc_availed.py
@@ -135,6 +135,7 @@ class ITCAvailedData:
                 doc.itc_classification,
                 doc_item.is_fixed_asset,
                 doc.is_reverse_charge,
+                doc_item.gst_hsn_code,
             )
             .where(
                 (doc.company_gstin != IfNull(doc.supplier_gstin, ""))

--- a/india_compliance/gst_india/report/summary_of_itc_availed/test_summary_of_itc_availed.py
+++ b/india_compliance/gst_india/report/summary_of_itc_availed/test_summary_of_itc_availed.py
@@ -1,0 +1,76 @@
+import frappe
+from frappe.tests import IntegrationTestCase, change_settings
+from frappe.utils import getdate
+
+from india_compliance.gst_india.doctype.bill_of_entry.bill_of_entry import (
+    make_bill_of_entry,
+)
+from india_compliance.gst_india.report.summary_of_itc_availed.summary_of_itc_availed import (
+    execute,
+)
+from india_compliance.gst_india.utils.tests import create_purchase_invoice
+
+COMPANY = "_Test Indian Registered Company"
+COMPANY_GSTIN = "24AAQCA8719H1ZC"
+
+
+def _filters(posting_date):
+    return frappe._dict(
+        {
+            "company": COMPANY,
+            "company_gstin": COMPANY_GSTIN,
+            "date_range": [posting_date, posting_date],
+            "filter_by": "Posting Date",
+        }
+    )
+
+
+class TestSummaryOfITCAvailed(IntegrationTestCase):
+    def setUp(self):
+        filters = {"company": COMPANY}
+        for doctype in ("Purchase Invoice", "Bill of Entry"):
+            frappe.db.delete(doctype, filters=filters)
+
+    @classmethod
+    def tearDownClass(cls):
+        frappe.db.rollback()
+
+    @change_settings("GST Settings", {"enable_overseas_transactions": 1})
+    def test_boe_classified_as_import_of_goods(self):
+        pi = create_purchase_invoice(supplier="_Test Foreign Supplier", update_stock=1)
+
+        boe = make_bill_of_entry(pi.name)
+        boe.items[0].customs_duty = 100
+        boe.items[0].gst_hsn_code = "999900"
+        boe.bill_of_entry_no = "BOE-ITC-001"
+        boe.bill_of_entry_date = getdate()
+        boe.save()
+        boe.submit()
+
+        _, data = execute(_filters(getdate()))
+
+        import_goods_row = next(
+            (
+                row
+                for row in data
+                if row.get("indent") == 0
+                and "Import Of Goods (including supplies from SEZ)"
+                in row.get("details", "")
+            ),
+            None,
+        )
+        import_services_row = next(
+            (
+                row
+                for row in data
+                if row.get("indent") == 0
+                and "Import Of Services (excluding inward supplies from SEZ)"
+                in row.get("details", "")
+            ),
+            None,
+        )
+
+        self.assertIsNotNone(import_goods_row)
+        self.assertIsNotNone(import_services_row)
+        self.assertEqual(import_goods_row["igst_amount"], 36.0)
+        self.assertEqual(import_services_row["igst_amount"], 0.0)

--- a/india_compliance/gst_india/report/summary_of_itc_availed/test_summary_of_itc_availed.py
+++ b/india_compliance/gst_india/report/summary_of_itc_availed/test_summary_of_itc_availed.py
@@ -41,7 +41,7 @@ class TestSummaryOfITCAvailed(IntegrationTestCase):
 
         boe = make_bill_of_entry(pi.name)
         boe.items[0].customs_duty = 100
-        boe.items[0].gst_hsn_code = "999900"
+        boe.items[0].gst_hsn_code = "730419"
         boe.bill_of_entry_no = "BOE-ITC-001"
         boe.bill_of_entry_date = getdate()
         boe.save()

--- a/india_compliance/gst_india/report/summary_of_itc_availed/test_summary_of_itc_availed.py
+++ b/india_compliance/gst_india/report/summary_of_itc_availed/test_summary_of_itc_availed.py
@@ -74,3 +74,27 @@ class TestSummaryOfITCAvailed(IntegrationTestCase):
         self.assertIsNotNone(import_services_row)
         self.assertEqual(import_goods_row["igst_amount"], 36.0)
         self.assertEqual(import_services_row["igst_amount"], 0.0)
+
+    def test_service_purchase_is_grouped_under_input_services(self):
+        create_purchase_invoice(
+            supplier="_Test Registered Supplier",
+            item_code="_Test Service Item",
+            is_in_state=True,
+        )
+
+        _, data = execute(_filters(getdate()))
+
+        input_services_row = next(
+            (
+                row
+                for row in data
+                if row.get("indent") == 1
+                and row.get("details") == "Input Services"
+                and (row.get("cgst_amount") or 0) > 0
+            ),
+            None,
+        )
+
+        self.assertIsNotNone(input_services_row)
+        self.assertEqual(input_services_row["cgst_amount"], 9.0)
+        self.assertEqual(input_services_row["sgst_amount"], 9.0)

--- a/india_compliance/gst_india/utils/__init__.py
+++ b/india_compliance/gst_india/utils/__init__.py
@@ -821,12 +821,10 @@ def are_goods_supplied(doc):
 
 
 def are_services_supplied(doc):
-    return any(
+    return all(
         item
         for item in doc.items
-        if item.gst_hsn_code
-        and item.gst_hsn_code.startswith(SERVICE_HSN_PREFIX)
-        and item.qty != 0
+        if item.gst_hsn_code and item.gst_hsn_code.startswith(SERVICE_HSN_PREFIX)
     )
 
 

--- a/india_compliance/gst_india/utils/__init__.py
+++ b/india_compliance/gst_india/utils/__init__.py
@@ -42,6 +42,7 @@ from india_compliance.gst_india.constants import (
     SERVICE_HSN_PREFIX,
     STATE_NUMBERS,
     STATE_PINCODE_MAPPING,
+    TAX_TYPES,
     TCS,
     TIMEZONE,
     UOM_MAP,
@@ -1294,3 +1295,7 @@ def set_ewaybill_status(
         return
 
     doc.db_set("e_waybill_status", status, commit=commit, notify=notify)
+
+
+def has_gst_taxes(doc):
+    return any(row.gst_tax_type in TAX_TYPES for row in doc.taxes)

--- a/india_compliance/gst_india/utils/__init__.py
+++ b/india_compliance/gst_india/utils/__init__.py
@@ -35,6 +35,7 @@ from india_compliance.gst_india.constants import (
     GST_INVOICE_NUMBER_FORMAT,
     GST_PARTY_TYPES,
     GSTIN_FORMATS,
+    IMPORT_GST_CATEGORIES,
     PAN_NUMBER,
     PINCODE_FORMAT,
     SALES_DOCTYPES,
@@ -382,6 +383,14 @@ def is_foreign_doc(doc):
 
 def is_foreign_transaction(gst_category, place_of_supply):
     return gst_category == "Overseas" and place_of_supply == "96-Other Countries"
+
+
+def is_import_of_goods(doc):
+    return doc.gst_category in IMPORT_GST_CATEGORIES and are_goods_supplied(doc)
+
+
+def is_import_of_services(doc):
+    return doc.gst_category == "Overseas" and are_services_supplied(doc)
 
 
 def get_hsn_settings():
@@ -799,6 +808,16 @@ def are_goods_supplied(doc):
         for item in doc.items
         if item.gst_hsn_code
         and not item.gst_hsn_code.startswith(SERVICE_HSN_PREFIX)
+        and item.qty != 0
+    )
+
+
+def are_services_supplied(doc):
+    return any(
+        item
+        for item in doc.items
+        if item.gst_hsn_code
+        and item.gst_hsn_code.startswith(SERVICE_HSN_PREFIX)
         and item.qty != 0
     )
 

--- a/india_compliance/gst_india/utils/__init__.py
+++ b/india_compliance/gst_india/utils/__init__.py
@@ -38,6 +38,7 @@ from india_compliance.gst_india.constants import (
     PAN_NUMBER,
     PINCODE_FORMAT,
     SALES_DOCTYPES,
+    SERVICE_HSN_PREFIX,
     STATE_NUMBERS,
     STATE_PINCODE_MAPPING,
     TCS,
@@ -797,7 +798,7 @@ def are_goods_supplied(doc):
         item
         for item in doc.items
         if item.gst_hsn_code
-        and not item.gst_hsn_code.startswith("99")
+        and not item.gst_hsn_code.startswith(SERVICE_HSN_PREFIX)
         and item.qty != 0
     )
 

--- a/india_compliance/gst_india/utils/__init__.py
+++ b/india_compliance/gst_india/utils/__init__.py
@@ -390,6 +390,14 @@ def is_import_of_goods(doc):
 
 
 def is_import_of_services(doc):
+    """
+    Note: https://hnallp.com/assets/articles/6c0b7-gst-applicability-on-sez-transactions_final.pdf
+    Only services with GST Category as Overseas are considered as import of services.
+    Section 7(5) of IGST supply of goods or service to or by SEZ will be considered as inter-
+    State supply.Therefore, the sez service purchase transaction shall be treated as a domestic supply of services and GST
+    would be collected and discharged by the SEZ Unit / SEZ Developer i.e., under Forward
+    Charge Mechanism.
+    """
     return doc.gst_category == "Overseas" and are_services_supplied(doc)
 
 

--- a/india_compliance/gst_india/utils/__init__.py
+++ b/india_compliance/gst_india/utils/__init__.py
@@ -398,7 +398,7 @@ def is_import_of_services(doc):
     would be collected and discharged by the SEZ Unit / SEZ Developer i.e., under Forward
     Charge Mechanism.
     """
-    return doc.gst_category == "Overseas" and are_services_supplied(doc)
+    return doc.gst_category == "Overseas" and not are_goods_supplied(doc)
 
 
 def get_hsn_settings():
@@ -817,14 +817,6 @@ def are_goods_supplied(doc):
         if item.gst_hsn_code
         and not item.gst_hsn_code.startswith(SERVICE_HSN_PREFIX)
         and item.qty != 0
-    )
-
-
-def are_services_supplied(doc):
-    return all(
-        item
-        for item in doc.items
-        if item.gst_hsn_code and item.gst_hsn_code.startswith(SERVICE_HSN_PREFIX)
     )
 
 

--- a/india_compliance/gst_india/utils/e_invoice.py
+++ b/india_compliance/gst_india/utils/e_invoice.py
@@ -32,6 +32,7 @@ from india_compliance.gst_india.constants import (
     GST_CATEGORIES,
     GSTIN_FORMAT,
     PORT_CODES,
+    SERVICE_HSN_PREFIX,
     TAXABLE_GST_TREATMENTS,
 )
 from india_compliance.gst_india.constants.e_invoice import (
@@ -738,7 +739,9 @@ class EInvoiceData(GSTTransactionData):
             {
                 "discount_amount": 0,
                 "serial_no": "",
-                "is_service_item": "Y" if item.gst_hsn_code.startswith("99") else "N",
+                "is_service_item": (
+                    "Y" if item.gst_hsn_code.startswith(SERVICE_HSN_PREFIX) else "N"
+                ),
                 "unit_rate": (
                     abs(self.rounded(item.taxable_value / item.qty, 3))
                     if item.qty

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -29,6 +29,7 @@ from india_compliance.gst_india.constants import (
     GST_TAX_TYPES,
     GSTIN_FORMAT,
     SALES_DOCTYPES,
+    SERVICE_HSN_PREFIX,
     STATE_NUMBERS,
     TAXABLE_GST_TREATMENTS,
 )
@@ -1436,7 +1437,8 @@ class EWaybillData(GSTTransactionData):
 
         # Atleast one item with HSN code of goods is required
         has_atleast_one_goods_item = any(
-            not item.gst_hsn_code.startswith("99") for item in self.doc.items
+            not item.gst_hsn_code.startswith(SERVICE_HSN_PREFIX)
+            for item in self.doc.items
         )
 
         if not has_atleast_one_goods_item:
@@ -1624,7 +1626,7 @@ class EWaybillData(GSTTransactionData):
         main_hsn_code = next(
             row.gst_hsn_code
             for row in doc.items
-            if not row.gst_hsn_code.startswith("99")
+            if not row.gst_hsn_code.startswith(SERVICE_HSN_PREFIX)
         )
 
         self.transaction_details.update(

--- a/india_compliance/gst_india/utils/gstr3b/gstr3b_data.py
+++ b/india_compliance/gst_india/utils/gstr3b/gstr3b_data.py
@@ -203,7 +203,7 @@ class GSTR3BQuery:
             )
             .where((self.PI.is_opening == "No"))
             .where(self.PI.company_gstin != IfNull(self.PI.supplier_gstin, ""))
-            .where(IfNull(self.PI.itc_classification, "") != "Import Of Goods")
+            .where(self.PI.is_boe_applicable == 0)
         )
 
         return self.get_query_with_common_filters(query, self.PI)

--- a/india_compliance/gst_india/utils/gstr3b/gstr3b_data.py
+++ b/india_compliance/gst_india/utils/gstr3b/gstr3b_data.py
@@ -3,7 +3,7 @@ from frappe.query_builder import Case
 from frappe.query_builder.custom import ConstantColumn
 from frappe.query_builder.functions import IfNull, Sum
 
-from india_compliance.gst_india.constants import GST_TAX_TYPES
+from india_compliance.gst_india.constants import GST_TAX_TYPES, SERVICE_HSN_PREFIX
 from india_compliance.gst_india.overrides.transaction import is_inter_state_supply
 from india_compliance.gst_india.utils import get_full_gst_uom
 from india_compliance.gst_india.utils.gstr_1 import GSTR1_SubCategory
@@ -393,7 +393,7 @@ class GSTR3BInvoices(GSTR3BQuery, GSTR3BSubcategory):
         )
 
     def process_uom(self, invoice, identified_uom):
-        if invoice.gst_hsn_code and invoice.gst_hsn_code.startswith("99"):
+        if invoice.gst_hsn_code and invoice.gst_hsn_code.startswith(SERVICE_HSN_PREFIX):
             invoice["uom"] = "OTH-OTHERS"
             return
 

--- a/india_compliance/gst_india/utils/gstr3b/gstr3b_data.py
+++ b/india_compliance/gst_india/utils/gstr3b/gstr3b_data.py
@@ -76,14 +76,25 @@ AMOUNT_FIELDS = (
 
 class GSTR3BCategoryConditions:
     def is_composition_nil_rated_or_exempted(self, invoice):
-        return invoice.gst_category != "Overseas" and (
+        itc_classification = invoice.get("itc_classification")
+
+        return itc_classification not in ("Import Of Goods", "Import Of Service") and (
             invoice.gst_treatment == "Nil-Rated"
             or invoice.gst_treatment == "Exempted"
             or invoice.gst_category == "Registered Composition"
         )
 
     def is_non_gst(self, invoice):
-        return invoice.gst_category != "Overseas" and invoice.gst_treatment == "Non-GST"
+        itc_classification = invoice.get("itc_classification")
+
+        return (
+            itc_classification
+            not in (
+                "Import Of Goods",
+                "Import Of Service",
+            )
+            and invoice.gst_treatment == "Non-GST"
+        )
 
     def is_itc_available(self, invoice):
         return invoice.ineligibility_reason != "ITC restricted due to PoS rules"
@@ -217,6 +228,7 @@ class GSTR3BQuery:
                 ConstantColumn("Bill of Entry").as_("voucher_type"),
                 self.BOE.name.as_("voucher_no"),
                 self.BOE.posting_date,
+                ConstantColumn("Import Of Goods").as_("itc_classification"),
                 self.BOE_ITEM.is_ineligible_for_itc,
                 self.BOE_ITEM.item_code,
                 self.BOE_ITEM.gst_hsn_code,

--- a/india_compliance/gst_india/utils/gstr3b/gstr3b_data.py
+++ b/india_compliance/gst_india/utils/gstr3b/gstr3b_data.py
@@ -76,25 +76,14 @@ AMOUNT_FIELDS = (
 
 class GSTR3BCategoryConditions:
     def is_composition_nil_rated_or_exempted(self, invoice):
-        itc_classification = invoice.get("itc_classification")
-
-        return itc_classification not in ("Import Of Goods", "Import Of Service") and (
+        return (
             invoice.gst_treatment == "Nil-Rated"
             or invoice.gst_treatment == "Exempted"
             or invoice.gst_category == "Registered Composition"
         )
 
     def is_non_gst(self, invoice):
-        itc_classification = invoice.get("itc_classification")
-
-        return (
-            itc_classification
-            not in (
-                "Import Of Goods",
-                "Import Of Service",
-            )
-            and invoice.gst_treatment == "Non-GST"
-        )
+        return invoice.gst_treatment == "Non-GST"
 
     def is_itc_available(self, invoice):
         return invoice.ineligibility_reason != "ITC restricted due to PoS rules"

--- a/india_compliance/gst_india/utils/gstr_1/gstr_1_data.py
+++ b/india_compliance/gst_india/utils/gstr_1/gstr_1_data.py
@@ -10,7 +10,10 @@ from frappe.query_builder import Case, Criterion
 from frappe.query_builder.functions import Date, IfNull, Sum
 from frappe.utils import cint, flt, getdate
 
-from india_compliance.gst_india.constants import GST_REFUND_TAX_TYPES
+from india_compliance.gst_india.constants import (
+    GST_REFUND_TAX_TYPES,
+    SERVICE_HSN_PREFIX,
+)
 from india_compliance.gst_india.utils import (
     get_escaped_name,
     get_full_gst_uom,
@@ -455,7 +458,9 @@ class GSTR1Invoices(GSTR1Query, GSTR1Subcategory):
             self.assign_categories(invoice)
             self.set_hsn_sub_category(invoice, bifurcate_hsn)
 
-            if invoice.gst_hsn_code and invoice.gst_hsn_code.startswith("99"):
+            if invoice.gst_hsn_code and invoice.gst_hsn_code.startswith(
+                SERVICE_HSN_PREFIX
+            ):
                 invoice["uom"] = "OTH-OTHERS"
                 invoice["qty"] = 0
                 continue

--- a/india_compliance/gst_india/utils/gstr_1/gstr_1_json_map.py
+++ b/india_compliance/gst_india/utils/gstr_1/gstr_1_json_map.py
@@ -5,7 +5,7 @@ from itertools import chain
 import frappe
 from frappe.utils import cint, flt
 
-from india_compliance.gst_india.constants import UOM_MAP
+from india_compliance.gst_india.constants import SERVICE_HSN_PREFIX, UOM_MAP
 from india_compliance.gst_india.utils import (
     MONTHS,
     get_gst_accounts_by_type,
@@ -1281,7 +1281,7 @@ class HSNSUM(GSTR1DataMapper):
             if (
                 data
                 and (hsn_code := data.get(inv_f.HSN_CODE) or "")
-                and hsn_code.startswith("99")
+                and hsn_code.startswith(SERVICE_HSN_PREFIX)
             ):
                 return "NA"
 

--- a/india_compliance/gst_india/utils/test_e_waybill.py
+++ b/india_compliance/gst_india/utils/test_e_waybill.py
@@ -16,6 +16,7 @@ from frappe.www.printview import get_html_and_style
 from erpnext.controllers.sales_and_purchase_return import make_return_doc
 
 from india_compliance.gst_india.api_classes.base import BASE_URL
+from india_compliance.gst_india.constants import SERVICE_HSN_PREFIX
 from india_compliance.gst_india.overrides.sales_invoice import (
     is_e_waybill_applicable,
 )
@@ -1637,7 +1638,11 @@ def _bulk_insert_hsn_wise_items(hsn_codes):
                 frappe.session.user,
                 code["hsn_code"],
                 code["description"],
-                "Services" if code["hsn_code"][:2] == "99" else "Products",
+                (
+                    "Services"
+                    if code["hsn_code"][:2] == SERVICE_HSN_PREFIX
+                    else "Products"
+                ),
                 "Nos",
             ]
             for idx, code in enumerate(hsn_codes, 13000)

--- a/india_compliance/hooks.py
+++ b/india_compliance/hooks.py
@@ -176,6 +176,7 @@ doc_events = {
             "india_compliance.gst_india.overrides.purchase_invoice.onload",
             "india_compliance.gst_india.overrides.transaction.onload",
         ],
+        "before_insert": "india_compliance.gst_india.overrides.purchase_invoice.before_insert",
         "before_print": "india_compliance.gst_india.overrides.transaction.before_print",
         "before_validate": [
             "india_compliance.gst_india.overrides.transaction.before_validate_transaction",

--- a/india_compliance/hooks.py
+++ b/india_compliance/hooks.py
@@ -176,7 +176,6 @@ doc_events = {
             "india_compliance.gst_india.overrides.purchase_invoice.onload",
             "india_compliance.gst_india.overrides.transaction.onload",
         ],
-        "before_insert": "india_compliance.gst_india.overrides.purchase_invoice.before_insert",
         "before_print": "india_compliance.gst_india.overrides.transaction.before_print",
         "before_validate": [
             "india_compliance.gst_india.overrides.transaction.before_validate_transaction",

--- a/india_compliance/install.py
+++ b/india_compliance/install.py
@@ -48,6 +48,7 @@ POST_INSTALL_PATCHES = (
     "update_reconciliation_status",
     "update_vehicle_no_field_in_purchase_receipt",
     "update_gst_treatment_for_taxable_nil_transaction_item",  # it should be always after improve item tax template
+    "update_gst_treatment_for_import_transactions",
     "migrate_fields_for_gstr3b",
 )
 

--- a/india_compliance/patches.txt
+++ b/india_compliance/patches.txt
@@ -5,7 +5,7 @@ execute:from frappe.installer import add_module_defs; add_module_defs("india_com
 
 [post_model_sync]
 india_compliance.patches.v14.set_default_for_overridden_accounts_setting
-execute:from india_compliance.gst_india.setup import create_custom_fields; create_custom_fields() #69
+execute:from india_compliance.gst_india.setup import create_custom_fields; create_custom_fields() #70
 execute:from india_compliance.gst_india.setup import create_property_setters; create_property_setters() #11
 execute:from india_compliance.income_tax_india.setup import create_custom_fields; create_custom_fields() #4
 india_compliance.patches.post_install.remove_old_fields #2
@@ -79,4 +79,5 @@ india_compliance.patches.v15.unset_auth_token
 india_compliance.patches.v15.update_itc_claim_period
 india_compliance.patches.v15.migrate_logo_for_printing
 execute:from india_compliance.audit_trail.setup import create_custom_fields; create_custom_fields()
+india_compliance.patches.v15.update_itc_classification_for_sez_import_invoices
 india_compliance.patches.post_install.update_gst_treatment_for_import_transactions

--- a/india_compliance/patches.txt
+++ b/india_compliance/patches.txt
@@ -5,7 +5,7 @@ execute:from frappe.installer import add_module_defs; add_module_defs("india_com
 
 [post_model_sync]
 india_compliance.patches.v14.set_default_for_overridden_accounts_setting
-execute:from india_compliance.gst_india.setup import create_custom_fields; create_custom_fields() #70
+execute:from india_compliance.gst_india.setup import create_custom_fields; create_custom_fields() #71
 execute:from india_compliance.gst_india.setup import create_property_setters; create_property_setters() #11
 execute:from india_compliance.income_tax_india.setup import create_custom_fields; create_custom_fields() #4
 india_compliance.patches.post_install.remove_old_fields #2
@@ -80,4 +80,5 @@ india_compliance.patches.v15.update_itc_claim_period
 india_compliance.patches.v15.migrate_logo_for_printing
 execute:from india_compliance.audit_trail.setup import create_custom_fields; create_custom_fields()
 india_compliance.patches.v15.update_itc_classification_for_sez_import_invoices
+india_compliance.patches.v15.set_boe_applicable_for_import_goods_purchase_invoices
 india_compliance.patches.post_install.update_gst_treatment_for_import_transactions

--- a/india_compliance/patches.txt
+++ b/india_compliance/patches.txt
@@ -79,3 +79,4 @@ india_compliance.patches.v15.unset_auth_token
 india_compliance.patches.v15.update_itc_claim_period
 india_compliance.patches.v15.migrate_logo_for_printing
 execute:from india_compliance.audit_trail.setup import create_custom_fields; create_custom_fields()
+india_compliance.patches.post_install.update_gst_treatment_for_import_transactions

--- a/india_compliance/patches.txt
+++ b/india_compliance/patches.txt
@@ -5,7 +5,7 @@ execute:from frappe.installer import add_module_defs; add_module_defs("india_com
 
 [post_model_sync]
 india_compliance.patches.v14.set_default_for_overridden_accounts_setting
-execute:from india_compliance.gst_india.setup import create_custom_fields; create_custom_fields() #71
+execute:from india_compliance.gst_india.setup import create_custom_fields; create_custom_fields() #70
 execute:from india_compliance.gst_india.setup import create_property_setters; create_property_setters() #11
 execute:from india_compliance.income_tax_india.setup import create_custom_fields; create_custom_fields() #4
 india_compliance.patches.post_install.remove_old_fields #2

--- a/india_compliance/patches/post_install/update_gst_treatment_for_import_transactions.py
+++ b/india_compliance/patches/post_install/update_gst_treatment_for_import_transactions.py
@@ -4,6 +4,9 @@ IMPORT_CLASSIFICATIONS = ("Import Of Goods", "Import Of Service")
 
 
 def execute():
+    """
+    For existing import transactions (Import Of Goods or Import Of Service), set gst_treatment to "Taxable".
+    """
     pi = frappe.qb.DocType("Purchase Invoice")
     pi_item = frappe.qb.DocType("Purchase Invoice Item")
 

--- a/india_compliance/patches/post_install/update_gst_treatment_for_import_transactions.py
+++ b/india_compliance/patches/post_install/update_gst_treatment_for_import_transactions.py
@@ -1,0 +1,19 @@
+import frappe
+
+IMPORT_CLASSIFICATIONS = ("Import Of Goods", "Import Of Service")
+
+
+def execute():
+    pi = frappe.qb.DocType("Purchase Invoice")
+    pi_item = frappe.qb.DocType("Purchase Invoice Item")
+
+    (
+        frappe.qb.update(pi_item)
+        .inner_join(pi)
+        .on(pi_item.parent == pi.name)
+        .set(pi_item.gst_treatment, "Taxable")
+        .where(pi.itc_classification.isin(IMPORT_CLASSIFICATIONS))
+        .where(pi_item.gst_treatment != "Taxable")
+        .where(pi.docstatus == 1)
+        .run()
+    )

--- a/india_compliance/patches/v15/set_boe_applicable_for_import_goods_purchase_invoices.py
+++ b/india_compliance/patches/v15/set_boe_applicable_for_import_goods_purchase_invoices.py
@@ -5,21 +5,21 @@ from india_compliance.gst_india.constants import TAX_TYPES
 
 
 def execute():
-    purchase_invoice = frappe.qb.DocType("Purchase Invoice")
-    purchase_invoice_tax = frappe.qb.DocType("Purchase Taxes and Charges")
+    pi = frappe.qb.DocType("Purchase Invoice")
+    pi_tax = frappe.qb.DocType("Purchase Taxes and Charges")
 
     invoices_with_gst_taxes = (
-        frappe.qb.from_(purchase_invoice_tax)
-        .select(purchase_invoice_tax.parent)
-        .where(purchase_invoice_tax.parenttype == "Purchase Invoice")
-        .where(purchase_invoice_tax.gst_tax_type.isin(TAX_TYPES))
+        frappe.qb.from_(pi_tax)
+        .select(pi_tax.parent)
+        .where(pi_tax.parenttype == "Purchase Invoice")
+        .where(pi_tax.gst_tax_type.isin(TAX_TYPES))
         .distinct()
     )
 
     (
-        frappe.qb.update(purchase_invoice)
-        .set(purchase_invoice.is_boe_applicable, 1)
-        .where(IfNull(purchase_invoice.itc_classification, "") == "Import Of Goods")
-        .where(purchase_invoice.name.notin(invoices_with_gst_taxes))
-        .where(purchase_invoice.docstatus == 1)
+        frappe.qb.update(pi)
+        .set(pi.is_boe_applicable, 1)
+        .where(IfNull(pi.itc_classification, "") == "Import Of Goods")
+        .where(pi.name.notin(invoices_with_gst_taxes))
+        .where(pi.docstatus == 1)
     ).run()

--- a/india_compliance/patches/v15/set_boe_applicable_for_import_goods_purchase_invoices.py
+++ b/india_compliance/patches/v15/set_boe_applicable_for_import_goods_purchase_invoices.py
@@ -1,22 +1,18 @@
 import frappe
 from frappe.query_builder.functions import IfNull
 
+from india_compliance.gst_india.constants import TAX_TYPES
+
 
 def execute():
     purchase_invoice = frappe.qb.DocType("Purchase Invoice")
-    purchase_invoice_item = frappe.qb.DocType("Purchase Invoice Item")
+    purchase_invoice_tax = frappe.qb.DocType("Purchase Taxes and Charges")
 
-    invoices_with_gst_rate = (
-        frappe.qb.from_(purchase_invoice_item)
-        .select(purchase_invoice_item.parent)
-        .where(
-            (
-                IfNull(purchase_invoice_item.cgst_rate, 0)
-                + IfNull(purchase_invoice_item.sgst_rate, 0)
-                + IfNull(purchase_invoice_item.igst_rate, 0)
-            )
-            > 0
-        )
+    invoices_with_gst_taxes = (
+        frappe.qb.from_(purchase_invoice_tax)
+        .select(purchase_invoice_tax.parent)
+        .where(purchase_invoice_tax.parenttype == "Purchase Invoice")
+        .where(purchase_invoice_tax.gst_tax_type.isin(TAX_TYPES))
         .distinct()
     )
 
@@ -24,6 +20,6 @@ def execute():
         frappe.qb.update(purchase_invoice)
         .set(purchase_invoice.is_boe_applicable, 1)
         .where(IfNull(purchase_invoice.itc_classification, "") == "Import Of Goods")
-        .where(purchase_invoice.name.notin(invoices_with_gst_rate))
+        .where(purchase_invoice.name.notin(invoices_with_gst_taxes))
         .where(purchase_invoice.docstatus == 1)
     ).run()

--- a/india_compliance/patches/v15/set_boe_applicable_for_import_goods_purchase_invoices.py
+++ b/india_compliance/patches/v15/set_boe_applicable_for_import_goods_purchase_invoices.py
@@ -1,0 +1,35 @@
+import frappe
+from frappe.query_builder.functions import IfNull
+
+
+def execute():
+    purchase_invoice = frappe.qb.DocType("Purchase Invoice")
+    purchase_invoice_item = frappe.qb.DocType("Purchase Invoice Item")
+
+    invoices_with_gst_rate = (
+        frappe.qb.from_(purchase_invoice_item)
+        .select(purchase_invoice_item.parent)
+        .where(
+            (
+                IfNull(purchase_invoice_item.cgst_rate, 0)
+                + IfNull(purchase_invoice_item.sgst_rate, 0)
+                + IfNull(purchase_invoice_item.igst_rate, 0)
+            )
+            > 0
+        )
+        .distinct()
+    )
+
+    (
+        frappe.qb.update(purchase_invoice)
+        .set(purchase_invoice.is_boe_applicable, 0)
+        .where(IfNull(purchase_invoice.itc_classification, "") == "Import Of Goods")
+        .where(purchase_invoice.name.isin(invoices_with_gst_rate))
+    ).run()
+
+    (
+        frappe.qb.update(purchase_invoice)
+        .set(purchase_invoice.is_boe_applicable, 1)
+        .where(IfNull(purchase_invoice.itc_classification, "") == "Import Of Goods")
+        .where(purchase_invoice.name.notin(invoices_with_gst_rate))
+    ).run()

--- a/india_compliance/patches/v15/set_boe_applicable_for_import_goods_purchase_invoices.py
+++ b/india_compliance/patches/v15/set_boe_applicable_for_import_goods_purchase_invoices.py
@@ -22,13 +22,6 @@ def execute():
 
     (
         frappe.qb.update(purchase_invoice)
-        .set(purchase_invoice.is_boe_applicable, 0)
-        .where(IfNull(purchase_invoice.itc_classification, "") == "Import Of Goods")
-        .where(purchase_invoice.name.isin(invoices_with_gst_rate))
-    ).run()
-
-    (
-        frappe.qb.update(purchase_invoice)
         .set(purchase_invoice.is_boe_applicable, 1)
         .where(IfNull(purchase_invoice.itc_classification, "") == "Import Of Goods")
         .where(purchase_invoice.name.notin(invoices_with_gst_rate))

--- a/india_compliance/patches/v15/set_boe_applicable_for_import_goods_purchase_invoices.py
+++ b/india_compliance/patches/v15/set_boe_applicable_for_import_goods_purchase_invoices.py
@@ -25,4 +25,5 @@ def execute():
         .set(purchase_invoice.is_boe_applicable, 1)
         .where(IfNull(purchase_invoice.itc_classification, "") == "Import Of Goods")
         .where(purchase_invoice.name.notin(invoices_with_gst_rate))
+        .where(purchase_invoice.docstatus == 1)
     ).run()

--- a/india_compliance/patches/v15/update_itc_classification_for_sez_import_invoices.py
+++ b/india_compliance/patches/v15/update_itc_classification_for_sez_import_invoices.py
@@ -1,16 +1,25 @@
 import frappe
 
-from india_compliance.gst_india.constants import SERVICE_HSN_PREFIX
+from india_compliance.gst_india.constants import SERVICE_HSN_PREFIX, TAX_TYPES
 
 
 def execute():
     """
     - For SEZ import invoices with goods items and no tax charged, set itc_classification to "Import Of Goods"
     - For BOE invoices, pending_boe_qty should be equal to qty
-    - For non-BOE SEZ invoice items, pending_boe_qty should be 0.
+    - If single item is goods and rest are services, then also itc_classification should be "Import Of Goods".
     """
     pi = frappe.qb.DocType("Purchase Invoice")
     pi_item = frappe.qb.DocType("Purchase Invoice Item")
+    pi_tax = frappe.qb.DocType("Purchase Taxes and Charges")
+
+    invoices_with_gst_taxes = (
+        frappe.qb.from_(pi_tax)
+        .select(pi_tax.parent)
+        .where(pi_tax.parenttype == "Purchase Invoice")
+        .where(pi_tax.gst_tax_type.isin(TAX_TYPES))
+        .distinct()
+    )
 
     sez_invoices_with_goods = (
         frappe.qb.from_(pi_item)
@@ -22,7 +31,7 @@ def execute():
         .where(pi_item.qty != 0)
         .where(pi_item.gst_hsn_code != "")
         .where(pi_item.gst_hsn_code.not_like(f"{SERVICE_HSN_PREFIX}%"))
-        .where((pi_item.igst_rate + pi_item.cgst_rate + pi_item.sgst_rate) == 0)
+        .where(pi_item.parent.notin(invoices_with_gst_taxes))
         .distinct()
     )
 

--- a/india_compliance/patches/v15/update_itc_classification_for_sez_import_invoices.py
+++ b/india_compliance/patches/v15/update_itc_classification_for_sez_import_invoices.py
@@ -1,0 +1,58 @@
+import frappe
+
+from india_compliance.gst_india.constants import SERVICE_HSN_PREFIX
+
+
+def execute():
+    """
+    - For SEZ import invoices with goods items and no tax charged, set itc_classification to "Import Of Goods"
+    - For BOE invoices, pending_boe_qty should be equal to qty
+    - For non-BOE SEZ invoice items, pending_boe_qty should be 0.
+    """
+    pi = frappe.qb.DocType("Purchase Invoice")
+    pi_item = frappe.qb.DocType("Purchase Invoice Item")
+
+    sez_invoices_with_goods = (
+        frappe.qb.from_(pi_item)
+        .join(pi)
+        .on(pi_item.parent == pi.name)
+        .select(pi_item.parent)
+        .where(pi.docstatus == 1)
+        .where(pi.gst_category == "SEZ")
+        .where(pi_item.qty != 0)
+        .where(pi_item.gst_hsn_code != "")
+        .where(pi_item.gst_hsn_code.not_like(f"{SERVICE_HSN_PREFIX}%"))
+        .where((pi_item.igst_rate + pi_item.cgst_rate + pi_item.sgst_rate) == 0)
+        .distinct()
+    )
+
+    # Set itc_classification to "Import Of Goods" for SEZ invoices with goods items and no tax charged
+    (
+        frappe.qb.update(pi)
+        .set(pi.itc_classification, "Import Of Goods")
+        .where(pi.docstatus == 1)
+        .where(pi.gst_category == "SEZ")
+        .where(pi.itc_classification != "Import Of Goods")
+        .where(pi.name.isin(sez_invoices_with_goods))
+        .run()
+    )
+
+    # For BOE invoices, pending_boe_qty should be equal to qty
+    (
+        frappe.qb.update(pi_item)
+        .set(pi_item.pending_boe_qty, pi_item.qty)
+        .where(pi_item.parent.isin(sez_invoices_with_goods))
+        .run()
+    )
+
+    # For non-BOE sez invoice items, pending_boe_qty should be 0
+    (
+        frappe.qb.update(pi_item)
+        .join(pi)
+        .on(pi_item.parent == pi.name)
+        .set(pi_item.pending_boe_qty, 0)
+        .where(pi.docstatus == 1)
+        .where(pi.gst_category == "SEZ")
+        .where(pi.itc_classification != "Import Of Goods")
+        .run()
+    )

--- a/india_compliance/patches/v15/update_itc_classification_for_sez_import_invoices.py
+++ b/india_compliance/patches/v15/update_itc_classification_for_sez_import_invoices.py
@@ -5,21 +5,13 @@ from india_compliance.gst_india.constants import SERVICE_HSN_PREFIX, TAX_TYPES
 
 def execute():
     """
-    - For SEZ import invoices with goods items and no tax charged, set itc_classification to "Import Of Goods"
+    - For SEZ import invoices with goods items, set itc_classification to "Import Of Goods"
     - For BOE invoices, pending_boe_qty should be equal to qty
     - If single item is goods and rest are services, then also itc_classification should be "Import Of Goods".
     """
     pi = frappe.qb.DocType("Purchase Invoice")
     pi_item = frappe.qb.DocType("Purchase Invoice Item")
     pi_tax = frappe.qb.DocType("Purchase Taxes and Charges")
-
-    invoices_with_gst_taxes = (
-        frappe.qb.from_(pi_tax)
-        .select(pi_tax.parent)
-        .where(pi_tax.parenttype == "Purchase Invoice")
-        .where(pi_tax.gst_tax_type.isin(TAX_TYPES))
-        .distinct()
-    )
 
     sez_invoices_with_goods = (
         frappe.qb.from_(pi_item)
@@ -31,11 +23,10 @@ def execute():
         .where(pi_item.qty != 0)
         .where(pi_item.gst_hsn_code != "")
         .where(pi_item.gst_hsn_code.not_like(f"{SERVICE_HSN_PREFIX}%"))
-        .where(pi_item.parent.notin(invoices_with_gst_taxes))
         .distinct()
     )
 
-    # Set itc_classification to "Import Of Goods" for SEZ invoices with goods items and no tax charged
+    # Set itc_classification to "Import Of Goods" for SEZ invoices with goods items
     (
         frappe.qb.update(pi)
         .set(pi.itc_classification, "Import Of Goods")
@@ -46,15 +37,23 @@ def execute():
         .run()
     )
 
-    # For BOE invoices, pending_boe_qty should be equal to qty
+    # For BOE invoices without taxes, pending_boe_qty should be equal to qty
+    invoices_with_gst_taxes = (
+        frappe.qb.from_(pi_tax)
+        .select(pi_tax.parent)
+        .where(pi_tax.parenttype == "Purchase Invoice")
+        .where(pi_tax.gst_tax_type.isin(TAX_TYPES))
+        .distinct()
+    )
     (
         frappe.qb.update(pi_item)
         .set(pi_item.pending_boe_qty, pi_item.qty)
         .where(pi_item.parent.isin(sez_invoices_with_goods))
+        .where(pi_item.parent.notin(invoices_with_gst_taxes))
         .run()
     )
 
-    # For non-BOE sez invoice items, pending_boe_qty should be 0
+    # For non-BOE sez invoice items with taxes, pending_boe_qty should be 0
     (
         frappe.qb.update(pi_item)
         .join(pi)
@@ -62,6 +61,6 @@ def execute():
         .set(pi_item.pending_boe_qty, 0)
         .where(pi.docstatus == 1)
         .where(pi.gst_category == "SEZ")
-        .where(pi.itc_classification != "Import Of Goods")
+        .where(pi.name.isin(invoices_with_gst_taxes))
         .run()
     )

--- a/india_compliance/public/js/transaction.js
+++ b/india_compliance/public/js/transaction.js
@@ -155,6 +155,10 @@ async function update_gst_details(frm, event) {
             frm.doc.purpose === "Material Transfer" && frm.doc.is_return;
     } else {
         fieldnames_to_set.push("supplier_address", "supplier_gstin");
+
+        if (frm.doc.doctype === "Purchase Invoice") {
+            fieldnames_to_set.push("is_boe_applicable");
+        }
     }
 
     for (const fieldname of fieldnames_to_set) {

--- a/india_compliance/public/js/transaction.js
+++ b/india_compliance/public/js/transaction.js
@@ -155,10 +155,6 @@ async function update_gst_details(frm, event) {
             frm.doc.purpose === "Material Transfer" && frm.doc.is_return;
     } else {
         fieldnames_to_set.push("supplier_address", "supplier_gstin");
-
-        if (frm.doc.doctype === "Purchase Invoice") {
-            fieldnames_to_set.push("is_boe_applicable");
-        }
     }
 
     for (const fieldname of fieldnames_to_set) {


### PR DESCRIPTION
- Allow BOE for Import of Goods from SEZ
- GST Treatment for Imports in purchase as Taxable
- Introduced new constant for SERVICE HSN (99)
- Only the import of goods from the SEZ will be considered as an import.
- Added a patch to update GST Treatment as Taxable for Import of Services and Import of Goods.
- Added a patch to update the itc_classification SEZ goods invoice with no taxes.


closes: https://github.com/frappe/erpnext/issues/53387
closes: https://github.com/resilient-tech/india-compliance/issues/3965

no-docs