### PR TITLE
ci: add workflow_dispatch

### DIFF
--- a/.github/helper/install.sh
+++ b/.github/helper/install.sh
@@ -27,7 +27,10 @@ wkpid=$!
 
 pip install frappe-bench
 
-git clone "https://github.com/frappe/frappe" --branch "$BRANCH_TO_CLONE" --depth 1
+FRAPPE_REMOTE=${FRAPPE_REMOTE:-https://github.com/frappe/frappe.git}
+FRAPPE_BRANCH=${FRAPPE_BRANCH:-$BRANCH_TO_CLONE}
+
+git clone "$FRAPPE_REMOTE" --branch "$FRAPPE_BRANCH" --depth 1
 bench init --skip-assets --frappe-path ~/frappe --python "$(which python)" frappe-bench
 
 mkdir ~/frappe-bench/sites/test_site
@@ -53,7 +56,10 @@ sed -i 's/schedule:/# schedule:/g' Procfile
 sed -i 's/socketio:/# socketio:/g' Procfile
 sed -i 's/redis_socketio:/# redis_socketio:/g' Procfile
 
-bench get-app erpnext --branch "$BRANCH_TO_CLONE" --resolve-deps
+ERPNEXT_REMOTE=${ERPNEXT_REMOTE:-https://github.com/frappe/erpnext.git}
+ERPNEXT_BRANCH=${ERPNEXT_BRANCH:-$BRANCH_TO_CLONE}
+
+bench get-app "$ERPNEXT_REMOTE" --branch "$ERPNEXT_BRANCH" --resolve-deps
 bench get-app india_compliance "${GITHUB_WORKSPACE}"
 bench setup requirements --dev
 

--- a/.github/helper/install.sh
+++ b/.github/helper/install.sh
@@ -30,7 +30,7 @@ pip install frappe-bench
 FRAPPE_REMOTE=${FRAPPE_REMOTE:-https://github.com/frappe/frappe.git}
 FRAPPE_BRANCH=${FRAPPE_BRANCH:-$BRANCH_TO_CLONE}
 
-git clone "$FRAPPE_REMOTE" --branch "$FRAPPE_BRANCH" --depth 1
+git clone "$FRAPPE_REMOTE" --branch "$FRAPPE_BRANCH" --depth 1 ~/frappe
 bench init --skip-assets --frappe-path ~/frappe --python "$(which python)" frappe-bench
 
 mkdir ~/frappe-bench/sites/test_site

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -37,9 +37,37 @@ on:
       - "**.md"
       - "**.html"
       - "**.csv"
+
+  workflow_dispatch:
+    inputs:
+      frappe_remote:
+        description: "Frappe remote URL"
+        required: false
+        default: "https://github.com/frappe/frappe.git"
+        type: string
+      frappe_branch:
+        description: "Frappe branch"
+        required: false
+        default: "develop"
+        type: string
+      erpnext_remote:
+        description: "ERPNext remote URL"
+        required: false
+        default: "https://github.com/frappe/erpnext.git"
+        type: string
+      erpnext_branch:
+        description: "ERPNext branch"
+        required: false
+        default: "develop"
+        type: string
+
 env:
   BRANCH: ${{ inputs.base_ref || github.base_ref || github.ref_name }}
   APP_NAME: ${{ inputs.app_name || 'india_compliance' }}
+
+concurrency:
+  group: server-tests-${{ github.event_name }}-${{ github.event.number || github.event_name == 'workflow_dispatch' && github.run_id || '' }}
+  cancel-in-progress: true
 
 jobs:
   tests:
@@ -116,6 +144,10 @@ jobs:
           bash ${GITHUB_WORKSPACE}/.github/helper/install.sh
         env:
           BRANCH_TO_CLONE: ${{ env.BRANCH }}
+          FRAPPE_REMOTE: ${{ inputs.frappe_remote }}
+          FRAPPE_BRANCH: ${{ inputs.frappe_branch }}
+          ERPNEXT_REMOTE: ${{ inputs.erpnext_remote }}
+          ERPNEXT_BRANCH: ${{ inputs.erpnext_branch }}
 
       - name: Run Tests
         run: cd ~/frappe-bench/ && bench --site test_site run-parallel-tests --app ${{ env.APP_NAME }} --with-coverage

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -66,7 +66,7 @@ env:
   APP_NAME: ${{ inputs.app_name || 'india_compliance' }}
 
 concurrency:
-  group: server-tests-${{ github.event_name }}-${{ github.event.number || github.event_name == 'workflow_dispatch' && github.run_id || '' }}
+  group: server-tests-${{ github.event_name }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.event.number || github.ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Add `workflow_dispatch` with Custom Frappe/ERPNext Remotes and Concurrency control

Adds a manual `workflow_dispatch` trigger to `server-tests.yml` so the CI can be run against custom forks or branches of Frappe and ERPNext without modifying any files. Also fixes `install.sh` to correctly handle ERPNext forks that have a different app/repo name than `erpnext`.

Adds `concurrency` group keyed by event type + PR number (or run ID for dispatches), with `cancel-in-progress: true` to avoid redundant runs on the same PR.


