### PR TITLE
fix: failing test

### DIFF
--- a/india_compliance/gst_india/doctype/bill_of_entry/test_bill_of_entry.py
+++ b/india_compliance/gst_india/doctype/bill_of_entry/test_bill_of_entry.py
@@ -3,11 +3,11 @@
 
 import json
 import re
+import unittest.mock as mock
 
 import frappe
 from frappe.tests import IntegrationTestCase
 from frappe.utils import today
-from erpnext.projects.doctype.project.test_project import make_project
 
 from india_compliance.gst_india.doctype.bill_of_entry.bill_of_entry import (
     get_pi_items,
@@ -19,6 +19,11 @@ from india_compliance.gst_india.overrides.test_transaction import create_cess_ac
 from india_compliance.gst_india.utils import get_gst_accounts_by_type
 from india_compliance.gst_india.utils.itc_claim import format_period
 from india_compliance.gst_india.utils.tests import create_purchase_invoice
+
+with mock.patch("frappe.db"), mock.patch("frappe.new_doc"), mock.patch(
+    "frappe.get_doc"
+):
+    from erpnext.projects.doctype.project.test_project import make_project
 
 IGNORE_TEST_RECORD_DEPENDENCIES = [
     "Bill of Entry",
@@ -311,7 +316,6 @@ class TestBillofEntry(IntegrationTestCase):
 
     def test_project_in_gl_entries(self):
         """Test that project from Purchase Invoice is auto-copied to Bill of Entry and passed to GL Entry"""
-
         project = make_project(
             {
                 "project_name": "_Test BOE Project",

--- a/india_compliance/gst_india/overrides/test_purchase_invoice.py
+++ b/india_compliance/gst_india/overrides/test_purchase_invoice.py
@@ -1,9 +1,9 @@
 import re
+import unittest.mock as mock
 
 import frappe
 from frappe.tests import IntegrationTestCase, change_settings
 from frappe.utils import add_months, getdate
-from erpnext.accounts.doctype.account.test_account import create_account
 
 from india_compliance.gst_india.utils.itc_claim import (
     ITC_CLAIM_PERIOD_DEFERRED,
@@ -11,6 +11,11 @@ from india_compliance.gst_india.utils.itc_claim import (
     update_gstr3b_filing_status,
 )
 from india_compliance.gst_india.utils.tests import append_item, create_purchase_invoice
+
+with mock.patch("frappe.db"), mock.patch("frappe.new_doc"), mock.patch(
+    "frappe.get_doc"
+):
+    from erpnext.accounts.doctype.account.test_account import create_account
 
 
 class TestPurchaseInvoice(IntegrationTestCase):

--- a/india_compliance/gst_india/overrides/test_subcontracting_transaction.py
+++ b/india_compliance/gst_india/overrides/test_subcontracting_transaction.py
@@ -1,4 +1,5 @@
 import re
+import unittest.mock as mock
 
 import frappe
 from frappe.tests import IntegrationTestCase
@@ -6,14 +7,20 @@ from erpnext.controllers.subcontracting_controller import (
     get_materials_from_supplier,
     make_rm_stock_entry,
 )
-from erpnext.controllers.tests.test_subcontracting_controller import get_rm_items
-from erpnext.manufacturing.doctype.production_plan.test_production_plan import make_bom
 from erpnext.subcontracting.doctype.subcontracting_order.subcontracting_order import (
     make_subcontracting_receipt,
 )
-from erpnext.subcontracting.doctype.subcontracting_order.test_subcontracting_order import (
-    create_subcontracting_order,
-)
+
+with mock.patch("frappe.db"), mock.patch("frappe.new_doc"), mock.patch(
+    "frappe.get_doc"
+):
+    from erpnext.controllers.tests.test_subcontracting_controller import get_rm_items
+    from erpnext.manufacturing.doctype.production_plan.test_production_plan import (
+        make_bom,
+    )
+    from erpnext.subcontracting.doctype.subcontracting_order.test_subcontracting_order import (
+        create_subcontracting_order,
+    )
 
 from india_compliance.gst_india.utils.tests import create_transaction
 

--- a/india_compliance/gst_india/utils/itc_04/test_itc_04_export.py
+++ b/india_compliance/gst_india/utils/itc_04/test_itc_04_export.py
@@ -1,14 +1,20 @@
+import unittest.mock as mock
+
 from frappe.tests import IntegrationTestCase
-from erpnext.accounts.doctype.payment_reconciliation.test_payment_reconciliation import (
-    create_fiscal_year,
-)
-from erpnext.controllers.tests.test_subcontracting_controller import get_rm_items
 from erpnext.subcontracting.doctype.subcontracting_order.subcontracting_order import (
     make_subcontracting_receipt,
 )
-from erpnext.subcontracting.doctype.subcontracting_order.test_subcontracting_order import (
-    create_subcontracting_order,
-)
+
+with mock.patch("frappe.db"), mock.patch("frappe.new_doc"), mock.patch(
+    "frappe.get_doc"
+):
+    from erpnext.accounts.doctype.payment_reconciliation.test_payment_reconciliation import (
+        create_fiscal_year,
+    )
+    from erpnext.controllers.tests.test_subcontracting_controller import get_rm_items
+    from erpnext.subcontracting.doctype.subcontracting_order.test_subcontracting_order import (
+        create_subcontracting_order,
+    )
 
 from india_compliance.gst_india.overrides.test_subcontracting_transaction import (
     create_purchase_order,


### PR DESCRIPTION
Any ERPNext Test Utilities should be imported with unittest mock to avoid repeated creation of BootStrapTestData of ERPNext and avoid breaking of test after refactor of ERPNext as in: https://github.com/frappe/erpnext/commit/518800cd2f5e7fef00e70a5c90da14af2a5e522c and https://github.com/frappe/erpnext/commit/5a4a77f5d27510ce809923b81028a8f59b3a9dba


