### PR TITLE
fix: refactor generate_gstr1 message pattern to support custom start messages

### DIFF
--- a/india_compliance/gst_india/doctype/gstr_1/gstr_1.py
+++ b/india_compliance/gst_india/doctype/gstr_1/gstr_1.py
@@ -82,20 +82,20 @@ class GSTR1(Document):
             log_name, company=self.company, filing_preference=self.filing_preference
         )
 
-        message = None
+        busy_message = None
         if gstr1_log.status == "In Progress":
-            message = (
+            busy_message = (
                 "GSTR-1 is being prepared. Please wait for the process to complete."
             )
 
         elif gstr1_log.status == "Queued":
-            message = (
+            busy_message = (
                 "GSTR-1 download is queued and could take some time. Please wait"
                 " for the process to complete."
             )
 
-        if message:
-            frappe.msgprint(_(message), title=_("GSTR-1 Generation In Progress"))
+        if busy_message:
+            frappe.msgprint(_(busy_message), title=_("GSTR-1 Generation In Progress"))
             return
 
         settings = frappe.get_cached_doc("GST Settings")


### PR DESCRIPTION
## Problem

The generate_gstr1 function in gstr_1.py had an issue with how it handled messages, making the message parameter useless:

1. **Parameter Overwrite**: The message argument was explicitly reset to `None` at the start of the function.
2. **Variable Reuse**: The same message variable was used to track internal "busy" statuses (e.g., "In Progress", "Queued") and also for the final success toast.

## Solution

Separated the internal state tracking from the output message:
- Introduced `busy_message` for tracking "In Progress" or "Queued" logic instead of `message`.

## Example Usage

This fix enables passing custom messages from the frontend which were previously ignored or broken. For example, in gstr_1.js, we call generate_gstr1 to verify a filed return:

```javascript
this.frm
    .taxpayer_api_call("generate_gstr1", {
        message: "Verifying filed GSTR-1",
    })
```

Previously, this custom message ("Verifying filed GSTR-1") would have been overwritten by the default "GSTR-1 is being prepared". With this change, it is correctly displayed as the starting alert.
