### PR TITLE
fix: ensure company GSTIN options are set only for new GSTR 3B reports

### DIFF
--- a/india_compliance/gst_india/doctype/gstr_3b_report/gstr_3b_report.js
+++ b/india_compliance/gst_india/doctype/gstr_3b_report/gstr_3b_report.js
@@ -11,7 +11,8 @@ frappe.ui.form.on("GSTR 3B Report", {
 
         if (frm.doc.company && frm.is_new()) {
             india_compliance.set_gstin_options(frm, false, true).then(options => {
-                frm.set_value("company_gstin", options[0]);
+                if (options && options.length)
+                    frm.set_value("company_gstin", options[0]);
             });
         }
 

--- a/india_compliance/gst_india/doctype/gstr_3b_report/gstr_3b_report.js
+++ b/india_compliance/gst_india/doctype/gstr_3b_report/gstr_3b_report.js
@@ -9,10 +9,11 @@ frappe.ui.form.on("GSTR 3B Report", {
     onload: function (frm) {
         set_options_for_year_month(frm);
 
-        if (frm.doc.company)
+        if (frm.doc.company && frm.is_new()) {
             india_compliance.set_gstin_options(frm, false, true).then(options => {
                 frm.set_value("company_gstin", options[0]);
             });
+        }
 
         frappe.realtime.on("gstr3b_report_generation", function () {
             frm.reload_doc();
@@ -25,7 +26,7 @@ frappe.ui.form.on("GSTR 3B Report", {
         const is_filed = frm.doc.filing_status === "Filed";
         frm.page.set_indicator(
             is_filed ? __("Filed") : __("Not Filed"),
-            is_filed ? "green" : "orange"
+            is_filed ? "green" : "orange",
         );
 
         frm.set_intro(__("Please save the report again to rebuild or update"));
@@ -36,9 +37,9 @@ frappe.ui.form.on("GSTR 3B Report", {
             var w = window.open(
                 frappe.urllib.get_full_url(
                     "/api/method/india_compliance.gst_india.doctype.gstr_3b_report.gstr_3b_report.make_json?" +
-                    "name=" +
-                    encodeURIComponent(frm.doc.name)
-                )
+                        "name=" +
+                        encodeURIComponent(frm.doc.name),
+                ),
             );
 
             if (!w) {
@@ -52,9 +53,9 @@ frappe.ui.form.on("GSTR 3B Report", {
             var w = window.open(
                 frappe.urllib.get_full_url(
                     "/api/method/india_compliance.gst_india.doctype.gstr_3b_report.gstr_3b_report.download_gstr3b_as_excel?" +
-                    "name=" +
-                    encodeURIComponent(frm.doc.name)
-                )
+                        "name=" +
+                        encodeURIComponent(frm.doc.name),
+                ),
             );
 
             if (!w) {
@@ -96,7 +97,7 @@ frappe.ui.form.on("GSTR 3B Report", {
                 gstin: frm.doc.company_gstin,
                 return_period: india_compliance.get_period(
                     frm.doc.month_or_quarter,
-                    frm.doc.year
+                    frm.doc.year,
                 ),
                 doctype: frm.doc.doctype,
                 callback: function (regeneration_status) {
@@ -113,10 +114,8 @@ frappe.ui.form.on("GSTR 3B Report", {
         });
 
         if (!frm.is_new()) {
-            let action =
-                frm.doc.filing_status === "Filed" ? "Not Filed" : "Filed";
-            let status_label =
-                action === "Filed" ? __("Filed") : __("Unfiled");
+            let action = frm.doc.filing_status === "Filed" ? "Not Filed" : "Filed";
+            let status_label = action === "Filed" ? __("Filed") : __("Unfiled");
 
             frm.add_custom_button(
                 __("Mark as {0}", [status_label]),
@@ -138,10 +137,10 @@ frappe.ui.form.on("GSTR 3B Report", {
                                 },
                                 callback: () => frm.reload_doc(),
                             });
-                        }
+                        },
                     );
                 },
-                __("Filing Status")
+                __("Filing Status"),
             );
         }
     },
@@ -164,7 +163,7 @@ function append_form(frm) {
     $(
         frappe.render_template("gstr_3b_report", {
             data: JSON.parse(frm.doc.json_output),
-        })
+        }),
     ).appendTo(frm.fields_dict.gstr3b_form.wrapper);
 }
 


### PR DESCRIPTION
Issue: Due to autosetting of GSTIN on onload.A user with multiple GSTINs in a single company was not able to re-save because the company GSTIN can be set only once.

<img width="1609" height="120" alt="image" src="https://github.com/user-attachments/assets/85767b3b-66cf-4694-8fbb-d97c07ce5a0d" />
