### PR TITLE
fix: reorder conditions in sales invoice e-waybill validation  to avoid unnnecessary call for unregistered company

### DIFF
--- a/india_compliance/gst_india/client_scripts/sales_invoice.js
+++ b/india_compliance/gst_india/client_scripts/sales_invoice.js
@@ -41,8 +41,8 @@ frappe.ui.form.on(DOCTYPE, {
             frm.doc.customer_address ||
             frm.doc.is_return ||
             frm.doc.is_debit_note ||
-            !(await has_e_waybill_threshold_met(frm)) ||
-            !is_e_waybill_applicable(frm)
+            !is_e_waybill_applicable(frm) ||
+            !(await has_e_waybill_threshold_met(frm))
         )
             return;
 

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -621,9 +621,13 @@ def is_inter_state_supply(doc):
     else:
         party_gst_category = doc.gst_category
 
-    return party_gst_category == "SEZ" or (
-        doc.place_of_supply[:2] != get_source_state_code(doc)
-    )
+    if party_gst_category == "SEZ":
+        return True
+
+    if not doc.place_of_supply:
+        return False
+
+    return doc.place_of_supply[:2] != get_source_state_code(doc)
 
 
 def get_source_state_code(doc):


### PR DESCRIPTION
Issue: The threshold check API was being called for an unregistered company, where the place of supply is not set, causing the issue.

closes: https://github.com/resilient-tech/india-compliance/issues/4117
