### PR TITLE
fix: guard dialog onchange handlers against early calls during construction

### DIFF
--- a/india_compliance/gst_india/client_scripts/e_waybill_actions.js
+++ b/india_compliance/gst_india/client_scripts/e_waybill_actions.js
@@ -1326,7 +1326,7 @@ async function update_gst_tranporter_id(dialog) {
             transporter,
             "gst_transporter_id",
         );
-        transporter_id = response?.gst_transporter_id;
+        transporter_id = response?.gst_transporter_id || "";
     }
 
     dialog.set_value("gst_transporter_id", transporter_id);

--- a/india_compliance/gst_india/client_scripts/e_waybill_actions.js
+++ b/india_compliance/gst_india/client_scripts/e_waybill_actions.js
@@ -1318,14 +1318,18 @@ function is_e_waybill_cancellable(frm) {
 }
 
 async function update_gst_tranporter_id(dialog) {
+    let transporter_id = "";
     const transporter = dialog.get_value("transporter");
-    const { message: response } = await frappe.db.get_value(
-        "Supplier",
-        transporter,
-        "gst_transporter_id",
-    );
+    if (transporter) {
+        const { message: response } = await frappe.db.get_value(
+            "Supplier",
+            transporter,
+            "gst_transporter_id",
+        );
+        transporter_id = response?.gst_transporter_id;
+    }
 
-    dialog.set_value("gst_transporter_id", response.gst_transporter_id);
+    dialog.set_value("gst_transporter_id", transporter_id);
 }
 
 function validate_gst_transporter_id(dialog, doc) {

--- a/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.js
+++ b/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.js
@@ -1006,7 +1006,7 @@ class ImportDialog {
     }
 
     async fetch_import_history() {
-        if (!this.company_gstin) return;
+        if (!this.company_gstin || !this.return_type || !this.date_range) return;
 
         // fetch history
         const { message } = await this.frm._call("get_import_history", {

--- a/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.js
+++ b/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.js
@@ -1121,17 +1121,14 @@ class ImportDialog {
                     const period = this.dialog.get_value("period");
                     if (!period) return;
 
-                    if (period === "Custom") {
-                        this.date_range = this.dialog.get_value("date_range");
-                        this.fetch_import_history();
-                        return;
+                    this.date_range = this.dialog.get_value("date_range");
+                    if (period !== "Custom") {
+                        const { message } = await this.frm._call("get_date_range", {
+                            period,
+                        });
+
+                        if (message) this.date_range = message;
                     }
-
-                    const { message } = await this.frm._call("get_date_range", {
-                        period,
-                    });
-
-                    this.date_range = message || this.dialog.get_value("date_range");
                     this.fetch_import_history();
                 },
             },

--- a/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.js
+++ b/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.js
@@ -1119,6 +1119,14 @@ class ImportDialog {
                 default: this.frm.doc.inward_supply_period,
                 onchange: async () => {
                     const period = this.dialog.get_value("period");
+                    if (!period) return;
+
+                    if (period === "Custom") {
+                        this.date_range = this.dialog.get_value("date_range");
+                        this.fetch_import_history();
+                        return;
+                    }
+
                     const { message } = await this.frm._call("get_date_range", {
                         period,
                     });


### PR DESCRIPTION
regression: https://github.com/frappe/frappe/pull/37384
Issue: Previously, field defaults were applied via set_input(default_value), which only updates the DOM silently. After this PR, defaults are applied via set_value(default_value), which triggers onchange.
This causes onchange to fire for all fields with a default during new frappe.ui.Dialog() construction — before the dialog has been initialised.

Frappe Support Issue: https://support.frappe.io/desk/hd-ticket/63019