### PR TITLE
fix: disallow reverse charge for SEZ without payment of GST

### DIFF
--- a/india_compliance/gst_india/overrides/test_transaction.py
+++ b/india_compliance/gst_india/overrides/test_transaction.py
@@ -160,7 +160,7 @@ class TestTransaction(IntegrationTestCase):
         self.assertRaisesRegex(
             frappe.exceptions.ValidationError,
             re.compile(
-                r"^(Transaction cannot be reverse charge for SEZ supply without payment of GST)$"
+                r"^(Transaction cannot be reverse charge for export/SEZ supply without payment of GST)$"
             ),
             create_transaction,
             **self.transaction_details,

--- a/india_compliance/gst_india/overrides/test_transaction.py
+++ b/india_compliance/gst_india/overrides/test_transaction.py
@@ -152,6 +152,7 @@ class TestTransaction(IntegrationTestCase):
 
         self.assertEqual(return_doc.is_reverse_charge, 1)
 
+    @change_settings("GST Settings", {"enable_overseas_transactions": 1})
     def test_sez_without_payment_with_reverse_charge(self):
         if not self.is_sales_doctype:
             return

--- a/india_compliance/gst_india/overrides/test_transaction.py
+++ b/india_compliance/gst_india/overrides/test_transaction.py
@@ -152,6 +152,22 @@ class TestTransaction(IntegrationTestCase):
 
         self.assertEqual(return_doc.is_reverse_charge, 1)
 
+    def test_sez_without_payment_with_reverse_charge(self):
+        if not self.is_sales_doctype:
+            return
+
+        self.assertRaisesRegex(
+            frappe.exceptions.ValidationError,
+            re.compile(
+                r"^(Transaction cannot be reverse charge for SEZ supply without payment of GST)$"
+            ),
+            create_transaction,
+            **self.transaction_details,
+            gst_category="SEZ",
+            is_export_with_gst=0,
+            is_reverse_charge=1,
+        )
+
     def test_non_taxable_items_with_tax(self):
         doc = create_transaction(
             **self.transaction_details,

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -695,7 +695,7 @@ def validate_sales_reverse_charge(doc):
     if doc.get("is_reverse_charge") and is_export_without_payment_of_gst(doc):
         frappe.throw(
             _(
-                "Transaction cannot be reverse charge for SEZ supply without payment"
+                "Transaction cannot be reverse charge for export/SEZ supply without payment"
                 " of GST"
             )
         )

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -692,6 +692,14 @@ def validate_sales_reverse_charge(doc):
             )
         )
 
+    if doc.get("is_reverse_charge") and is_export_without_payment_of_gst(doc):
+        frappe.throw(
+            _(
+                "Transaction cannot be reverse charge for SEZ supply without payment"
+                " of GST"
+            )
+        )
+
 
 def _validate_hsn_codes(doc, valid_hsn_length, throw=False, message=None):
     rows_with_missing_hsn = []


### PR DESCRIPTION
## Summary
This PR adds a GST validation to prevent an invalid combination on sales transactions:
- `is_reverse_charge = 1`
- SEZ/export without payment of GST (`is_export_with_gst = 0`)

It also adds a regression test to cover this scenario.

## Problem
Reverse charge on outward SEZ supplies without payment of GST is not a valid business flow, but it was previously allowed.

## Changes
- Updated `validate_sales_reverse_charge` in `india_compliance/gst_india/overrides/transaction.py`
  - Throws validation error when reverse charge is selected for export/SEZ supplies without payment.
- Added test `test_sez_without_payment_with_reverse_charge` in `india_compliance/gst_india/overrides/test_transaction.py`
  - Verifies the above case raises a `ValidationError`.

## Validation message
`Transaction cannot be reverse charge for SEZ supply without payment of GST`