### PR TITLE
fix: use compact JSON encoding for compressed GST return log-files

### DIFF
--- a/india_compliance/gst_india/doctype/gst_return_log/gst_return_log.py
+++ b/india_compliance/gst_india/doctype/gst_return_log/gst_return_log.py
@@ -2,6 +2,7 @@
 # For license information, please see license.txt
 
 import gzip
+import json
 from datetime import datetime
 
 import frappe
@@ -13,6 +14,7 @@ from frappe.utils import (
     get_link_to_form,
     getdate,
 )
+from frappe.utils.response import json_handler
 
 from india_compliance.gst_india.doctype.gst_return_log.generate_gstr_1 import (
     FileGSTR1,
@@ -316,7 +318,9 @@ def get_file_doc(doctype, docname, attached_to_field):
 
 
 def get_compressed_data(json_data):
-    return gzip.compress(frappe.safe_encode(frappe.as_json(json_data)))
+    return gzip.compress(
+        frappe.safe_encode(json.dumps(json_data, default=json_handler, separators=(",", ":")))
+    )
 
 
 def get_decompressed_data(content):


### PR DESCRIPTION
## Problem
`get_compressed_data` was calling `frappe.as_json` which passes `indent=1` and `sort_keys=True` to `json.dumps`. This produces pretty-printed output with `\n`, `\t`, and spaces — pure whitespace overhead in every stored file.

## Changes
- Use `json.dumps` directly with `separators=(",", ":")` — eliminates all whitespace from the serialized JSON
