### PR TITLE
fix: prevent DoesNotExistError on unsaved documents during GST validation

### DIFF
--- a/india_compliance/gst_india/overrides/company.py
+++ b/india_compliance/gst_india/overrides/company.py
@@ -1,4 +1,5 @@
 import frappe
+from frappe import _
 from frappe.utils import flt
 from erpnext.setup.setup_wizard.operations.taxes_setup import (
     from_detailed_data,
@@ -64,6 +65,9 @@ def make_default_gst_expense_accounts(company):
 
 @frappe.whitelist()
 def make_default_tax_templates(company: str, gst_rate=None):
+    if not frappe.db.exists("Company", company):
+        frappe.throw(_("Please save the Company before creating tax templates."))
+
     frappe.has_permission("Company", ptype="write", doc=company, throw=True)
 
     default_taxes = get_tax_defaults(gst_rate)

--- a/india_compliance/gst_india/overrides/test_company.py
+++ b/india_compliance/gst_india/overrides/test_company.py
@@ -48,3 +48,15 @@ class TestCompanyFixtures(FrappeTestCase):
                         else gst_rate / 2
                     )
                     self.assertEqual(row["account_head"]["tax_rate"], expected_rate)
+
+    def test_make_default_tax_templates_unsaved_company(self):
+        """make_default_tax_templates should throw ValidationError for unsaved company."""
+        from india_compliance.gst_india.overrides.company import (
+            make_default_tax_templates,
+        )
+
+        self.assertRaises(
+            frappe.ValidationError,
+            make_default_tax_templates,
+            "new-company-abc-123",
+        )

--- a/india_compliance/gst_india/utils/__init__.py
+++ b/india_compliance/gst_india/utils/__init__.py
@@ -96,6 +96,10 @@ def get_gstin_list(party, party_type="Company"):
     """
     Returns a list the party's GSTINs.
     """
+    if not frappe.db.exists(party_type, party):
+        frappe.has_permission(party_type, throw=True)
+        return []
+
     frappe.has_permission(party_type, doc=party, throw=True)
 
     gstin_list = frappe.get_all(

--- a/india_compliance/gst_india/utils/test_utils.py
+++ b/india_compliance/gst_india/utils/test_utils.py
@@ -49,3 +49,11 @@ class TestUtils(FrappeTestCase):
 
             for i, expected_date in enumerate(expected_date_range):
                 self.assertEqual(expected_date, actual_date_range[i])
+
+    def test_get_gstin_list_with_unsaved_document(self):
+        """get_gstin_list should return empty list for unsaved documents."""
+        from india_compliance.gst_india.utils import get_gstin_list
+
+        frappe.set_user("Administrator")
+        result = get_gstin_list("new-supplier-xyz123", "Supplier")
+        self.assertEqual(result, [])


### PR DESCRIPTION
## Description

When a user creates a new, unsaved Supplier/Customer/Company and interacts with GST-related fields (e.g., adding a GSTIN), a `DoesNotExistError` is thrown, surfaced to the user as a **"Supplier/Customer Not Found"** (HTTP 404) error.

### Root Cause

`frappe.has_permission(doctype, doc=docname, throw=True)` internally calls `frappe.get_doc(doctype, docname)` when `doc` is a string (`frappe/permissions.py:127`). For unsaved records, the client passes a temporary name (e.g., `new-supplier-abc123`) which does not exist in the database, causing `frappe.DoesNotExistError` to be raised.

### Affected Functions

- `get_gstin_list` in `gst_india/utils/__init__.py`
- `make_default_tax_templates` in `gst_india/overrides/company.py`

### Changes

- **`get_gstin_list`**: Added `frappe.db.exists()` guard before `frappe.has_permission()`. For unsaved documents, validates doctype-level read permission and returns `[]` (unsaved docs cannot have GSTINs or linked addresses).
- **`make_default_tax_templates`**: Added `frappe.db.exists()` guard with a user-friendly `frappe.throw()` message asking to save the Company first, since tax templates require a persisted Company record.

### Steps to Reproduce (Before Fix)

1. Navigate to **Supplier > New**
2. Interact with any GSTIN-related field before saving
3. Observe `DoesNotExistError` / "Supplier Not Found" error in the UI

### Testing

- Added `test_get_gstin_list_with_unsaved_document` — confirms `[]` returned without exception
- Added `test_make_default_tax_templates_unsaved_company` — confirms `ValidationError` raised with user-friendly message

closes #[issue-number]