### PR TITLE
fix(UI): set doctype-specific position for is_reverse_charge

### DIFF
--- a/india_compliance/gst_india/constants/custom_fields.py
+++ b/india_compliance/gst_india/constants/custom_fields.py
@@ -480,14 +480,6 @@ CUSTOM_FIELDS = {
             "fetch_from": "",
         },
         {
-            "fieldname": "is_reverse_charge",
-            "label": "Is Reverse Charge",
-            "fieldtype": "Check",
-            "insert_after": "apply_tds",
-            "print_hide": 1,
-            "default": "0",
-        },
-        {
             "fieldname": "section_gst_breakup",
             "label": "GST Breakup",
             "fieldtype": "Section Break",
@@ -1412,8 +1404,11 @@ SALES_REVERSE_CHARGE_FIELDS = {
     "Sales Order": {**reverse_charge_field, "insert_after": "skip_delivery_note"},
     "Delivery Note": {**reverse_charge_field, "insert_after": "set_posting_time"},
     "Sales Invoice": {**reverse_charge_field, "insert_after": "is_debit_note"},
+    "Purchase Invoice": {**reverse_charge_field, "insert_after": "is_return"},
+    "Purchase Receipt": {**reverse_charge_field, "insert_after": "is_return"},
+    "Purchase Order": {**reverse_charge_field, "insert_after": "supplier_warehouse"},
+    "Supplier Quotation": {**reverse_charge_field, "insert_after": "has_unit_price_items"},
 }
-
 E_INVOICE_FIELDS = {
     "Sales Invoice": [
         {

--- a/india_compliance/gst_india/constants/custom_fields.py
+++ b/india_compliance/gst_india/constants/custom_fields.py
@@ -1404,11 +1404,15 @@ SALES_REVERSE_CHARGE_FIELDS = {
     "Sales Order": {**reverse_charge_field, "insert_after": "skip_delivery_note"},
     "Delivery Note": {**reverse_charge_field, "insert_after": "set_posting_time"},
     "Sales Invoice": {**reverse_charge_field, "insert_after": "is_debit_note"},
+}
+
+PURCHASE_REVERSE_CHARGE_FIELDS = {
     "Purchase Invoice": {**reverse_charge_field, "insert_after": "is_return"},
     "Purchase Receipt": {**reverse_charge_field, "insert_after": "is_return"},
     "Purchase Order": {**reverse_charge_field, "insert_after": "supplier_warehouse"},
     "Supplier Quotation": {**reverse_charge_field, "insert_after": "has_unit_price_items"},
 }
+
 E_INVOICE_FIELDS = {
     "Sales Invoice": [
         {

--- a/india_compliance/gst_india/setup/__init__.py
+++ b/india_compliance/gst_india/setup/__init__.py
@@ -13,6 +13,7 @@ from india_compliance.gst_india.constants.custom_fields import (
     EDUCATION_CUSTOM_FIELDS,
     HEALTHCARE_CUSTOM_FIELDS,
     HRMS_CUSTOM_FIELDS,
+    PURCHASE_REVERSE_CHARGE_FIELDS,
     SALES_REVERSE_CHARGE_FIELDS,
 )
 from india_compliance.gst_india.setup.property_setters import get_property_setters
@@ -328,6 +329,7 @@ def get_all_custom_fields():
     for custom_fields in (
         CUSTOM_FIELDS,
         SALES_REVERSE_CHARGE_FIELDS,
+        PURCHASE_REVERSE_CHARGE_FIELDS,
         E_INVOICE_FIELDS,
         E_WAYBILL_FIELDS,
     ):

--- a/india_compliance/patches.txt
+++ b/india_compliance/patches.txt
@@ -5,7 +5,7 @@ execute:from frappe.installer import add_module_defs; add_module_defs("india_com
 
 [post_model_sync]
 india_compliance.patches.v14.set_default_for_overridden_accounts_setting
-execute:from india_compliance.gst_india.setup import create_custom_fields; create_custom_fields() #71
+execute:from india_compliance.gst_india.setup import create_custom_fields; create_custom_fields() #72
 execute:from india_compliance.gst_india.setup import create_property_setters; create_property_setters() #11
 execute:from india_compliance.income_tax_india.setup import create_custom_fields; create_custom_fields() #5
 india_compliance.patches.post_install.remove_old_fields #2


### PR DESCRIPTION
## Issue
`is_reverse_charge` was placed incorrectly in the connections tab.

_Before_

<img width="1250" height="320" alt="Screenshot 2026-04-06 at 6 05 20 PM" src="https://github.com/user-attachments/assets/71e4359d-7e60-40c2-9501-13680c3b7db6" />

## Fix

Removed `is_reverse_charge` from the shared purchase tuple and moved it to `SALES_REVERSE_CHARGE_FIELDS` 

_After_

<img width="1247" height="599" alt="Screenshot 2026-04-06 at 6 33 42 PM" src="https://github.com/user-attachments/assets/c8d1c6ee-fd00-49d7-b487-25c0b046a9dc" />


Fixes: https://github.com/frappe/erpnext/issues/54092
