### PR TITLE
fix: conditional check for refund amount

### DIFF
--- a/india_compliance/gst_india/overrides/test_transaction.py
+++ b/india_compliance/gst_india/overrides/test_transaction.py
@@ -1029,6 +1029,25 @@ class TestTransaction(IntegrationTestCase):
             doc.save,
         )
 
+    @change_settings("GST Settings", {"enable_overseas_transactions": 1})
+    def test_validate_gst_refund_accounts_for_credit_note(self):
+        doc = create_refund_transaction()
+        doc.submit()
+
+        # Credit note should save successfully: signs are flipped, refund row is positive
+        return_doc = make_return_doc("Sales Invoice", doc.name)
+        return_doc.save()
+        self.assertGreater(return_doc.taxes[1].tax_amount, 0)
+
+        # Force refund row to become negative on the credit note and expect a
+        # validation error saying it should be positive
+        return_doc.taxes[1].rate = 18
+        self.assertRaisesRegex(
+            frappe.exceptions.ValidationError,
+            re.compile(r"^(.*Tax amount should be positive for GST Account.*)$"),
+            return_doc.save,
+        )
+
     def test_item_gst_details_for_non_gst_transactions(self):
         """
         Test Non-GST Transactions can be processed without errors.

--- a/india_compliance/gst_india/overrides/test_transaction.py
+++ b/india_compliance/gst_india/overrides/test_transaction.py
@@ -1093,17 +1093,22 @@ class TestTransaction(IntegrationTestCase):
 def create_refund_transaction():
     gst_settings = frappe.get_cached_doc("GST Settings")
 
-    gst_settings.append(
-        "gst_accounts",
-        {
-            "company": "_Test Indian Registered Company",
-            "cgst_account": "Output Tax CGST Refund - _TIRC",
-            "sgst_account": "Output Tax SGST Refund - _TIRC",
-            "igst_account": "Output Tax IGST Refund - _TIRC",
-            "account_type": "Output Refund",
-        },
+    refund_row_exists = any(
+        row.account_type == "Output Refund" and row.company == "_Test Indian Registered Company"
+        for row in gst_settings.gst_accounts
     )
-    gst_settings.save()
+    if not refund_row_exists:
+        gst_settings.append(
+            "gst_accounts",
+            {
+                "company": "_Test Indian Registered Company",
+                "cgst_account": "Output Tax CGST Refund - _TIRC",
+                "sgst_account": "Output Tax SGST Refund - _TIRC",
+                "igst_account": "Output Tax IGST Refund - _TIRC",
+                "account_type": "Output Refund",
+            },
+        )
+        gst_settings.save()
 
     transaction_details = {
         "doctype": "Sales Invoice",

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -1024,6 +1024,7 @@ def validate_gst_refund_accounts(doc):
     if doc.doctype not in SALES_DOCTYPES:
         return
 
+    is_return = doc.get("is_return", False)
     has_refund = False
     net_amount = 0
 
@@ -1032,11 +1033,15 @@ def validate_gst_refund_accounts(doc):
             net_amount += tax.base_tax_amount_after_discount_amount
             continue
 
-        # Validate if tax amount is negative
-        if tax.tax_amount > 0:
+        # Refund should be
+        # -ve for normal invoices and
+        # +ve for credit notes (is_return)
+        is_invalid = tax.tax_amount < 0 if is_return else tax.tax_amount > 0
+        if is_invalid:
+            expected = "positive" if is_return else "negative"
             frappe.throw(
-                _("Row #{0}: Tax amount should be negative for GST Account {1}").format(
-                    tax.idx, tax.account_head
+                _("Row #{0}: Tax amount should be {1} for GST Account {2}").format(
+                    tax.idx, expected, tax.account_head
                 )
             )
 


### PR DESCRIPTION
closes: #3731 

Traceback:

```
request.js:473 Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 120, in application
    response = frappe.api.handle(request)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/api/__init__.py", line 52, in handle
    data = endpoint(**arguments)
           ^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/api/v1.py", line 40, in handle_rpc_call
    return frappe.handler.handle()
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/handler.py", line 53, in handle
    data = execute_cmd(cmd)
           ^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/handler.py", line 86, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/__init__.py", line 1764, in call
    return fn(*args, **newargs)
           ^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/utils/typing_validations.py", line 32, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/desk/form/save.py", line 39, in savedocs
    doc.save()
  File "apps/frappe/frappe/model/document.py", line 378, in save
    return self._save(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 400, in _save
    return self.insert()
           ^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 309, in insert
    self.run_before_save_methods()
  File "apps/frappe/frappe/model/document.py", line 1140, in run_before_save_methods
    self.run_method("validate")
  File "apps/frappe/frappe/model/document.py", line 1011, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 1371, in composer
    return composed(self, method, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 1355, in runner
    add_to_return_value(self, f(self, method, *args, **kwargs))
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/india_compliance/india_compliance/gst_india/overrides/sales_invoice.py", line 62, in validate
    if validate_transaction(doc) is False:
       ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/india_compliance/india_compliance/gst_india/overrides/transaction.py", line 1789, in validate_transaction
    validate_gst_refund_accounts(doc)
  File "apps/india_compliance/india_compliance/gst_india/overrides/transaction.py", line 1180, in validate_gst_refund_accounts
    frappe.throw(
  File "apps/frappe/frappe/__init__.py", line 619, in throw
    msgprint(
  File "apps/frappe/frappe/__init__.py", line 584, in msgprint
    _raise_exception()
  File "apps/frappe/frappe/__init__.py", line 535, in _raise_exception
    raise exc
frappe.exceptions.ValidationError: Row #2: Tax amount should be negative for GST Account IGST Refund Receivable - RSSL
```