### PR TITLE
test: copy erpnext test utils as needed to avoid triggering creation

### DIFF
--- a/india_compliance/gst_india/doctype/bill_of_entry/test_bill_of_entry.py
+++ b/india_compliance/gst_india/doctype/bill_of_entry/test_bill_of_entry.py
@@ -25,7 +25,7 @@ IGNORE_TEST_RECORD_DEPENDENCIES = [
     "Bill of Entry",
     "Purchase Invoice",
     "Cost Center",
-    # "Tax Category",
+    "Tax Category",
     "Item",
     # "UOM",
     "Item Tax Template",

--- a/india_compliance/gst_india/doctype/bill_of_entry/test_bill_of_entry.py
+++ b/india_compliance/gst_india/doctype/bill_of_entry/test_bill_of_entry.py
@@ -3,7 +3,6 @@
 
 import json
 import re
-import unittest.mock as mock
 
 import frappe
 from frappe.tests import IntegrationTestCase
@@ -20,9 +19,7 @@ from india_compliance.gst_india.overrides.test_transaction import create_cess_ac
 from india_compliance.gst_india.utils import get_gst_accounts_by_type
 from india_compliance.gst_india.utils.itc_claim import format_period
 from india_compliance.gst_india.utils.tests import create_purchase_invoice
-
-with mock.patch("frappe.db"), mock.patch("frappe.new_doc"), mock.patch("frappe.get_doc"):
-    from erpnext.projects.doctype.project.test_project import make_project
+from india_compliance.tests.erpnext_test_utils import make_project
 
 IGNORE_TEST_RECORD_DEPENDENCIES = [
     "Bill of Entry",

--- a/india_compliance/gst_india/doctype/gst_hsn_code/test_gst_hsn_code.py
+++ b/india_compliance/gst_india/doctype/gst_hsn_code/test_gst_hsn_code.py
@@ -9,7 +9,7 @@ from india_compliance.gst_india.doctype.gst_hsn_code.gst_hsn_code import (
     update_taxes_in_item_master,
 )
 
-IGNORE_TEST_RECORD_DEPENDENCIES = ["Item Tax Template"]
+IGNORE_TEST_RECORD_DEPENDENCIES = ["Item Tax Template", "Tax Category"]
 
 
 class TestGSTHSNCode(IntegrationTestCase):

--- a/india_compliance/gst_india/overrides/test_purchase_invoice.py
+++ b/india_compliance/gst_india/overrides/test_purchase_invoice.py
@@ -1,5 +1,4 @@
 import re
-import unittest.mock as mock
 
 import frappe
 from frappe.tests import IntegrationTestCase, change_settings

--- a/india_compliance/gst_india/overrides/test_purchase_invoice.py
+++ b/india_compliance/gst_india/overrides/test_purchase_invoice.py
@@ -11,9 +11,7 @@ from india_compliance.gst_india.utils.itc_claim import (
     update_gstr3b_filing_status,
 )
 from india_compliance.gst_india.utils.tests import append_item, create_purchase_invoice
-
-with mock.patch("frappe.db"), mock.patch("frappe.new_doc"), mock.patch("frappe.get_doc"):
-    from erpnext.accounts.doctype.account.test_account import create_account
+from india_compliance.tests.erpnext_test_utils import create_account
 
 
 class TestPurchaseInvoice(IntegrationTestCase):

--- a/india_compliance/gst_india/overrides/test_subcontracting_transaction.py
+++ b/india_compliance/gst_india/overrides/test_subcontracting_transaction.py
@@ -6,25 +6,21 @@ from erpnext.controllers.subcontracting_controller import (
     get_materials_from_supplier,
     make_rm_stock_entry,
 )
+from erpnext.stock.doctype.purchase_receipt.purchase_receipt import (
+    make_stock_entry as make_se_from_pr,
+)
+from erpnext.stock.doctype.stock_entry.stock_entry import make_stock_in_entry
 from erpnext.subcontracting.doctype.subcontracting_order.subcontracting_order import (
     make_subcontracting_receipt,
 )
 from frappe.tests import IntegrationTestCase
 
-with mock.patch("frappe.db"), mock.patch("frappe.new_doc"), mock.patch("frappe.get_doc"):
-    from erpnext.controllers.tests.test_subcontracting_controller import get_rm_items
-    from erpnext.manufacturing.doctype.production_plan.test_production_plan import (
-        make_bom,
-    )
-    from erpnext.stock.doctype.purchase_receipt.purchase_receipt import (
-        make_stock_entry as make_se_from_pr,
-    )
-    from erpnext.stock.doctype.stock_entry.stock_entry import make_stock_in_entry
-    from erpnext.subcontracting.doctype.subcontracting_order.test_subcontracting_order import (
-        create_subcontracting_order,
-    )
-
 from india_compliance.gst_india.utils.tests import create_transaction
+from india_compliance.tests.erpnext_test_utils import (
+    create_subcontracting_order,
+    get_rm_items,
+    make_bom,
+)
 
 
 def make_raw_materials():

--- a/india_compliance/gst_india/overrides/test_subcontracting_transaction.py
+++ b/india_compliance/gst_india/overrides/test_subcontracting_transaction.py
@@ -1,5 +1,4 @@
 import re
-import unittest.mock as mock
 
 import frappe
 from erpnext.controllers.subcontracting_controller import (

--- a/india_compliance/gst_india/utils/itc_04/test_itc_04_export.py
+++ b/india_compliance/gst_india/utils/itc_04/test_itc_04_export.py
@@ -1,4 +1,3 @@
-from erpnext.buying.doctype.purchase_order.purchase_order import get_mapped_subcontracting_order
 from erpnext.subcontracting.doctype.subcontracting_order.subcontracting_order import (
     make_subcontracting_receipt,
 )

--- a/india_compliance/gst_india/utils/itc_04/test_itc_04_export.py
+++ b/india_compliance/gst_india/utils/itc_04/test_itc_04_export.py
@@ -1,18 +1,11 @@
 import unittest.mock as mock
 
+import frappe
+from erpnext.buying.doctype.purchase_order.purchase_order import get_mapped_subcontracting_order
 from erpnext.subcontracting.doctype.subcontracting_order.subcontracting_order import (
     make_subcontracting_receipt,
 )
 from frappe.tests import IntegrationTestCase
-
-with mock.patch("frappe.db"), mock.patch("frappe.new_doc"), mock.patch("frappe.get_doc"):
-    from erpnext.accounts.doctype.payment_reconciliation.test_payment_reconciliation import (
-        create_fiscal_year,
-    )
-    from erpnext.controllers.tests.test_subcontracting_controller import get_rm_items
-    from erpnext.subcontracting.doctype.subcontracting_order.test_subcontracting_order import (
-        create_subcontracting_order,
-    )
 
 from india_compliance.gst_india.overrides.test_subcontracting_transaction import (
     create_purchase_order,
@@ -20,6 +13,11 @@ from india_compliance.gst_india.overrides.test_subcontracting_transaction import
     make_stock_transfer_entry,
 )
 from india_compliance.gst_india.utils.itc_04.itc_04_export import download_itc_04_json
+from india_compliance.tests.erpnext_test_utils import (
+    create_fiscal_year,
+    create_subcontracting_order,
+    get_rm_items,
+)
 
 SERVICE_ITEM = {
     "item_code": "Subcontracted Service Item 1",

--- a/india_compliance/gst_india/utils/itc_04/test_itc_04_export.py
+++ b/india_compliance/gst_india/utils/itc_04/test_itc_04_export.py
@@ -1,6 +1,3 @@
-import unittest.mock as mock
-
-import frappe
 from erpnext.buying.doctype.purchase_order.purchase_order import get_mapped_subcontracting_order
 from erpnext.subcontracting.doctype.subcontracting_order.subcontracting_order import (
     make_subcontracting_receipt,

--- a/india_compliance/gst_india/utils/test_e_invoice_e_waybill_workflow.py
+++ b/india_compliance/gst_india/utils/test_e_invoice_e_waybill_workflow.py
@@ -2,7 +2,7 @@ import json
 from unittest.mock import patch
 
 import frappe
-from frappe.tests.test_api import FrappeAPITestCase
+from frappe.tests.test_api import FrappeAPITestCase, suppress_stdout
 
 from india_compliance.exceptions import (
     AlreadyGeneratedError,
@@ -139,10 +139,11 @@ class TestEInvoiceWorkflow(WorkflowTestBase):
         """
         sid = self.sid
         frappe.db.commit()  # nosemgrep
-        response = self.post(
-            self.method(E_INVOICE_API),
-            {"docname": docname, "throw": throw, "force": force, "sid": sid},
-        )
+        with suppress_stdout():
+            response = self.post(
+                self.method(E_INVOICE_API),
+                {"docname": docname, "throw": throw, "force": force, "sid": sid},
+            )
         frappe.db.rollback()  # Fresh transaction to see WSGI-committed changes
         return response
 
@@ -351,7 +352,8 @@ class TestEWaybillWorkflow(WorkflowTestBase):
         data = {"doctype": doctype, "docname": docname, "force": force, "sid": sid}
         if values is not None:
             data["values"] = frappe.as_json(values)
-        response = self.post(self.method(E_WAYBILL_API), data)
+        with suppress_stdout():
+            response = self.post(self.method(E_WAYBILL_API), data)
         frappe.db.rollback()
         return response
 

--- a/india_compliance/tests/erpnext_test_utils.py
+++ b/india_compliance/tests/erpnext_test_utils.py
@@ -134,9 +134,7 @@ def get_rm_items(supplied_items):
     return rm_items
 
 
-# from erpnext.manufacturing.doctype.production_plan.test_production_plan import (
-#     make_bom,
-# )
+# from erpnext.manufacturing.doctype.production_plan.test_production_plan import make_bom
 def make_bom(**args):
     args = frappe._dict(args)
 
@@ -201,9 +199,7 @@ def make_bom(**args):
     return bom
 
 
-# from erpnext.subcontracting.doctype.subcontracting_order.test_subcontracting_order import (
-#     create_subcontracting_order,
-# )
+# from erpnext.subcontracting.doctype.subcontracting_order.test_subcontracting_order import create_subcontracting_order
 def create_subcontracting_order(**args):
     args = frappe._dict(args)
     sco = get_mapped_subcontracting_order(source_name=args.po_name)
@@ -243,7 +239,7 @@ def create_subcontracting_order(**args):
     return sco
 
 
-# from erpnext.accounts.doctype.payment_reconciliation.test_payment_reconciliation import (create_fiscal_year)
+# from erpnext.accounts.doctype.payment_reconciliation.test_payment_reconciliation import create_fiscal_year
 def create_fiscal_year(company, year_start_date, year_end_date):
     fy_docname = frappe.db.exists(
         "Fiscal Year", {"year_start_date": year_start_date, "year_end_date": year_end_date}

--- a/india_compliance/tests/erpnext_test_utils.py
+++ b/india_compliance/tests/erpnext_test_utils.py
@@ -224,9 +224,9 @@ def create_subcontracting_order(**args):
             warehouses = []
             for item in po.items:
                 warehouses.append(item.warehouse)
-            else:
-                for idx, val in enumerate(sco.items):
-                    val.warehouse = warehouses[idx]
+
+            for idx, val in enumerate(sco.items):
+                val.warehouse = warehouses[idx]
 
     warehouses = set()
     for item in sco.items:

--- a/india_compliance/tests/erpnext_test_utils.py
+++ b/india_compliance/tests/erpnext_test_utils.py
@@ -1,0 +1,267 @@
+import frappe
+from erpnext.buying.doctype.purchase_order.purchase_order import get_mapped_subcontracting_order
+from frappe.utils import getdate, nowdate
+
+
+# from erpnext.projects.doctype.project.test_project import make_project
+def create_task(
+    subject,
+    start=None,
+    end=None,
+    depends_on=None,
+    project=None,
+    parent_task=None,
+    is_group=0,
+    is_template=0,
+    begin=0,
+    duration=0,
+    save=True,
+    priority=None,
+):
+    if not frappe.db.exists("Task", subject):
+        task = frappe.new_doc("Task")
+        task.status = "Open"
+        task.subject = subject
+        task.exp_start_date = start or nowdate()
+        task.exp_end_date = end or nowdate()
+        task.project = (
+            project or None if is_template else frappe.get_value("Project", {"project_name": "_Test Project"})
+        )
+        task.is_template = is_template
+        task.start = begin
+        task.duration = duration
+        task.is_group = is_group
+        task.parent_task = parent_task
+        task.priority = priority
+        if save:
+            task.save()
+    else:
+        task = frappe.get_doc("Task", subject)
+
+    if depends_on:
+        task.append("depends_on", {"task": depends_on})
+        if save:
+            task.save()
+    return task
+
+
+def make_project_template(project_template_name, project_tasks=None):
+    if project_tasks is None:
+        project_tasks = []
+    if not frappe.db.exists("Project Template", project_template_name):
+        project_tasks = project_tasks or [
+            create_task(subject="_Test Template Task 1", is_template=1, begin=0, duration=3),
+            create_task(subject="_Test Template Task 2", is_template=1, begin=0, duration=2),
+        ]
+        doc = frappe.get_doc(doctype="Project Template", name=project_template_name)
+        for task in project_tasks:
+            doc.append("tasks", {"task": task.name})
+        doc.insert()
+
+    return frappe.get_doc("Project Template", project_template_name)
+
+
+def make_project(args):
+    args = frappe._dict(args)
+
+    if args.project_name and frappe.db.exists("Project", {"project_name": args.project_name}):
+        return frappe.get_doc("Project", {"project_name": args.project_name})
+
+    project = frappe.get_doc(
+        doctype="Project",
+        project_name=args.project_name,
+        status="Open",
+        expected_start_date=args.start_date,
+        company=args.company or "_Test Company",
+    )
+
+    if args.project_template_name:
+        template = make_project_template(args.project_template_name)
+        project.project_template = template.name
+
+    project.insert()
+
+    return project
+
+
+# from erpnext.accounts.doctype.account.test_account import create_account
+def create_account(**kwargs):
+    account = frappe.db.get_value(
+        "Account", filters={"account_name": kwargs.get("account_name"), "company": kwargs.get("company")}
+    )
+    if account:
+        account = frappe.get_doc("Account", account)
+        account.update(
+            dict(
+                is_group=kwargs.get("is_group", 0),
+                parent_account=kwargs.get("parent_account"),
+            )
+        )
+        account.save()
+        return account.name
+    else:
+        account = frappe.get_doc(
+            doctype="Account",
+            is_group=kwargs.get("is_group", 0),
+            account_name=kwargs.get("account_name"),
+            account_type=kwargs.get("account_type"),
+            parent_account=kwargs.get("parent_account"),
+            company=kwargs.get("company"),
+            account_currency=kwargs.get("account_currency"),
+        )
+
+        account.save()
+        return account.name
+
+
+# from erpnext.controllers.tests.test_subcontracting_controller import get_rm_items
+def get_rm_items(supplied_items):
+    rm_items = []
+
+    for item in supplied_items:
+        rm_items.append(
+            {
+                "main_item_code": item.main_item_code,
+                "item_code": item.rm_item_code,
+                "qty": item.required_qty,
+                "rate": item.rate,
+                "stock_uom": item.stock_uom,
+                "warehouse": item.reserve_warehouse,
+                "use_serial_batch_fields": 0,
+            }
+        )
+
+    return rm_items
+
+
+# from erpnext.manufacturing.doctype.production_plan.test_production_plan import (
+#     make_bom,
+# )
+def make_bom(**args):
+    args = frappe._dict(args)
+
+    bom = frappe.get_doc(
+        {
+            "doctype": "BOM",
+            "is_default": 1,
+            "item": args.item,
+            "currency": args.currency or "USD",
+            "quantity": args.quantity or 1,
+            "company": args.company or "_Test Company",
+            "routing": args.routing,
+            "with_operations": args.with_operations or 0,
+            "process_loss_percentage": args.process_loss_percentage or 0,
+        }
+    )
+
+    if args.operating_cost_per_bom_quantity:
+        bom.fg_based_operating_cost = 1
+        bom.operating_cost_per_bom_quantity = args.operating_cost_per_bom_quantity
+
+    for item in args.raw_materials:
+        item_doc = frappe.get_doc("Item", item)
+        bom.append(
+            "items",
+            {
+                "item_code": item,
+                "qty": args.rm_qty or 1.0,
+                "uom": item_doc.stock_uom,
+                "stock_uom": item_doc.stock_uom,
+                "rate": item_doc.valuation_rate or args.rate,
+                "source_warehouse": args.source_warehouse,
+            },
+        )
+
+    if args.scrap_items:
+        for item in args.scrap_items:
+            item_doc = frappe.get_doc("Item", item)
+            bom.append(
+                "secondary_items",
+                {
+                    "type": "Scrap",
+                    "item_code": item,
+                    "item_name": item,
+                    "uom": item_doc.stock_uom,
+                    "stock_uom": item_doc.stock_uom,
+                    "qty": args.scrap_qty or 1,
+                    "cost_allocation_per": args.scrap_cost_allocation_per or 10,
+                    "process_loss_per": args.scrap_process_loss_per or 10,
+                },
+            )
+
+    if not args.do_not_save:
+        bom.insert(ignore_permissions=True)
+
+        if not args.do_not_submit:
+            bom.submit()
+
+    if args.set_as_default_bom and not args.do_not_save and not args.do_not_submit:
+        frappe.set_value("Item", args.item, "default_bom", bom.name)
+
+    return bom
+
+
+# from erpnext.subcontracting.doctype.subcontracting_order.test_subcontracting_order import (
+#     create_subcontracting_order,
+# )
+def create_subcontracting_order(**args):
+    args = frappe._dict(args)
+    sco = get_mapped_subcontracting_order(source_name=args.po_name)
+
+    for item in sco.items:
+        item.include_exploded_items = args.get("include_exploded_items", 1)
+
+    if args.warehouse:
+        for item in sco.items:
+            item.warehouse = args.warehouse
+    else:
+        warehouse = frappe.get_value("Purchase Order", args.po_name, "set_warehouse")
+        if warehouse:
+            for item in sco.items:
+                item.warehouse = warehouse
+        else:
+            po = frappe.get_doc("Purchase Order", args.po_name)
+            warehouses = []
+            for item in po.items:
+                warehouses.append(item.warehouse)
+            else:
+                for idx, val in enumerate(sco.items):
+                    val.warehouse = warehouses[idx]
+
+    warehouses = set()
+    for item in sco.items:
+        warehouses.add(item.warehouse)
+
+    if len(warehouses) == 1:
+        sco.set_warehouse = next(iter(warehouses))
+
+    if not args.do_not_save:
+        sco.insert()
+        if not args.do_not_submit:
+            sco.submit()
+
+    return sco
+
+
+# from erpnext.accounts.doctype.payment_reconciliation.test_payment_reconciliation import (create_fiscal_year)
+def create_fiscal_year(company, year_start_date, year_end_date):
+    fy_docname = frappe.db.exists(
+        "Fiscal Year", {"year_start_date": year_start_date, "year_end_date": year_end_date}
+    )
+    if not fy_docname:
+        fy_doc = frappe.get_doc(
+            {
+                "doctype": "Fiscal Year",
+                "year": f"{getdate(year_start_date).year}-{getdate(year_end_date).year}",
+                "year_start_date": year_start_date,
+                "year_end_date": year_end_date,
+                "companies": [{"company": company}],
+            }
+        ).save()
+        return fy_doc
+    else:
+        fy_doc = frappe.get_doc("Fiscal Year", fy_docname)
+        if not frappe.db.exists("Fiscal Year Company", {"parent": fy_docname, "company": company}):
+            fy_doc.append("companies", {"company": company})
+            fy_doc.save()
+        return fy_doc


### PR DESCRIPTION
## Issue

Although tests passed on the server, it was difficult to execute them locally as ERPNext utils couldn't be imported correctly.

## Fix

Moved ERPNext utils as used in India Compliance tests to the app to remove test dependence on ERPNext