### PR TITLE
feat(gstr-9): automated books data engine, portal comparison, and Excel export

### DIFF
--- a/india_compliance/gst_india/api_classes/taxpayer_returns.py
+++ b/india_compliance/gst_india/api_classes/taxpayer_returns.py
@@ -30,6 +30,7 @@ class ReturnsAPI(TaxpayerBaseAPI):
         # "IMS2B007": "not_applicable", # Either the entered ITC period is incorrect or it has 3B filed
         "IMS2005": "not_needed",  # 2B cannot be generated as there are no changes
         # "IMSSAV0015": # Previous Save or Reset request is already under progress. Please try after some time.
+        "RT-9AG-1013": "authorization_failed",  # Unauthorized User for GSTR-9
     }
 
     def download_files(self, return_period, token):
@@ -401,19 +402,11 @@ class GSTR9API(ReturnsAPI):
         super().setup(company_gstin=company_gstin)
 
     def get_data(self, otp=None):
-        url = self.get_url(self.END_POINT)
-        params = {"action": "CALRCDS", "gstin": self.company_gstin, "ret_period": self.return_period}
-
-        print(f"GSTR-9 API Request: URL={url} | Params={params}")
-
-        response = self.get(
+        return self.get(
             action="CALRCDS",
+            return_type="GSTR9",
             return_period=self.return_period,
             params={"gstin": self.company_gstin, "ret_period": self.return_period},
             endpoint=self.END_POINT,
             otp=otp,
         )
-
-        print(f"GSTR-9 API Response: {response}")
-
-        return response

--- a/india_compliance/gst_india/api_classes/taxpayer_returns.py
+++ b/india_compliance/gst_india/api_classes/taxpayer_returns.py
@@ -390,3 +390,30 @@ class IMSAPI(ReturnsAPI):
             endpoint=self.END_POINT,
             params={"gstin": self.company_gstin, "int_tran_id": transaction_id},
         )
+
+
+class GSTR9API(ReturnsAPI):
+    API_NAME = "GSTR-9"
+    END_POINT = "returns/gstr9"
+
+    def setup(self, company_gstin, return_period):
+        self.return_period = return_period
+        super().setup(company_gstin=company_gstin)
+
+    def get_data(self, otp=None):
+        url = self.get_url(self.END_POINT)
+        params = {"action": "CALRCDS", "gstin": self.company_gstin, "ret_period": self.return_period}
+
+        print(f"GSTR-9 API Request: URL={url} | Params={params}")
+
+        response = self.get(
+            action="CALRCDS",
+            return_period=self.return_period,
+            params={"gstin": self.company_gstin, "ret_period": self.return_period},
+            endpoint=self.END_POINT,
+            otp=otp,
+        )
+
+        print(f"GSTR-9 API Response: {response}")
+
+        return response

--- a/india_compliance/gst_india/doctype/gst_return_log/generate_gstr_9.py
+++ b/india_compliance/gst_india/doctype/gst_return_log/generate_gstr_9.py
@@ -74,8 +74,10 @@ class SummarizeGSTR9:
 
 class GenerateGSTR9(SummarizeGSTR9):
     """
-    Mixin for GSTReturnLog that handles GSTR-9 data generation,
-    auto-computation, optional portal download, and comparison.
+    Mixin for GSTReturnLog: GSTR-9 data generation and portal comparison.
+
+    Handles data generation, auto-computation, optional portal download,
+    and books-vs-portal reconciliation.
     """
 
     def get_gstr9_data(self):
@@ -130,9 +132,7 @@ class GenerateGSTR9(SummarizeGSTR9):
                     compute_auto_rows(row_data)
                     compute_auto_rows(portal_data)
                     data["portal"] = portal_data
-                    data["comparison"] = self._compare_books_and_portal(
-                        row_data, portal_data
-                    )
+                    data["comparison"] = self._compare_books_and_portal(row_data, portal_data)
             except Exception:
                 frappe.log_error(
                     title="GSTR-9 Portal Data Download Failed",
@@ -202,9 +202,7 @@ class GenerateGSTR9(SummarizeGSTR9):
             has_diff = False
 
             for field in AMOUNT_FIELDS:
-                diff[field] = flt(books_row.get(field, 0), 2) - flt(
-                    portal_row.get(field, 0), 2
-                )
+                diff[field] = flt(books_row.get(field, 0), 2) - flt(portal_row.get(field, 0), 2)
                 if diff[field] != 0:
                     has_diff = True
 

--- a/india_compliance/gst_india/doctype/gst_return_log/generate_gstr_9.py
+++ b/india_compliance/gst_india/doctype/gst_return_log/generate_gstr_9.py
@@ -1,0 +1,233 @@
+# Copyright (c) 2026, Resilient Tech and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe.utils import flt
+
+from india_compliance.gst_india.utils.gstr_9 import (
+    AMOUNT_FIELDS,
+    GSTR9_ROW_DESCRIPTION,
+    PORTAL_SOURCED_ROWS,
+    GSTR9_Row,
+    _empty_row,
+    aggregate_books,
+    compute_auto_rows,
+)
+
+
+class SummarizeGSTR9:
+    """Builds a summary list from GSTR-9 row data for frontend display."""
+
+    def get_summarized_data(self, data):
+        summary = []
+
+        for row_key, description in GSTR9_ROW_DESCRIPTION.items():
+            row_data = data.get(row_key, _empty_row())
+
+            if row_key in (GSTR9_Row.TABLE_9, GSTR9_Row.TABLE_14, GSTR9_Row.TABLE_15):
+                summary.append(
+                    {
+                        "row_key": row_key,
+                        "description": description,
+                        "rows": row_data if isinstance(row_data, list) else [],
+                    }
+                )
+                continue
+
+            if row_key in (GSTR9_Row.TABLE_17, GSTR9_Row.TABLE_18):
+                summary.append(self._hsn_summary_row(row_key, description, row_data))
+                continue
+
+            entry = {
+                "row_key": row_key,
+                "description": description,
+            }
+
+            for field in AMOUNT_FIELDS:
+                entry[field] = flt(row_data.get(field, 0), 2)
+
+            summary.append(entry)
+
+        return summary
+
+    def _hsn_summary_row(self, row_key, description, items):
+        """Aggregate HSN item list into a summary row with Goods/Services split."""
+        totals = _empty_row()
+
+        goods_list = (items or {}).get("goods") or []
+        services_list = (items or {}).get("services") or []
+        all_items = goods_list + services_list
+
+        for item in all_items:
+            for field in AMOUNT_FIELDS:
+                totals[field] += flt(item.get(field, 0))
+
+        return {
+            "row_key": row_key,
+            "description": description,
+            "no_of_records": len(all_items),
+            "goods": goods_list,
+            "services": services_list,
+            **{f: flt(totals[f], 2) for f in AMOUNT_FIELDS},
+        }
+
+
+class GenerateGSTR9(SummarizeGSTR9):
+    """
+    Mixin for GSTReturnLog that handles GSTR-9 data generation,
+    auto-computation, optional portal download, and comparison.
+    """
+
+    def get_gstr9_data(self):
+        """Load already-generated GSTR-9 data from attachments."""
+        books_summary = self.get_json_for("books_summary")
+        if not books_summary:
+            return
+
+        data = {"books_summary": books_summary}
+
+        if portal_summary := self.get_json_for("unfiled_summary"):
+            data["portal_summary"] = portal_summary
+
+        if comparison := self.get_json_for("reconcile"):
+            data["comparison"] = comparison
+
+        data["status"] = self.filing_status or "Not Filed"
+        self.update_status("Generated")
+        return data
+
+    def generate_gstr9_data(self, filters, callback=None):
+        """
+        Generate GSTR-9 Data.
+
+        Steps:
+        1. Compute books data (invoice-level with classification)
+        2. Aggregate invoices → row-level amounts
+        3. Compute auto-calculated sub-totals
+        4. Summarize and save
+        5. Optionally fetch portal data and compare
+        """
+        data = {}
+
+        books = self._get_gstr9_books_data(filters)
+
+        # Aggregate invoice lists → row-level amount dicts for auto-compute
+        row_data = aggregate_books(books)
+        compute_auto_rows(row_data)
+        data["row_data"] = row_data
+
+        # Check if portal APIs are enabled
+        settings = frappe.get_cached_doc("GST Settings")
+
+        if settings.is_gstr9_api_enabled(self.gstin, warn_for_missing_credentials=True):
+            try:
+                portal_data = self._get_gstr9_portal_data(filters)
+                if portal_data:
+                    for row_key in PORTAL_SOURCED_ROWS:
+                        if row_key in portal_data:
+                            row_data[row_key] = portal_data[row_key]
+
+                    compute_auto_rows(row_data)
+                    compute_auto_rows(portal_data)
+                    data["portal"] = portal_data
+                    data["comparison"] = self._compare_books_and_portal(
+                        row_data, portal_data
+                    )
+            except Exception:
+                frappe.log_error(
+                    title="GSTR-9 Portal Data Download Failed",
+                    message=frappe.get_traceback(),
+                )
+
+        # Summarize and strip raw data from response
+        self._summarize_gstr9_data(data)
+        data.pop("row_data", None)
+        data.pop("portal", None)
+        data["status"] = self.filing_status or "Not Filed"
+
+        return callback and callback(filters)
+
+    def _get_gstr9_books_data(self, filters):
+        """Compute or load cached invoice-level books data."""
+        if self.is_latest_data and self.get("books"):
+            books = self.get_json_for("books")
+            if books:
+                return books
+
+        from india_compliance.gst_india.utils.gstr_9.gstr_9_data import GSTR9BooksData
+
+        books = GSTR9BooksData(filters).get_data()
+        self.update_json_for("books", books, reset_reconcile=True)
+        return books
+
+    def _get_gstr9_portal_data(self, filters):
+        """Download or load cached portal auto-drafted data."""
+        if self.is_latest_data and self.get("unfiled"):
+            portal_data = self.get_json_for("unfiled")
+            if portal_data:
+                return portal_data
+
+        from india_compliance.gst_india.utils.gstr_9.gstr_9_download import (
+            download_gstr9_data,
+        )
+
+        portal_data = download_gstr9_data(self, filters)
+        if portal_data:
+            self.update_json_for("unfiled", portal_data)
+
+        return portal_data
+
+    def _compare_books_and_portal(self, books_data, portal_data):
+        """Compare books data with portal data row by row."""
+        comparison = {}
+
+        all_rows = set(books_data.keys()) | set(portal_data.keys())
+
+        for row_key in all_rows:
+            # Skip HSN detail lists, nested-list rows, and metadata keys
+            if row_key in (
+                GSTR9_Row.TABLE_9,
+                GSTR9_Row.TABLE_14,
+                GSTR9_Row.TABLE_15,
+                GSTR9_Row.TABLE_17,
+                GSTR9_Row.TABLE_18,
+                "creation",
+            ):
+                continue
+
+            books_row = books_data.get(row_key, _empty_row())
+            portal_row = portal_data.get(row_key, _empty_row())
+
+            diff = _empty_row()
+            has_diff = False
+
+            for field in AMOUNT_FIELDS:
+                diff[field] = flt(books_row.get(field, 0), 2) - flt(
+                    portal_row.get(field, 0), 2
+                )
+                if diff[field] != 0:
+                    has_diff = True
+
+            if has_diff:
+                comparison[row_key] = {
+                    "books": books_row,
+                    "portal": portal_row,
+                    "difference": diff,
+                }
+
+        if comparison:
+            self.update_json_for("reconcile", comparison)
+
+        return comparison
+
+    def _summarize_gstr9_data(self, data):
+        """Summarize aggregated row data (and optionally portal) for frontend."""
+        if row_data := data.get("row_data"):
+            summary = self.get_summarized_data(row_data)
+            self.update_json_for("books_summary", summary)
+            data["books_summary"] = summary
+
+        if portal := data.get("portal"):
+            summary = self.get_summarized_data(portal)
+            self.update_json_for("unfiled_summary", summary)
+            data["portal_summary"] = summary

--- a/india_compliance/gst_india/doctype/gst_return_log/generate_gstr_9.py
+++ b/india_compliance/gst_india/doctype/gst_return_log/generate_gstr_9.py
@@ -73,8 +73,7 @@ class SummarizeGSTR9:
 
 
 class GenerateGSTR9(SummarizeGSTR9):
-    """
-    Mixin for GSTReturnLog: GSTR-9 data generation and portal comparison.
+    """Mixin for GSTReturnLog: GSTR-9 data generation and portal comparison.
 
     Handles data generation, auto-computation, optional portal download,
     and books-vs-portal reconciliation.

--- a/india_compliance/gst_india/doctype/gst_return_log/gst_return_log.json
+++ b/india_compliance/gst_india/doctype/gst_return_log/gst_return_log.json
@@ -173,7 +173,7 @@
   {
    "fieldname": "reconcile",
    "fieldtype": "Attach",
-   "label": "Reconcile GSTR-1",
+   "label": "Reconcile",
    "read_only": 1
   },
   {
@@ -239,7 +239,7 @@
    "link_fieldname": "reference_docname"
   }
  ],
- "modified": "2025-01-11 08:19:45.848389",
+ "modified": "2026-04-06 16:19:17.645684",
  "modified_by": "Administrator",
  "module": "GST India",
  "name": "GST Return Log",

--- a/india_compliance/gst_india/doctype/gst_return_log/gst_return_log.py
+++ b/india_compliance/gst_india/doctype/gst_return_log/gst_return_log.py
@@ -20,12 +20,15 @@ from india_compliance.gst_india.doctype.gst_return_log.generate_gstr_1 import (
     FileGSTR1,
     GenerateGSTR1,
 )
+from india_compliance.gst_india.doctype.gst_return_log.generate_gstr_9 import (
+    GenerateGSTR9,
+)
 from india_compliance.gst_india.utils import get_party_for_gstin
 
 DOCTYPE = "GST Return Log"
 
 
-class GSTReturnLog(GenerateGSTR1, FileGSTR1, Document):
+class GSTReturnLog(GenerateGSTR9, GenerateGSTR1, FileGSTR1, Document):
     @property
     def status(self):
         return self.generation_status

--- a/india_compliance/gst_india/doctype/gst_settings/gst_settings.json
+++ b/india_compliance/gst_india/doctype/gst_settings/gst_settings.json
@@ -58,6 +58,8 @@
   "column_break_cxmn",
   "restrict_changes_after_gstr_1",
   "role_allowed_to_modify",
+  "gstr_9_section_break",
+  "enable_gstr_9_api",
   "other_apis_section",
   "autofill_party_info",
   "archive_party_info_days",
@@ -670,7 +672,7 @@
   {
    "default": "1",
    "depends_on": "eval: india_compliance.is_api_enabled(doc) && doc.enable_gstr_1_api",
-   "description": "Use API to compare records with GST Portal Before Filing.",
+   "description": "Use API to compare records with GST Portal Before Filing",
    "fieldname": "compare_unfiled_data",
    "fieldtype": "Check",
    "label": "Compare Data with GST Portal Before Filing"
@@ -682,6 +684,19 @@
    "fieldname": "enable_gstr_1_api",
    "fieldtype": "Check",
    "label": "Enable GSTR-1 API Features"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval: india_compliance.is_api_enabled(doc)",
+   "description": "Use APIs to compare records with GST Portal and File GST Returns",
+   "fieldname": "enable_gstr_9_api",
+   "fieldtype": "Check",
+   "label": "Enable GSTR-9 API Features"
+  },
+  {
+   "fieldname": "gstr_9_section_break",
+   "fieldtype": "Section Break",
+   "label": "GSTR-9"
   },
   {
    "default": "0",

--- a/india_compliance/gst_india/doctype/gst_settings/gst_settings.py
+++ b/india_compliance/gst_india/doctype/gst_settings/gst_settings.py
@@ -373,6 +373,32 @@ class GSTSettings(Document):
 
         return True
 
+    # GSTR 9 UTILITY
+    def is_gstr9_api_enabled(self, gstin, warn_for_missing_credentials=False):
+        if not is_production_api_enabled(self):
+            return False
+
+        if not self.enable_gstr_9_api:
+            return False
+
+        if not self.has_valid_credentials(gstin, "Returns"):
+            if warn_for_missing_credentials:
+                frappe.publish_realtime(
+                    "show_missing_gst_credentials_message",
+                    dict(
+                        message=_(
+                            "Credentials are missing for GSTIN {0} for service"
+                            " Returns in GST Settings"
+                        ).format(gstin),
+                        title=_("Missing Credentials"),
+                    ),
+                    user=frappe.session.user,
+                )
+
+            return False
+
+        return True
+
 
 @frappe.whitelist()
 def disable_api_promo():

--- a/india_compliance/gst_india/doctype/gst_settings/gst_settings.py
+++ b/india_compliance/gst_india/doctype/gst_settings/gst_settings.py
@@ -387,8 +387,7 @@ class GSTSettings(Document):
                     "show_missing_gst_credentials_message",
                     dict(
                         message=_(
-                            "Credentials are missing for GSTIN {0} for service"
-                            " Returns in GST Settings"
+                            "Credentials are missing for GSTIN {0} for service Returns in GST Settings"
                         ).format(gstin),
                         title=_("Missing Credentials"),
                     ),

--- a/india_compliance/gst_india/doctype/gstr_9/gstr_9.css
+++ b/india_compliance/gst_india/doctype/gstr_9/gstr_9.css
@@ -1,0 +1,139 @@
+/* GSTR-9 Form Styles */
+
+div[data-page-route="GSTR-9"] [data-fieldname="tabs_html"] .section-body {
+    margin-top: 0;
+}
+
+div[data-page-route="GSTR-9"] .section-body {
+    max-width: 100% !important;
+}
+
+div[data-page-route="GSTR-9"] [data-fieldname="tabs_html"] .form-tabs-list {
+    margin-top: var(--margin-sm);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding-right: var(--padding-lg);
+    position: inherit;
+}
+
+div[data-page-route="GSTR-9"] [data-fieldname="tabs_empty_state"],
+div[data-page-route="GSTR-9"] [data-fieldname="tabs_no_data"] {
+    min-height: 320px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-direction: column;
+}
+
+div[data-page-route="GSTR-9"] [data-fieldname="tabs_empty_state"] > img,
+div[data-page-route="GSTR-9"] [data-fieldname="tabs_no_data"] > img {
+    margin-bottom: var(--margin-md);
+    max-height: 100px;
+}
+
+div[data-page-route="GSTR-9"] .frappe-control [data-fieldtype="HTML"] {
+    margin-left: -11px;
+    margin-right: -15px;
+}
+
+/* Section headers */
+.gstr9-section {
+    margin-bottom: var(--margin-lg);
+}
+
+.gstr9-section-title {
+    font-size: var(--text-base);
+    font-weight: 600;
+    padding: var(--padding-sm) var(--padding-md);
+    margin-bottom: 0;
+    background-color: var(--bg-light-gray);
+    border: 1px solid var(--border-color);
+    border-bottom: none;
+    border-radius: var(--border-radius) var(--border-radius) 0 0;
+}
+
+/* HSN Part A / Part B sub-heading */
+.gstr9-hsn-subtitle {
+    font-size: var(--text-sm);
+    font-weight: 600;
+    padding: var(--padding-xs) var(--padding-md);
+    margin: var(--margin-sm) 0 0 0;
+    color: var(--text-muted);
+    border-left: 3px solid var(--primary);
+}
+
+/* Table styling */
+.gstr9-table {
+    font-size: var(--text-sm);
+    margin-bottom: 0;
+}
+
+.gstr9-table thead th {
+    background-color: var(--subtle-fg);
+    white-space: nowrap;
+    font-weight: 600;
+    vertical-align: middle;
+}
+
+.gstr9-table td,
+.gstr9-table th {
+    padding: 6px 10px;
+    vertical-align: middle;
+}
+
+.gstr9-col-sno {
+    width: 60px;
+    min-width: 60px;
+    font-weight: 600;
+}
+
+.gstr9-col-desc {
+    min-width: 300px;
+}
+
+.gstr9-col-source {
+    width: 80px;
+    min-width: 80px;
+    text-align: center;
+}
+
+/* Auto-computed rows (sub-totals, totals) */
+.gstr9-row-auto {
+    background-color: var(--subtle-accent);
+    font-weight: 600;
+}
+
+.gstr9-row-auto td {
+    font-weight: 600;
+}
+
+/* Portal-sourced rows */
+.gstr9-row-portal {
+    background-color: var(--bg-light-gray);
+}
+
+/* Comparison tab styling */
+.gstr9-comparison-books td {
+    background-color: var(--subtle-accent);
+}
+
+.gstr9-comparison-portal td {
+    background-color: var(--subtle-accent);
+}
+
+.gstr9-comparison-diff td {
+    background-color: var(--bg-light-gray);
+}
+
+/* Badge styling */
+.gstr9-table .badge {
+    font-size: 0.7em;
+    vertical-align: middle;
+    margin-left: 4px;
+}
+
+/* Disabled/N-A cells — white background, no content */
+.gstr9-table td.gstr9-cell-disabled {
+    background-color: var(--bg-light-gray);
+}

--- a/india_compliance/gst_india/doctype/gstr_9/gstr_9.js
+++ b/india_compliance/gst_india/doctype/gstr_9/gstr_9.js
@@ -1224,6 +1224,17 @@ class GSTR9 {
             return;
         }
 
+        if (result && result.too_large) {
+            frappe.msgprint({
+                title: __("Large Dataset — Export Required"),
+                message: __(
+                    "The books data file is too large to display inline. Use the Export Books as Excel button to download all invoices.",
+                ),
+                indicator: "orange",
+            });
+            return;
+        }
+
         this._show_detail_dialog(
             row_key,
             description,
@@ -1255,51 +1266,56 @@ class GSTR9 {
         const doc_label = is_purchase ? __("Bill No.") : __("Invoice No.");
         const class_label = is_purchase ? __("Classification") : __("Type");
 
-        const totals = { taxable_value: 0, igst: 0, cgst: 0, sgst: 0, cess: 0 };
+        const totals = {
+            total_taxable_value: 0,
+            total_igst_amount: 0,
+            total_cgst_amount: 0,
+            total_sgst_amount: 0,
+            total_cess_amount: 0,
+        };
+
+        const party_gstin_field = is_purchase ? "supplier_gstin" : "customer_gstin";
+        const party_name_field = is_purchase ? "supplier_name" : "customer_name";
 
         const rows = data.map(row => {
-            let type_label;
-            if (is_purchase) {
-                type_label = row.itc_classification || row.gst_category || "";
-            } else if (row.is_return) {
-                type_label = __("Credit Note");
-            } else if (row.is_debit_note) {
-                type_label = __("Debit Note");
-            } else {
-                type_label = __(row.gst_category || "Invoice");
-            }
-
-            for (const f of ["taxable_value", "igst", "cgst", "sgst", "cess"]) {
-                totals[f] += row[f] || 0;
-            }
+            totals.total_taxable_value += row.total_taxable_value || 0;
+            totals.total_igst_amount += row.total_igst_amount || 0;
+            totals.total_cgst_amount += row.total_cgst_amount || 0;
+            totals.total_sgst_amount += row.total_sgst_amount || 0;
+            totals.total_cess_amount += row.total_cess_amount || 0;
 
             return {
-                posting_date: frappe.datetime.str_to_user(row.posting_date) || "",
+                document_date: frappe.datetime.str_to_user(row.document_date) || "",
                 document_number: row.document_number,
                 doc_route: row.doc_route || route,
-                party_gstin: row.party_gstin || "",
-                party_name: row.party_name || row.party || "",
-                type_label,
-                taxable_value: row.taxable_value || 0,
-                igst: row.igst || 0,
-                cgst: row.cgst || 0,
-                sgst: row.sgst || 0,
-                cess: row.cess || 0,
+                party_gstin: row[party_gstin_field] || "",
+                party_name: row[party_name_field] || "",
+                type_label: row.transaction_type || "",
+                total_taxable_value: row.total_taxable_value || 0,
+                total_igst_amount: row.total_igst_amount || 0,
+                total_cgst_amount: row.total_cgst_amount || 0,
+                total_sgst_amount: row.total_sgst_amount || 0,
+                total_cess_amount: row.total_cess_amount || 0,
             };
         });
 
         const currency_fields = new Set([
-            "taxable_value",
-            "igst",
-            "cgst",
-            "sgst",
-            "cess",
+            "total_taxable_value",
+            "total_igst_amount",
+            "total_cgst_amount",
+            "total_sgst_amount",
+            "total_cess_amount",
         ]);
 
         const fmt_currency = value => format_currency(value || 0);
 
         const columns = [
-            { id: "posting_date", name: __("Date"), field: "posting_date", width: 100 },
+            {
+                id: "document_date",
+                name: __("Date"),
+                field: "document_date",
+                width: 100,
+            },
             {
                 id: "document_number",
                 name: doc_label,
@@ -1322,41 +1338,41 @@ class GSTR9 {
             },
             { id: "type_label", name: class_label, field: "type_label", width: 180 },
             {
-                id: "taxable_value",
+                id: "total_taxable_value",
                 name: __("Taxable Value"),
-                field: "taxable_value",
+                field: "total_taxable_value",
                 width: 130,
                 align: "right",
                 format: fmt_currency,
             },
             {
-                id: "igst",
+                id: "total_igst_amount",
                 name: __("IGST"),
-                field: "igst",
+                field: "total_igst_amount",
                 width: 110,
                 align: "right",
                 format: fmt_currency,
             },
             {
-                id: "cgst",
+                id: "total_cgst_amount",
                 name: __("CGST"),
-                field: "cgst",
+                field: "total_cgst_amount",
                 width: 110,
                 align: "right",
                 format: fmt_currency,
             },
             {
-                id: "sgst",
+                id: "total_sgst_amount",
                 name: __("SGST/UTGST"),
-                field: "sgst",
+                field: "total_sgst_amount",
                 width: 120,
                 align: "right",
                 format: fmt_currency,
             },
             {
-                id: "cess",
+                id: "total_cess_amount",
                 name: __("Cess"),
-                field: "cess",
+                field: "total_cess_amount",
                 width: 95,
                 align: "right",
                 format: fmt_currency,
@@ -1392,7 +1408,7 @@ class GSTR9 {
                 hooks: {
                     columnTotal: (_col, row) => {
                         const id = row.column?.id;
-                        if (id === "posting_date") return __("Total");
+                        if (id === "document_date") return __("{0}", ["Total"]);
                         if (currency_fields.has(id)) return totals[id] || 0;
                         return "";
                     },
@@ -1444,6 +1460,16 @@ class GSTR9 {
                     .finally(() => {
                         this._recomputing = false;
                     });
+            });
+
+            this.frm.add_custom_button(__("Export Books as Excel"), () => {
+                open_url_post(
+                    "/api/method/india_compliance.gst_india.doctype.gstr_9.gstr_9.export_gstr9_books_as_excel",
+                    {
+                        company_gstin: this.frm.doc.company_gstin,
+                        financial_year: this.frm.doc.financial_year,
+                    },
+                );
             });
 
             if (is_gstr9_api_enabled()) {

--- a/india_compliance/gst_india/doctype/gstr_9/gstr_9.js
+++ b/india_compliance/gst_india/doctype/gstr_9/gstr_9.js
@@ -711,6 +711,19 @@ class GSTR9 {
         $wrapper.html(html);
     }
 
+    _render_value_cells(row, row_key, columns) {
+        const disabled = DISABLED_CELLS[row_key];
+        let html = "";
+        for (const col of columns) {
+            if (disabled?.has(col.fieldname)) {
+                html += `<td class="gstr9-cell-disabled"></td>`;
+            } else {
+                html += `<td class="text-right">${format_currency(row[col.fieldname] || 0)}</td>`;
+            }
+        }
+        return html;
+    }
+
     _build_section_with_type_column_html(section, rows, row_map, is_books = false, columns = AMOUNT_COLUMNS) {
         const bifurcated_rows = section.bifurcated_rows || {};
 
@@ -786,15 +799,7 @@ class GSTR9 {
                         html += `<td>${__(type_label)}</td>`;
                     }
 
-                    for (const col of columns) {
-                        if (sub_disabled?.has(col.fieldname)) {
-                            html += `<td class="gstr9-cell-disabled"></td>`;
-                        } else {
-                            html += `<td class="text-right">${format_currency(
-                                sub_row[col.fieldname] || 0,
-                            )}</td>`;
-                        }
-                    }
+                    html += this._render_value_cells(sub_row, sub_key, columns);
 
                     html += `</tr>`;
                 }
@@ -822,14 +827,7 @@ class GSTR9 {
 
                 html += `</td><td></td>`; // empty Type cell
 
-                const disabled = DISABLED_CELLS[row_key];
-                for (const col of columns) {
-                    if (disabled?.has(col.fieldname)) {
-                        html += `<td class="gstr9-cell-disabled"></td>`;
-                    } else {
-                        html += `<td class="text-right">${format_currency(row[col.fieldname] || 0)}</td>`;
-                    }
-                }
+                html += this._render_value_cells(row, row_key, columns);
 
                 html += `</tr>`;
             }
@@ -889,14 +887,7 @@ class GSTR9 {
 
             html += `</td>`;
 
-            const disabled = DISABLED_CELLS[row.row_key];
-            for (const col of columns) {
-                if (disabled?.has(col.fieldname)) {
-                    html += `<td class="gstr9-cell-disabled"></td>`;
-                } else {
-                    html += `<td class="text-right">${format_currency(row[col.fieldname] || 0)}</td>`;
-                }
-            }
+            html += this._render_value_cells(row, row.row_key, columns);
 
             html += `</tr>`;
         }
@@ -1369,16 +1360,19 @@ class GSTR9 {
 
     // ───── Form Actions ─────
 
+    _on_gst_data(r, onSuccess) {
+        if (!r.message) return;
+        this.frm.doc.__gst_data = r.message;
+        this.frm.trigger("load_gstr9_data");
+        onSuccess?.();
+    }
+
     render_form_actions() {
         this.frm.page.clear_actions();
 
         // Primary: Generate
         this.frm.page.set_primary_action(__("Generate"), () => {
-            this.frm.taxpayer_api_call("generate_gstr9").then((r) => {
-                if (!r.message) return;
-                this.frm.doc.__gst_data = r.message;
-                this.frm.trigger("load_gstr9_data");
-            });
+            this.frm.taxpayer_api_call("generate_gstr9").then((r) => this._on_gst_data(r));
         });
 
         // Custom buttons (only if data exists)
@@ -1388,11 +1382,7 @@ class GSTR9 {
                 this._recomputing = true;
                 this.frm
                     .taxpayer_api_call("recompute_books")
-                    .then((r) => {
-                        if (!r.message) return;
-                        this.frm.doc.__gst_data = r.message;
-                        this.frm.trigger("load_gstr9_data");
-                    })
+                    .then((r) => this._on_gst_data(r))
                     .finally(() => {
                         this._recomputing = false;
                     });
@@ -1410,15 +1400,14 @@ class GSTR9 {
             if (is_gstr9_api_enabled()) {
                 this.frm.add_custom_button(__("Download Portal Data"), () => {
                     frappe.show_alert(__("Downloading portal data from GSTN..."));
-                    this.frm.taxpayer_api_call("download_portal_data").then((r) => {
-                        if (!r.message) return;
-                        this.frm.doc.__gst_data = r.message;
-                        this.frm.trigger("load_gstr9_data");
-                        frappe.show_alert({
-                            message: __("Portal data downloaded successfully"),
-                            indicator: "green",
-                        });
-                    });
+                    this.frm.taxpayer_api_call("download_portal_data").then((r) =>
+                        this._on_gst_data(r, () =>
+                            frappe.show_alert({
+                                message: __("Portal data downloaded successfully"),
+                                indicator: "green",
+                            }),
+                        ),
+                    );
                 });
             }
         }

--- a/india_compliance/gst_india/doctype/gstr_9/gstr_9.js
+++ b/india_compliance/gst_india/doctype/gstr_9/gstr_9.js
@@ -1,0 +1,1473 @@
+// Copyright (c) 2025, Resilient Tech and contributors
+// For license information, please see license.txt
+
+frappe.provide("india_compliance");
+
+const DOCTYPE = "GSTR-9";
+
+// Amount columns for Tables 4-8
+const AMOUNT_COLUMNS = [
+    { label: "Taxable Value", fieldname: "taxable_value" },
+    { label: "IGST", fieldname: "igst" },
+    { label: "CGST", fieldname: "cgst" },
+    { label: "SGST/UTGST", fieldname: "sgst" },
+    { label: "Cess", fieldname: "cess" },
+];
+
+// Row descriptions
+const ROW_DESCRIPTIONS = {
+    "4A": "Supplies made to un-registered persons (B2C)",
+    "4B": "Supplies made to registered persons (B2B)",
+    "4C": "Zero rated supply (Export) on payment of tax (except supplies to SEZs)",
+    "4D": "Supply to SEZs on payment of tax",
+    "4E": "Deemed Exports",
+    "4F": "Advances on which tax has been paid but invoice has not been issued (not covered under (4A) to (4E) above)",
+    "4G": "Inward supplies on which tax is to be paid on reverse charge basis",
+    "4G1": "Supplies on which e-commerce operator is required to pay tax u/s 9(5) [Operator to report]",
+    "4H": "Sub-total (4A to 4G1)",
+    "4I": "Credit Notes issued in respect of transactions in (4B) to (4E)",
+    "4J": "Debit Notes issued in respect of transactions in (4B) to (4E)",
+    "4K": "Supplies / tax declared through Amendments (+)",
+    "4L": "Supplies / tax declared through Amendments (-)",
+    "4M": "Sub-total (4I to 4L)",
+    "4N": "Supplies and advances on which tax is to be paid (4H + 4M) above",
+    "5A": "Zero rated supply (Export) without payment of tax",
+    "5B": "Supply to SEZs without payment of tax",
+    "5C": "Supplies on which tax is to be paid by the recipient on reverse charge basis",
+    "5C1": "Supplies on which tax is to be paid by e-commerce operators u/s 9(5) [Supplier to report]",
+    "5D": "Exempted",
+    "5E": "Nil Rated",
+    "5F": "Non-GST supply (includes 'no supply')",
+    "5G": "Sub-total (5A to 5F)",
+    "5H": "Credit Notes issued in respect of transactions in (5A) to (5F)",
+    "5I": "Debit Notes issued in respect of transactions in (5A) to (5F)",
+    "5J": "Supplies declared through Amendments (+)",
+    "5K": "Supplies declared through Amendments (-)",
+    "5L": "Sub-total (5H to 5K)",
+    "5M": "Turnover on which tax is not to be paid  (5G + 5L) above",
+    "5N": "Total Turnover (including advances) (4N + 5M - 4G - 4G1)",
+    "6A": "Total amount of input tax credit availed through FORM GSTR-3B (Sum total of table 4A of FORM GSTR-3B)",
+    "6A1": "ITC of any preceding financial year availed in the financial year (which is included in 6A above) other than reclaim",
+    "6A2": "Net ITC of the financial year (A-A1)",
+    "6B": "Inward supplies (other than imports and inward supplies liable to reverse charge but includes services received from SEZs)",
+    "6B_ip": "Inputs",
+    "6B_cg": "Capital Goods",
+    "6B_is": "Input Services",
+    "6C": "Inward supplies received from unregistered persons liable to reverse charge (other than B above) on which tax is paid & ITC availed",
+    "6C_ip": "Inputs",
+    "6C_cg": "Capital Goods",
+    "6C_is": "Input Services",
+    "6D": "Inward supplies received from registered persons liable to reverse charge (other than B above) on which tax is paid and ITC availed",
+    "6D_ip": "Inputs",
+    "6D_cg": "Capital Goods",
+    "6D_is": "Input Services",
+    "6E": "Import of goods (including supplies from SEZ)",
+    "6E_ip": "Inputs",
+    "6E_cg": "Capital Goods",
+    "6F": "Import of services (excluding inward supplies from SEZs)",
+    "6G": "Input Tax credit received from ISD",
+    "6H": "Amount of ITC reclaimed under the provisions of the Act",
+    "6I": "Sub-total (B to H above)",
+    "6J": "Difference (I - A2 above)",
+    "6K": "Transition Credit through TRAN-1 (including revisions if any)",
+    "6L": "Transition Credit through TRAN-2",
+    "6M": "ITC availed through ITC-01, ITC-02, and ITC-02A (other than GSTR-3B and TRAN Forms)",
+    "6N": "Sub-total (K to M above)",
+    "6O": "Total ITC availed (I + N) above",
+    "7A": "As per Rule 37",
+    "7A1": "As per Rule 37A",
+    "7A2": "As per Rule 38",
+    "7B": "As per Rule 39",
+    "7C": "As per Rule 42",
+    "7D": "As per Rule 43",
+    "7E": "As per section 17(5)",
+    "7F": "Reversal of TRAN-I credit",
+    "7G": "Reversal of TRAN-II credit",
+    "7H1": "Other reversals (specify)",
+    "7I": "Total ITC Reversed (A to H)",
+    "7J": "Net ITC Available for Utilization (6O - 7I)",
+    "8A": "ITC as per GSTR-2B",
+    "8B": "ITC as per sum total of 6B above",
+    "8C": "ITC on inward supplies (other than imports and inward supplies liable to reverse charge but includes services received from SEZs) received during the financial year but availed in the next financial year upto specified period",
+    "8D": "Difference [8A - (8B + 8C)]",
+    "8E": "ITC available but not availed",
+    "8F": "ITC available but ineligible",
+    "8G": "IGST paid on import of goods",
+    "8H": "IGST credit availed on import of goods (as per 6(E) above) in financial year",
+    "8H1": "IGST Credit availed on Import of goods in next financial year",
+    "8I": "Difference (8G - 8H - 8H1)",
+    "8J": "ITC available but not availed on import of goods (Equal to 8I)",
+    "8K": "Total ITC to be lapsed in current financial year (8E + 8F + 8J)",
+    9: "Details of tax paid as declared in returns filed during the financial year",
+    10: "Supplies / tax declared through Debit Notes (+)",
+    11: "Supplies / tax reduced through Credit Notes (\u2013)",
+    "10_11_turnover": "Turnover including adjustments above (5N + 10 \u2013 11)",
+    12: "Reversal of ITC availed during previous financial year",
+    13: "ITC availed for the previous financial year",
+    14: "Differential tax paid on account of declaration in Table 10 & 11",
+    15: "Particulars of Demands and Refunds",
+    "16A": "Inward supplies received from composition taxpayers",
+    "16B": "Deemed supply under Section 143(3) and (5) by Job Worker",
+    "16C": "Goods sent on approval basis but not returned within 6 months",
+};
+
+// Auto-computed (non-editable) rows
+const AUTO_COMPUTED_ROWS = new Set([
+    "4H",
+    "4M",
+    "4N",
+    "5G",
+    "5L",
+    "5M",
+    "5N",
+    "10_11_turnover",
+    "6A2",
+    "6I",
+    "6J",
+    "6N",
+    "6O",
+    "7I",
+    "7J",
+    "8B",
+    "8D",
+    "8H",
+    "8I",
+    "8J",
+    "8K",
+]);
+
+// Portal-sourced (read-only) rows
+const PORTAL_SOURCED_ROWS = new Set(["6A", "8A", "9"]);
+
+// Rows not supported by books computation (manual/portal only)
+const NOT_SUPPORTED_ROWS = new Set(["4G1", "4K", "4L", "5J", "5K"]);
+
+// Rows that require manual entry by the user
+const MANUAL_ENTRY_ROWS = new Set([
+    "6A1",
+    "6H",
+    "6K",
+    "6L",
+    "6M",
+    "7A",
+    "7A1",
+    "7A2",
+    "7B",
+    "7C",
+    "7D",
+    "7E",
+    "7F",
+    "7G",
+    "7H1",
+    "8C",
+    "8E",
+    "8F",
+    "8G",
+    "8H1",
+]);
+
+// Rows that support drill-down to individual invoice records (Books tab only)
+const DETAIL_VIEW_ROWS = new Set([
+    // Table 4 — Outward supplies (taxable)
+    "4A",
+    "4B",
+    "4C",
+    "4D",
+    "4E",
+    "4G",
+    "4I",
+    "4J",
+    // Table 5 — Outward supplies (non-taxable)
+    "5A",
+    "5B",
+    "5C",
+    "5C1",
+    "5D",
+    "5E",
+    "5F",
+    "5H",
+    "5I",
+    // Table 6 — ITC availed (inward)
+    "6B",
+    "6B_ip",
+    "6B_cg",
+    "6B_is",
+    "6C",
+    "6C_ip",
+    "6C_cg",
+    "6C_is",
+    "6D",
+    "6D_ip",
+    "6D_cg",
+    "6D_is",
+    "6E",
+    "6E_ip",
+    "6E_cg",
+    "6F",
+    "6G",
+]);
+
+// Cells that are not applicable for a row — rendered with white background
+// Map of row_key → Set of disabled fieldnames
+const DISABLED_CELLS = {
+    "4C": new Set(["cgst", "sgst"]),
+    "4D": new Set(["cgst", "sgst"]),
+    "5A": new Set(["igst", "cgst", "sgst", "cess"]),
+    "5B": new Set(["igst", "cgst", "sgst", "cess"]),
+    "5C": new Set(["igst", "cgst", "sgst", "cess"]),
+    "5C1": new Set(["igst", "cgst", "sgst", "cess"]),
+    "5D": new Set(["igst", "cgst", "sgst", "cess"]),
+    "5E": new Set(["igst", "cgst", "sgst", "cess"]),
+    "5F": new Set(["igst", "cgst", "sgst", "cess"]),
+    "5G": new Set(["igst", "cgst", "sgst", "cess"]),
+    "5H": new Set(["igst", "cgst", "sgst", "cess"]),
+    "5I": new Set(["igst", "cgst", "sgst", "cess"]),
+    "5J": new Set(["igst", "cgst", "sgst", "cess"]),
+    "5K": new Set(["igst", "cgst", "sgst", "cess"]),
+    "5L": new Set(["igst", "cgst", "sgst", "cess"]),
+    "5M": new Set(["igst", "cgst", "sgst", "cess"]),
+    "6E": new Set(["cgst", "sgst"]),
+    "6E_ip": new Set(["cgst", "sgst"]),
+    "6E_cg": new Set(["cgst", "sgst"]),
+    "6F": new Set(["cgst", "sgst"]),
+    "6K": new Set(["igst", "cess"]),
+    "6L": new Set(["igst", "cess"]),
+    "7F": new Set(["igst", "cess"]),
+    "7G": new Set(["igst", "cess"]),
+    "8F": new Set(["igst", "cess"]),
+    "8G": new Set(["igst", "cess"]),
+};
+
+// Table sections for grouping rows in the UI
+const TABLE_SECTIONS = [
+    {
+        title: "Part II — Table 4: Outward Supplies (Tax Payable)",
+        rows: [
+            "4A",
+            "4B",
+            "4C",
+            "4D",
+            "4E",
+            "4F",
+            "4G",
+            "4G1",
+            "4H",
+            "4I",
+            "4J",
+            "4K",
+            "4L",
+            "4M",
+            "4N",
+        ],
+    },
+    {
+        title: "Part II — Table 5: Outward Supplies (Tax Not Payable)",
+        rows: [
+            "5A",
+            "5B",
+            "5C",
+            "5C1",
+            "5D",
+            "5E",
+            "5F",
+            "5G",
+            "5H",
+            "5I",
+            "5J",
+            "5K",
+            "5L",
+            "5M",
+            "5N",
+        ],
+    },
+    {
+        title: "Part III — Table 6: ITC Availed",
+        hide_taxable_value: true,
+        has_type_column: true,
+        rows: [
+            "6A",
+            "6A1",
+            "6A2",
+            "6B",
+            "6C",
+            "6D",
+            "6E",
+            "6F",
+            "6G",
+            "6H",
+            "6I",
+            "6J",
+            "6K",
+            "6L",
+            "6M",
+            "6N",
+            "6O",
+        ],
+        bifurcated_rows: {
+            "6B": ["6B_ip", "6B_cg", "6B_is"],
+            "6C": ["6C_ip", "6C_cg", "6C_is"],
+            "6D": ["6D_ip", "6D_cg", "6D_is"],
+            "6E": ["6E_ip", "6E_cg"],
+        },
+    },
+    {
+        title: "Part III — Table 7: ITC Reversed",
+        hide_taxable_value: true,
+        hidden: true,
+        rows: [
+            "7A",
+            "7A1",
+            "7A2",
+            "7B",
+            "7C",
+            "7D",
+            "7E",
+            "7F",
+            "7G",
+            "7H1",
+            "7I",
+            "7J",
+        ],
+    },
+    {
+        title: "Part III — Table 8: Other ITC Related Information",
+        hide_taxable_value: true,
+        hidden: true,
+        rows: ["8A", "8B", "8C", "8D", "8E", "8F", "8G", "8H", "8H1", "8I", "8J", "8K"],
+    },
+    {
+        title: "Part IV — Table 9: Tax Paid",
+        hidden: true,
+        rows: ["9"],
+    },
+    {
+        title: "Part V — Tables 10 & 11: Transactions for Previous FY Declared in Current FY",
+        hidden: true,
+        rows: ["10", "11", "10_11_turnover"],
+    },
+    {
+        title: "Part V — Tables 12 & 13: ITC Adjustments for Previous FY",
+        hide_taxable_value: true,
+        hidden: true,
+        rows: ["12", "13"],
+    },
+    {
+        title: "Part V — Table 14: Differential Tax Paid",
+        hidden: true,
+        rows: ["14"],
+        is_table_14: true,
+    },
+    {
+        title: "Part VI — Table 15: Demands and Refunds",
+        hidden: true,
+        rows: ["15"],
+        is_table_15: true,
+    },
+    {
+        title: "Part VI — Table 16: Composition Taxpayers / Deemed Supply / Approval Basis",
+        hidden: true,
+        rows: ["16A", "16B", "16C"],
+    },
+    {
+        title: "Part VI — Table 17: HSN-wise Summary of Outward Supplies",
+        rows: ["17"],
+        is_hsn: true,
+    },
+    {
+        title: "Part VI — Table 18: HSN-wise Summary of Inward Supplies",
+        rows: ["18"],
+        is_hsn: true,
+    },
+];
+
+// =====================================
+// Form Events
+// =====================================
+
+frappe.ui.form.on(DOCTYPE, {
+    async setup(frm) {
+        frm.gstr9 = new GSTR9(frm);
+
+        // Set defaults
+        frm.doc.company = frappe.defaults.get_user_default("Company");
+        frm.trigger("company");
+
+        // Setup realtime listeners
+        frappe.realtime.on("gstr9_data_prepared", message => {
+            const { filters } = message;
+
+            if (
+                frm.doc.company_gstin !== filters?.company_gstin ||
+                frm.doc.financial_year !== filters?.financial_year
+            )
+                return;
+
+            frm.taxpayer_api_call("generate_gstr9").then(r => {
+                if (!r.message) return;
+                frm.doc.__gst_data = r.message;
+                frm.trigger("load_gstr9_data");
+            });
+        });
+
+        frappe.realtime.on("gstr9_generation_failed", message => {
+            const { error, filters } = message;
+            frappe.msgprint({
+                title: __("GSTR-9 Generation Failed"),
+                message: __("GSTR-9 generation failed for {0} - {1}.<br/><br/>{2}", [
+                    filters?.company_gstin || "",
+                    filters?.financial_year || "",
+                    error || "",
+                ]),
+                indicator: "red",
+            });
+        });
+
+        frappe.realtime.on("show_missing_gst_credentials_message", message => {
+            frappe.msgprint(message);
+        });
+
+        frm.__setup_complete = true;
+    },
+
+    async company(frm) {
+        render_empty_state(frm);
+        if (!frm.doc.company) return;
+        const options = await india_compliance.set_gstin_options(frm, false, true);
+        frm.set_value("company_gstin", options?.[0]);
+    },
+
+    company_gstin(frm) {
+        render_empty_state(frm);
+    },
+
+    financial_year(frm) {
+        render_empty_state(frm);
+    },
+
+    refresh(frm) {
+        frm.disable_save();
+        frm.gstr9?.render_form_actions();
+
+        if (!frm.doc.__gst_data) {
+            frm.page.clear_indicator();
+            return;
+        }
+
+        frm.gstr9.render_indicator();
+    },
+
+    load_gstr9_data(frm) {
+        const data = frm.doc.__gst_data;
+        if (!data?.status) return;
+
+        frm.refresh();
+        frm.gstr9.status = data.status;
+        frm.gstr9.refresh_data(data);
+    },
+});
+
+function render_empty_state(frm) {
+    frm.doc.__gst_data = null;
+    frm.refresh();
+}
+
+function format_currency(value) {
+    return format_number(value, null, 2);
+}
+
+class GSTR9 {
+    TABS = [
+        { label: __("Books"), name: "books", is_active: true },
+        { label: __("Portal"), name: "portal" },
+        { label: __("Comparison"), name: "comparison" },
+    ];
+
+    constructor(frm) {
+        this.init(frm);
+        this.render();
+    }
+
+    init(frm) {
+        this.frm = frm;
+        this.data = null;
+        this.status = null;
+        this.$wrapper = frm.fields_dict.tabs_html.$wrapper;
+    }
+
+    refresh_data(data) {
+        if (data) this.data = data;
+
+        this.TABS.forEach(_tab => {
+            const tab_name = _tab.name;
+            const tab = this.tabs[`${tab_name}_tab`];
+            const tab_data = this._get_tab_data(tab_name);
+
+            if (!tab_data) {
+                tab.hide();
+                _tab.shown = false;
+                return;
+            }
+
+            tab.show();
+            _tab.shown = true;
+
+            const $html = this.tab_group.get_field(`${tab_name}_html`).$wrapper;
+            this._render_tab_content($html, tab_name, tab_data);
+        });
+    }
+
+    _get_tab_data(tab_name) {
+        if (!this.data) return null;
+
+        if (tab_name === "books") return this.data.books_summary;
+        if (tab_name === "portal") return this.data.portal_summary;
+        if (tab_name === "comparison") return this.data.comparison;
+
+        return null;
+    }
+
+    // ───── Render ─────
+
+    render() {
+        this._render_tab_group();
+        this._setup_detail_view_listeners();
+    }
+
+    _render_tab_group() {
+        const tab_fields = this.TABS.reduce(
+            (acc, tab) => [
+                ...acc,
+                {
+                    fieldtype: "Tab Break",
+                    fieldname: `${tab.name}_tab`,
+                    label: __(tab.label),
+                    active: tab.is_active ? 1 : 0,
+                },
+                {
+                    fieldtype: "HTML",
+                    fieldname: `${tab.name}_html`,
+                },
+            ],
+            [],
+        );
+
+        this.tab_group = new frappe.ui.FieldGroup({
+            fields: [{ fieldtype: "Section Break" }, ...tab_fields],
+            body: this.$wrapper,
+            frm: this.frm,
+        });
+        this.tab_group.make();
+
+        this.tabs = Object.fromEntries(
+            this.tab_group.tabs.map(tab => [tab.df.fieldname, tab]),
+        );
+
+        // Remove padding around content
+        this.$wrapper.closest(".form-column").css("padding", "0px");
+        this.$wrapper.closest(".row.form-section").css("padding", "0px");
+    }
+
+    _render_tab_content($wrapper, tab_name, data) {
+        $wrapper.empty();
+
+        if (tab_name === "comparison") {
+            this._render_comparison_tab($wrapper, data);
+            return;
+        }
+
+        // Books or Portal tab — summary rows
+        this._render_summary_tab($wrapper, data, tab_name);
+    }
+
+    _render_summary_tab($wrapper, summary_rows, tab_name) {
+        if (!summary_rows?.length) {
+            $wrapper.html(
+                `<div class="text-muted text-center" style="padding: 40px;">
+                    ${__("No data available")}
+                </div>`,
+            );
+            return;
+        }
+
+        // Build row lookup for quick access
+        const row_map = {};
+        for (const row of summary_rows) {
+            row_map[row.row_key] = row;
+        }
+
+        for (const section of TABLE_SECTIONS) {
+            if (section.hidden) continue;
+
+            // Table 14 — custom payable/paid/difference column structure
+            if (section.is_table_14) {
+                const row = row_map["14"];
+                if (!row) continue;
+                $wrapper.append(this._build_table_14_html(section.title, row));
+                continue;
+            }
+
+            // Table 15 — custom 7-component column structure
+            if (section.is_table_15) {
+                const row = row_map["15"];
+                if (!row) continue;
+                $wrapper.append(this._build_table_15_html(section.title, row));
+                continue;
+            }
+
+            // HSN section: render Goods (Part A) and Services (Part B) sub-tables
+            if (section.is_hsn) {
+                const hsn_key = section.rows[0];
+                const hsn_row = row_map[hsn_key];
+                if (!hsn_row) continue;
+                const has_data =
+                    (hsn_row.goods?.length || 0) + (hsn_row.services?.length || 0) > 0;
+                if (!has_data) continue;
+                $wrapper.append(this._build_hsn_section_html(section.title, hsn_row));
+                continue;
+            }
+
+            const section_rows = section.rows
+                .filter(key => row_map[key])
+                .map(key => row_map[key]);
+
+            if (!section_rows.length) continue;
+
+            // Special handling for Table 9
+            if (section.rows.includes("9")) {
+                $wrapper.append(this._build_table_9_html(section.title, row_map["9"]));
+                continue;
+            }
+
+            const section_cols =
+                section.custom_columns ||
+                (section.hide_taxable_value
+                    ? AMOUNT_COLUMNS.filter(c => c.fieldname !== "taxable_value")
+                    : AMOUNT_COLUMNS);
+
+            if (section.bifurcated_rows) {
+                $wrapper.append(
+                    this._build_section_with_type_column_html(
+                        section,
+                        section_rows,
+                        row_map,
+                        tab_name === "books",
+                        section_cols,
+                    ),
+                );
+            } else {
+                $wrapper.append(
+                    this._build_section_html(
+                        section.title,
+                        section_rows,
+                        tab_name === "books",
+                        section_cols,
+                    ),
+                );
+            }
+        }
+    }
+
+    _render_comparison_tab($wrapper, comparison) {
+        if (!comparison || !Object.keys(comparison).length) {
+            $wrapper.html(
+                `<div class="text-muted text-center" style="padding: 40px;">
+                    ${__("No differences found between Books and Portal data")}
+                </div>`,
+            );
+            return;
+        }
+
+        let html = `<div class="gstr9-comparison">`;
+
+        for (const section of TABLE_SECTIONS) {
+            if (section.hidden) continue;
+            if (section.is_hsn) continue; // HSN tables excluded from comparison
+
+            // For bifurcated sections, check sub-rows for differences
+            let keys_to_check;
+            if (section.bifurcated_rows) {
+                keys_to_check = section.rows.flatMap(key => {
+                    const subs = section.bifurcated_rows[key];
+                    return subs ? subs : [key];
+                });
+            } else {
+                keys_to_check = section.rows;
+            }
+
+            const section_diffs = keys_to_check.filter(key => comparison[key]);
+            if (!section_diffs.length) continue;
+
+            const cmp_cols =
+                section.custom_columns ||
+                (section.hide_taxable_value
+                    ? AMOUNT_COLUMNS.filter(c => c.fieldname !== "taxable_value")
+                    : AMOUNT_COLUMNS);
+
+            html += `<div class="gstr9-section">
+                <h6 class="gstr9-section-title">${__(section.title)}</h6>
+                <div class="table-responsive">
+                    <table class="table table-bordered gstr9-table">
+                        <thead>
+                            <tr>
+                                <th class="gstr9-col-sno">${__("S.No")}</th>
+                                <th class="gstr9-col-desc">${__("Description")}</th>
+                                <th class="gstr9-col-source">${__("Source")}</th>`;
+
+            for (const col of cmp_cols) {
+                html += `<th class="text-right">${__(col.label)}</th>`;
+            }
+
+            html += `</tr></thead><tbody>`;
+
+            for (const row_key of section_diffs) {
+                const diff = comparison[row_key];
+                const desc = ROW_DESCRIPTIONS[row_key] || row_key;
+
+                // Books row
+                html += `<tr class="gstr9-comparison-books">
+                    <td rowspan="3" class="gstr9-col-sno">${row_key}</td>
+                    <td rowspan="3" class="gstr9-col-desc">${__(desc)}</td>
+                    <td class="gstr9-col-source"><span class="badge badge-info">${__("Books")}</span></td>`;
+                for (const col of cmp_cols) {
+                    html += `<td class="text-right">${format_currency(diff.books?.[col.fieldname] || 0)}</td>`;
+                }
+                html += `</tr>`;
+
+                // Portal row
+                html += `<tr class="gstr9-comparison-portal">
+                    <td class="gstr9-col-source"><span class="badge badge-warning">${__("Portal")}</span></td>`;
+                for (const col of cmp_cols) {
+                    html += `<td class="text-right">${format_currency(diff.portal?.[col.fieldname] || 0)}</td>`;
+                }
+                html += `</tr>`;
+
+                // Difference row
+                html += `<tr class="gstr9-comparison-diff">
+                    <td class="gstr9-col-source"><strong>${__("Diff")}</strong></td>`;
+                for (const col of cmp_cols) {
+                    const val = diff.difference?.[col.fieldname] || 0;
+                    const cls = val > 0 ? "text-danger" : val < 0 ? "text-success" : "";
+                    html += `<td class="text-right ${cls}"><strong>${format_currency(val)}</strong></td>`;
+                }
+                html += `</tr>`;
+            }
+
+            html += `</tbody></table></div></div>`;
+        }
+
+        html += `</div>`;
+        $wrapper.html(html);
+    }
+
+    _build_section_with_type_column_html(
+        section,
+        rows,
+        row_map,
+        is_books = false,
+        columns = AMOUNT_COLUMNS,
+    ) {
+        const bifurcated_rows = section.bifurcated_rows || {};
+
+        let html = `<div class="gstr9-section">
+            <h6 class="gstr9-section-title">${__(section.title)}</h6>
+            <div class="table-responsive">
+                <table class="table table-bordered gstr9-table">
+                    <thead>
+                        <tr>
+                            <th class="gstr9-col-sno">${__("S.No")}</th>
+                            <th class="gstr9-col-desc">${__("Description")}</th>
+                            <th>${__("Type")}</th>`;
+
+        for (const col of columns) {
+            html += `<th class="text-right">${__(col.label)}</th>`;
+        }
+
+        html += `</tr></thead><tbody>`;
+
+        for (const row of rows) {
+            const row_key = row.row_key;
+            const is_auto = AUTO_COMPUTED_ROWS.has(row_key);
+            const is_portal = PORTAL_SOURCED_ROWS.has(row_key);
+            const is_manual_entry = MANUAL_ENTRY_ROWS.has(row_key);
+            let row_class = "";
+            if (is_auto) row_class = "gstr9-row-auto";
+            else if (is_portal || is_manual_entry) row_class = "gstr9-row-portal";
+
+            const sub_row_keys = bifurcated_rows[row_key];
+
+            if (sub_row_keys) {
+                // Bifurcated: description cell spans sub-rows, each sub-row gets a Type cell
+                const rowspan = sub_row_keys.length;
+                html += `<tr>
+                    <td class="gstr9-col-sno" rowspan="${rowspan}">${row_key}</td>
+                    <td class="gstr9-col-desc" rowspan="${rowspan}">`;
+
+                if (is_books && DETAIL_VIEW_ROWS.has(row_key)) {
+                    html += `<a href="#" class="gstr9-detail-link"
+                        data-row-key="${row_key}"
+                        data-description="${(row.description || "").replace(/"/g, "&quot;")}"
+                        >${__(row.description)}</a>`;
+                } else {
+                    html += `${__(row.description)}`;
+                }
+
+                if (is_portal) {
+                    html += ` <span class="badge badge-warning">${__("Portal")}</span>`;
+                }
+
+                html += `</td>`;
+
+                // Render each sub-row (always normal background, no inherited row_class)
+                for (let i = 0; i < sub_row_keys.length; i++) {
+                    const sub_key = sub_row_keys[i];
+                    const sub_row = row_map[sub_key] || {};
+                    const sub_disabled = DISABLED_CELLS[sub_key];
+
+                    if (i > 0) html += `<tr>`;
+
+                    // Use static ROW_DESCRIPTIONS as primary label (always available)
+                    const type_label =
+                        ROW_DESCRIPTIONS[sub_key] || sub_row.description || "";
+
+                    if (is_books && DETAIL_VIEW_ROWS.has(sub_key)) {
+                        html += `<td><a href="#" class="gstr9-detail-link"
+                            data-row-key="${sub_key}"
+                            data-description="${(row.description || "").replace(/"/g, "&quot;")} - ${type_label.replace(/"/g, "&quot;")}"
+                            >${__(type_label)}</a></td>`;
+                    } else {
+                        html += `<td>${__(type_label)}</td>`;
+                    }
+
+                    for (const col of columns) {
+                        if (sub_disabled?.has(col.fieldname)) {
+                            html += `<td class="gstr9-cell-disabled"></td>`;
+                        } else {
+                            html += `<td class="text-right">${format_currency(sub_row[col.fieldname] || 0)}</td>`;
+                        }
+                    }
+
+                    html += `</tr>`;
+                }
+            } else {
+                // Regular row: empty Type cell
+                html += `<tr class="${row_class}">
+                    <td class="gstr9-col-sno">${row_key}</td>
+                    <td class="gstr9-col-desc">`;
+
+                if (is_books && DETAIL_VIEW_ROWS.has(row_key)) {
+                    html += `<a href="#" class="gstr9-detail-link"
+                        data-row-key="${row_key}"
+                        data-description="${(row.description || "").replace(/"/g, "&quot;")}"
+                        >${__(row.description)}</a>`;
+                } else {
+                    html += `${__(row.description)}`;
+                }
+
+                if (is_portal) {
+                    html += ` <span class="badge badge-warning">${__("Portal")}</span>`;
+                }
+                if (is_manual_entry) {
+                    html += ` <span class="badge badge-primary">${__("Manual Entry")}</span>`;
+                }
+
+                html += `</td><td></td>`; // empty Type cell
+
+                const disabled = DISABLED_CELLS[row_key];
+                for (const col of columns) {
+                    if (disabled?.has(col.fieldname)) {
+                        html += `<td class="gstr9-cell-disabled"></td>`;
+                    } else {
+                        html += `<td class="text-right">${format_currency(row[col.fieldname] || 0)}</td>`;
+                    }
+                }
+
+                html += `</tr>`;
+            }
+        }
+
+        html += `</tbody></table></div></div>`;
+        return html;
+    }
+
+    _build_section_html(title, rows, is_books = false, columns = AMOUNT_COLUMNS) {
+        let html = `<div class="gstr9-section">
+            <h6 class="gstr9-section-title">${__(title)}</h6>
+            <div class="table-responsive">
+                <table class="table table-bordered gstr9-table">
+                    <thead>
+                        <tr>
+                            <th class="gstr9-col-sno">${__("S.No")}</th>
+                            <th class="gstr9-col-desc">${__("Description")}</th>`;
+
+        for (const col of columns) {
+            html += `<th class="text-right">${__(col.label)}</th>`;
+        }
+
+        html += `</tr></thead><tbody>`;
+
+        for (const row of rows) {
+            const is_auto = AUTO_COMPUTED_ROWS.has(row.row_key);
+            const is_portal = PORTAL_SOURCED_ROWS.has(row.row_key);
+            const is_not_supported = NOT_SUPPORTED_ROWS.has(row.row_key);
+            const is_manual_entry = MANUAL_ENTRY_ROWS.has(row.row_key);
+            let row_class = "";
+            if (is_auto) row_class = "gstr9-row-auto";
+            else if (is_portal || is_not_supported || is_manual_entry)
+                row_class = "gstr9-row-portal";
+
+            html += `<tr class="${row_class}">
+                <td class="gstr9-col-sno">${row.row_key}</td>
+                <td class="gstr9-col-desc">`;
+
+            if (is_books && DETAIL_VIEW_ROWS.has(row.row_key)) {
+                html += `<a href="#" class="gstr9-detail-link"
+                    data-row-key="${row.row_key}"
+                    data-description="${(row.description || "").replace(/"/g, "&quot;")}"
+                    >${__(row.description)}</a>`;
+            } else {
+                html += `${__(row.description)}`;
+            }
+
+            if (is_portal) {
+                html += ` <span class="badge badge-warning">${__("Portal")}</span>`;
+            }
+            if (is_not_supported) {
+                html += ` <span class="badge badge-secondary">${__("Not Supported")}</span>`;
+            }
+            if (is_manual_entry) {
+                html += ` <span class="badge badge-primary">${__("Manual Entry")}</span>`;
+            }
+
+            html += `</td>`;
+
+            const disabled = DISABLED_CELLS[row.row_key];
+            for (const col of columns) {
+                if (disabled?.has(col.fieldname)) {
+                    html += `<td class="gstr9-cell-disabled"></td>`;
+                } else {
+                    html += `<td class="text-right">${format_currency(row[col.fieldname] || 0)}</td>`;
+                }
+            }
+
+            html += `</tr>`;
+        }
+
+        html += `</tbody></table></div></div>`;
+        return html;
+    }
+
+    _build_table_9_html(title, row_data) {
+        const rows = (row_data && row_data.rows) || [];
+        // Table 9 ITC sub-columns (Paid through ITC breakdown)
+        const TABLE_9_ITC_COLUMNS = [
+            { label: "IGST", fieldname: "itc_igst" },
+            { label: "CGST", fieldname: "itc_cgst" },
+            { label: "SGST/UTGST", fieldname: "itc_sgst" },
+            { label: "Cess", fieldname: "itc_cess" },
+        ];
+
+        let html = `<div class="gstr9-section">
+            <h6 class="gstr9-section-title">${__(title)}</h6>`;
+
+        if (rows.length) {
+            // Two-row header: row-1 has main cols + "Paid through ITC" spanning 4;
+            // row-2 has the 4 ITC sub-cols.
+            const itc_span = TABLE_9_ITC_COLUMNS.length;
+            html += `<div class="table-responsive">
+                <table class="table table-bordered gstr9-table">
+                    <thead>
+                        <tr>
+                            <th rowspan="2" class="gstr9-col-sno">${__("S.No")}</th>
+                            <th rowspan="2" class="gstr9-col-desc">${__("Description")}</th>
+                            <th rowspan="2" class="text-right">${__("Tax Payable (₹)")}</th>
+                            <th rowspan="2" class="text-right">${__("Paid through Cash (₹)")}</th>
+                            <th colspan="${itc_span}" class="text-center">${__("Paid through ITC (₹)")}</th>
+                            <th rowspan="2" class="text-right">${__("Total Tax Paid (₹)")}</th>
+                            <th rowspan="2" class="text-right">${__("Difference (₹)")}</th>
+                        </tr>
+                        <tr>`;
+
+            for (const col of TABLE_9_ITC_COLUMNS) {
+                html += `<th class="text-right">${__(col.label)}</th>`;
+            }
+
+            html += `</tr>
+                    </thead>
+                    <tbody>`;
+
+            rows.forEach(row => {
+                html += `<tr class="gstr9-row-portal">
+                    <td>${row.row_label || ""}</td>
+                    <td>${__(row.tax_head || "")}</td>
+                    <td class="text-right">${format_currency(row.tax_payable || 0)}</td>
+                    <td class="text-right">${format_currency(row.paid_through_cash || 0)}</td>`;
+
+                for (const col of TABLE_9_ITC_COLUMNS) {
+                    html += `<td class="text-right">${format_currency(row[col.fieldname] || 0)}</td>`;
+                }
+
+                html += `
+                    <td class="text-right">${format_currency(row.total_paid || 0)}</td>
+                    <td class="text-right">${format_currency(row.difference || 0)}</td>
+                </tr>`;
+            });
+
+            html += `</tbody></table></div>`;
+        } else {
+            html += `<div class="text-muted text-center" style="padding: 20px;">
+                ${__("Table 9 data will be available after downloading portal data")}
+            </div>`;
+        }
+
+        html += `</div>`;
+        return html;
+    }
+
+    _build_table_14_html(title, row_data) {
+        const rows = (row_data && row_data.rows) || [];
+
+        let html = `<div class="gstr9-section">
+            <h6 class="gstr9-section-title">${__(title)}</h6>
+            <div class="table-responsive">
+                <table class="table table-bordered gstr9-table">
+                    <thead>
+                        <tr>
+                            <th class="gstr9-col-sno">${__("S.No")}</th>
+                            <th class="gstr9-col-desc">${__("Description")}</th>
+                            <th class="text-right">${__("Payable (₹)")}</th>
+                            <th class="text-right">${__("Paid (₹)")}</th>
+                            <th class="text-right">${__("Difference (₹)")}</th>
+                        </tr>
+                    </thead>
+                    <tbody>`;
+
+        for (const row of rows) {
+            const diff = flt(row.payable || 0) - flt(row.paid || 0);
+            html += `<tr>
+                <td class="gstr9-col-sno">${row.label || ""}</td>
+                <td class="gstr9-col-desc">${__(row.description || "")}</td>
+                <td class="text-right">${format_currency(row.payable || 0)}</td>
+                <td class="text-right">${format_currency(row.paid || 0)}</td>
+                <td class="text-right">${format_currency(diff)}</td>
+            </tr>`;
+        }
+
+        html += `</tbody></table></div></div>`;
+        return html;
+    }
+
+    _build_table_15_html(title, row_data) {
+        const rows = (row_data && row_data.rows) || [];
+
+        const T15_COLS = [
+            { label: __("IGST"), fieldname: "igst" },
+            { label: __("CGST"), fieldname: "cgst" },
+            { label: __("SGST/UTGST"), fieldname: "sgst" },
+            { label: __("Cess"), fieldname: "cess" },
+            { label: __("Interest"), fieldname: "interest" },
+            { label: __("Penalty"), fieldname: "penalty" },
+            { label: __("Late Fee / Others"), fieldname: "late_fee" },
+        ];
+
+        let html = `<div class="gstr9-section">
+            <h6 class="gstr9-section-title">${__(title)}</h6>
+            <div class="table-responsive">
+                <table class="table table-bordered gstr9-table">
+                    <thead>
+                        <tr>
+                            <th class="gstr9-col-sno">${__("S.No")}</th>
+                            <th class="gstr9-col-desc">${__("Details")}</th>`;
+
+        for (const col of T15_COLS) {
+            html += `<th class="text-right">${col.label}</th>`;
+        }
+
+        html += `</tr></thead><tbody>`;
+
+        for (const row of rows) {
+            html += `<tr>
+                <td class="gstr9-col-sno">${row.label || ""}</td>
+                <td class="gstr9-col-desc">${__(row.description || "")}</td>`;
+
+            for (const col of T15_COLS) {
+                html += `<td class="text-right">${format_currency(row[col.fieldname] || 0)}</td>`;
+            }
+
+            html += `</tr>`;
+        }
+
+        html += `</tbody></table></div></div>`;
+        return html;
+    }
+
+    _build_hsn_section_html(title, hsn_row) {
+        const goods = (hsn_row && hsn_row.goods) || [];
+        const services = (hsn_row && hsn_row.services) || [];
+
+        let html = `<div class="gstr9-section">
+            <h6 class="gstr9-section-title">${__(title)}</h6>`;
+
+        if (goods.length) {
+            html += this._build_hsn_sub_table_html(__("Part A - Goods"), goods, false);
+        }
+        if (services.length) {
+            html += this._build_hsn_sub_table_html(
+                __("Part B - Services"),
+                services,
+                true,
+            );
+        }
+
+        html += `</div>`;
+        return html;
+    }
+
+    _build_hsn_sub_table_html(subtitle, rows, is_service) {
+        // Goods cols: S.No | HSN | Desc | UQC | Qty | Rate | Taxable | IGST | CGST | SGST | Cess (11)
+        // Service cols: S.No | HSN | Desc | Rate | Taxable | IGST | CGST | SGST | Cess (9)
+        const total_colspan = is_service ? 4 : 6; // cols before taxable_value in totals row
+
+        let html = `<h6 class="gstr9-hsn-subtitle">${subtitle}</h6>
+            <div class="table-responsive">
+                <table class="table table-bordered gstr9-table">
+                    <thead>
+                        <tr>
+                            <th class="gstr9-col-sno">${__("S.No.")}</th>
+                            <th>${__("HSN/SAC")}</th>
+                            <th>${__("Description")}</th>`;
+
+        if (!is_service) {
+            html += `<th>${__("UQC")}</th>
+                            <th class="text-right">${__("Total Quantity")}</th>`;
+        }
+
+        html += `<th class="text-right">${__("Tax Rate")}</th>
+                            <th class="text-right">${__("Taxable Value")}</th>
+                            <th class="text-right">${__("IGST")}</th>
+                            <th class="text-right">${__("CGST")}</th>
+                            <th class="text-right">${__("SGST/UTGST")}</th>
+                            <th class="text-right">${__("Cess")}</th>
+                        </tr>
+                    </thead>
+                    <tbody>`;
+
+        const totals = { taxable_value: 0, igst: 0, cgst: 0, sgst: 0, cess: 0 };
+
+        rows.forEach((row, idx) => {
+            const hsn_link = row.hsn_code
+                ? `<a href="${frappe.utils.get_form_link("GST HSN Code", row.hsn_code)}">${row.hsn_code}</a>`
+                : "";
+            html += `<tr>
+                <td class="gstr9-col-sno">${idx + 1}</td>
+                <td>${hsn_link}</td>
+                <td>${row.description || ""}</td>`;
+
+            if (!is_service) {
+                html += `<td>${row.uom || ""}</td>
+                <td class="text-right">${format_number(row.quantity || 0, null, 3)}</td>`;
+            }
+
+            html += `<td class="text-right">${flt(row.tax_rate || 0, 2)}%</td>
+                <td class="text-right">${format_currency(row.taxable_value || 0)}</td>
+                <td class="text-right">${format_currency(row.igst || 0)}</td>
+                <td class="text-right">${format_currency(row.cgst || 0)}</td>
+                <td class="text-right">${format_currency(row.sgst || 0)}</td>
+                <td class="text-right">${format_currency(row.cess || 0)}</td>
+            </tr>`;
+
+            for (const f of ["taxable_value", "igst", "cgst", "sgst", "cess"]) {
+                totals[f] += row[f] || 0;
+            }
+        });
+
+        html += `<tr class="gstr9-row-auto">
+            <td colspan="${total_colspan}" class="text-right"><strong>${__("Total")}</strong></td>
+            <td class="text-right"><strong>${format_currency(totals.taxable_value)}</strong></td>
+            <td class="text-right"><strong>${format_currency(totals.igst)}</strong></td>
+            <td class="text-right"><strong>${format_currency(totals.cgst)}</strong></td>
+            <td class="text-right"><strong>${format_currency(totals.sgst)}</strong></td>
+            <td class="text-right"><strong>${format_currency(totals.cess)}</strong></td>
+        </tr>`;
+
+        html += `</tbody></table></div>`;
+        return html;
+    }
+
+    // ───── Detail view ─────
+
+    _setup_detail_view_listeners() {
+        this.$wrapper.on("click", ".gstr9-detail-link", async e => {
+            e.preventDefault();
+            const $link = $(e.currentTarget);
+            const row_key = $link.data("row-key");
+            const description = $link.data("description");
+            await this.show_invoice_detail(String(row_key), String(description));
+        });
+    }
+
+    async show_invoice_detail(row_key, description) {
+        frappe.show_alert(__("Loading details…"));
+
+        let result;
+        try {
+            const r = await frappe.call({
+                method: "india_compliance.gst_india.doctype.gstr_9.gstr_9.get_gstr9_invoice_detail",
+                args: {
+                    company_gstin: this.frm.doc.company_gstin,
+                    financial_year: this.frm.doc.financial_year,
+                    row_key,
+                },
+            });
+            result = r.message;
+        } catch (e) {
+            frappe.msgprint(__("Failed to load detail data."));
+            return;
+        }
+
+        this._show_detail_dialog(
+            row_key,
+            description,
+            result || { is_purchase: false, data: [] },
+        );
+    }
+
+    _show_detail_dialog(row_key, description, result) {
+        const { is_purchase, data } = result;
+
+        if (!data || !data.length) {
+            frappe.msgprint({
+                title: __("No Records"),
+                message: __("No records found for {0} — {1}", [
+                    row_key,
+                    __(description),
+                ]),
+            });
+            return;
+        }
+
+        const route = is_purchase ? "purchase-invoice" : "sales-invoice";
+        const party_gstin_label = is_purchase
+            ? __("Supplier GSTIN")
+            : __("Customer GSTIN");
+        const party_name_label = is_purchase
+            ? __("Supplier Name")
+            : __("Customer Name");
+        const doc_label = is_purchase ? __("Bill No.") : __("Invoice No.");
+        const class_label = is_purchase ? __("Classification") : __("Type");
+
+        const totals = { taxable_value: 0, igst: 0, cgst: 0, sgst: 0, cess: 0 };
+
+        const rows = data.map(row => {
+            let type_label;
+            if (is_purchase) {
+                type_label = row.itc_classification || row.gst_category || "";
+            } else if (row.is_return) {
+                type_label = __("Credit Note");
+            } else if (row.is_debit_note) {
+                type_label = __("Debit Note");
+            } else {
+                type_label = __(row.gst_category || "Invoice");
+            }
+
+            for (const f of ["taxable_value", "igst", "cgst", "sgst", "cess"]) {
+                totals[f] += row[f] || 0;
+            }
+
+            return {
+                posting_date: frappe.datetime.str_to_user(row.posting_date) || "",
+                document_number: row.document_number,
+                doc_route: row.doc_route || route,
+                party_gstin: row.party_gstin || "",
+                party_name: row.party_name || row.party || "",
+                type_label,
+                taxable_value: row.taxable_value || 0,
+                igst: row.igst || 0,
+                cgst: row.cgst || 0,
+                sgst: row.sgst || 0,
+                cess: row.cess || 0,
+            };
+        });
+
+        const currency_fields = new Set([
+            "taxable_value",
+            "igst",
+            "cgst",
+            "sgst",
+            "cess",
+        ]);
+
+        const fmt_currency = value => format_currency(value || 0);
+
+        const columns = [
+            { id: "posting_date", name: __("Date"), field: "posting_date", width: 100 },
+            {
+                id: "document_number",
+                name: doc_label,
+                field: "document_number",
+                width: 190,
+                format: (value, _row, _col, data) =>
+                    `<a href="/app/${data?.doc_route || route}/${encodeURIComponent(value || "")}" target="_blank">${frappe.utils.escape_html(value || "")}</a>`,
+            },
+            {
+                id: "party_gstin",
+                name: party_gstin_label,
+                field: "party_gstin",
+                width: 170,
+            },
+            {
+                id: "party_name",
+                name: party_name_label,
+                field: "party_name",
+                width: 180,
+            },
+            { id: "type_label", name: class_label, field: "type_label", width: 180 },
+            {
+                id: "taxable_value",
+                name: __("Taxable Value"),
+                field: "taxable_value",
+                width: 130,
+                align: "right",
+                format: fmt_currency,
+            },
+            {
+                id: "igst",
+                name: __("IGST"),
+                field: "igst",
+                width: 110,
+                align: "right",
+                format: fmt_currency,
+            },
+            {
+                id: "cgst",
+                name: __("CGST"),
+                field: "cgst",
+                width: 110,
+                align: "right",
+                format: fmt_currency,
+            },
+            {
+                id: "sgst",
+                name: __("SGST/UTGST"),
+                field: "sgst",
+                width: 120,
+                align: "right",
+                format: fmt_currency,
+            },
+            {
+                id: "cess",
+                name: __("Cess"),
+                field: "cess",
+                width: 95,
+                align: "right",
+                format: fmt_currency,
+            },
+        ];
+
+        const dialog = new frappe.ui.Dialog({
+            title: `${row_key} — ${__(description)}`,
+            size: "extra-large",
+            fields: [{ fieldtype: "HTML", fieldname: "detail_content" }],
+        });
+
+        dialog.$wrapper.find(".modal-dialog").css("max-width", "95vw");
+
+        const $wrapper = dialog.fields_dict.detail_content.$wrapper;
+        // const $dt_wrapper = $('<div style="height:55vh; overflow:auto"></div>');
+        const $dt_wrapper = $('<div style="overflow:auto"></div>');
+        $wrapper.append($dt_wrapper);
+
+        // Initialize DataTable only after the modal transition completes so the
+        // container has real pixel dimensions — otherwise frappe.DataTable measures
+        // zero width and renders nothing until a resize/filter forces a recalc.
+        dialog.$wrapper.one("shown.bs.modal", () => {
+            new frappe.DataTable($dt_wrapper.get(0), {
+                columns,
+                data: rows,
+                showTotalRow: true,
+                checkboxColumn: false,
+                inlineFilters: true,
+                noDataMessage: __("No data"),
+                cellHeight: 34,
+                layout: "fluid",
+                hooks: {
+                    columnTotal: (_col, row) => {
+                        const id = row.column?.id;
+                        if (id === "posting_date") return __("Total");
+                        if (currency_fields.has(id)) return totals[id] || 0;
+                        return "";
+                    },
+                },
+            });
+        });
+
+        dialog.show();
+    }
+
+    // ───── Indicator ─────
+
+    render_indicator() {
+        if (!this.status) {
+            this.frm.page.clear_indicator();
+            return;
+        }
+
+        const color = this.status === "Filed" ? "green" : "orange";
+        this.frm.page.set_indicator(this.status, color);
+    }
+
+    // ───── Form Actions ─────
+
+    render_form_actions() {
+        this.frm.page.clear_actions();
+
+        // Primary: Generate
+        this.frm.page.set_primary_action(__("Generate"), () => {
+            this.frm.taxpayer_api_call("generate_gstr9").then(r => {
+                if (!r.message) return;
+                this.frm.doc.__gst_data = r.message;
+                this.frm.trigger("load_gstr9_data");
+            });
+        });
+
+        // Custom buttons (only if data exists)
+        if (this.data) {
+            this.frm.add_custom_button(__("Recompute Books"), () => {
+                if (this._recomputing) return;
+                this._recomputing = true;
+                this.frm
+                    .taxpayer_api_call("recompute_books")
+                    .then(r => {
+                        if (!r.message) return;
+                        this.frm.doc.__gst_data = r.message;
+                        this.frm.trigger("load_gstr9_data");
+                    })
+                    .finally(() => {
+                        this._recomputing = false;
+                    });
+            });
+
+            if (is_gstr9_api_enabled()) {
+                this.frm.add_custom_button(__("Download Portal Data"), () => {
+                    frappe.show_alert(__("Downloading portal data from GSTN..."));
+                    this.frm.taxpayer_api_call("download_portal_data").then(r => {
+                        if (!r.message) return;
+                        this.frm.doc.__gst_data = r.message;
+                        this.frm.trigger("load_gstr9_data");
+                        frappe.show_alert({
+                            message: __("Portal data downloaded successfully"),
+                            indicator: "green",
+                        });
+                    });
+                });
+            }
+        }
+    }
+}
+
+function is_gstr9_api_enabled() {
+    return (
+        india_compliance.is_api_enabled() &&
+        !gst_settings.sandbox_mode &&
+        gst_settings.enable_gstr_9_api
+    );
+}

--- a/india_compliance/gst_india/doctype/gstr_9/gstr_9.js
+++ b/india_compliance/gst_india/doctype/gstr_9/gstr_9.js
@@ -174,6 +174,7 @@ const DETAIL_VIEW_ROWS = new Set([
     "4C",
     "4D",
     "4E",
+    "4F",
     "4G",
     "4I",
     "4J",
@@ -242,43 +243,11 @@ const DISABLED_CELLS = {
 const TABLE_SECTIONS = [
     {
         title: "Part II — Table 4: Outward Supplies (Tax Payable)",
-        rows: [
-            "4A",
-            "4B",
-            "4C",
-            "4D",
-            "4E",
-            "4F",
-            "4G",
-            "4G1",
-            "4H",
-            "4I",
-            "4J",
-            "4K",
-            "4L",
-            "4M",
-            "4N",
-        ],
+        rows: ["4A", "4B", "4C", "4D", "4E", "4F", "4G", "4G1", "4H", "4I", "4J", "4K", "4L", "4M", "4N"],
     },
     {
         title: "Part II — Table 5: Outward Supplies (Tax Not Payable)",
-        rows: [
-            "5A",
-            "5B",
-            "5C",
-            "5C1",
-            "5D",
-            "5E",
-            "5F",
-            "5G",
-            "5H",
-            "5I",
-            "5J",
-            "5K",
-            "5L",
-            "5M",
-            "5N",
-        ],
+        rows: ["5A", "5B", "5C", "5C1", "5D", "5E", "5F", "5G", "5H", "5I", "5J", "5K", "5L", "5M", "5N"],
     },
     {
         title: "Part III — Table 6: ITC Availed",
@@ -314,20 +283,7 @@ const TABLE_SECTIONS = [
         title: "Part III — Table 7: ITC Reversed",
         hide_taxable_value: true,
         hidden: true,
-        rows: [
-            "7A",
-            "7A1",
-            "7A2",
-            "7B",
-            "7C",
-            "7D",
-            "7E",
-            "7F",
-            "7G",
-            "7H1",
-            "7I",
-            "7J",
-        ],
+        rows: ["7A", "7A1", "7A2", "7B", "7C", "7D", "7E", "7F", "7G", "7H1", "7I", "7J"],
     },
     {
         title: "Part III — Table 8: Other ITC Related Information",
@@ -393,7 +349,7 @@ frappe.ui.form.on(DOCTYPE, {
         frm.trigger("company");
 
         // Setup realtime listeners
-        frappe.realtime.on("gstr9_data_prepared", message => {
+        frappe.realtime.on("gstr9_data_prepared", (message) => {
             const { filters } = message;
 
             if (
@@ -402,14 +358,14 @@ frappe.ui.form.on(DOCTYPE, {
             )
                 return;
 
-            frm.taxpayer_api_call("generate_gstr9").then(r => {
+            frm.taxpayer_api_call("generate_gstr9").then((r) => {
                 if (!r.message) return;
                 frm.doc.__gst_data = r.message;
                 frm.trigger("load_gstr9_data");
             });
         });
 
-        frappe.realtime.on("gstr9_generation_failed", message => {
+        frappe.realtime.on("gstr9_generation_failed", (message) => {
             const { error, filters } = message;
             frappe.msgprint({
                 title: __("GSTR-9 Generation Failed"),
@@ -422,7 +378,7 @@ frappe.ui.form.on(DOCTYPE, {
             });
         });
 
-        frappe.realtime.on("show_missing_gst_credentials_message", message => {
+        frappe.realtime.on("show_missing_gst_credentials_message", (message) => {
             frappe.msgprint(message);
         });
 
@@ -497,7 +453,7 @@ class GSTR9 {
     refresh_data(data) {
         if (data) this.data = data;
 
-        this.TABS.forEach(_tab => {
+        this.TABS.forEach((_tab) => {
             const tab_name = _tab.name;
             const tab = this.tabs[`${tab_name}_tab`];
             const tab_data = this._get_tab_data(tab_name);
@@ -558,9 +514,7 @@ class GSTR9 {
         });
         this.tab_group.make();
 
-        this.tabs = Object.fromEntries(
-            this.tab_group.tabs.map(tab => [tab.df.fieldname, tab]),
-        );
+        this.tabs = Object.fromEntries(this.tab_group.tabs.map((tab) => [tab.df.fieldname, tab]));
 
         // Remove padding around content
         this.$wrapper.closest(".form-column").css("padding", "0px");
@@ -619,16 +573,13 @@ class GSTR9 {
                 const hsn_key = section.rows[0];
                 const hsn_row = row_map[hsn_key];
                 if (!hsn_row) continue;
-                const has_data =
-                    (hsn_row.goods?.length || 0) + (hsn_row.services?.length || 0) > 0;
+                const has_data = (hsn_row.goods?.length || 0) + (hsn_row.services?.length || 0) > 0;
                 if (!has_data) continue;
                 $wrapper.append(this._build_hsn_section_html(section.title, hsn_row));
                 continue;
             }
 
-            const section_rows = section.rows
-                .filter(key => row_map[key])
-                .map(key => row_map[key]);
+            const section_rows = section.rows.filter((key) => row_map[key]).map((key) => row_map[key]);
 
             if (!section_rows.length) continue;
 
@@ -641,7 +592,7 @@ class GSTR9 {
             const section_cols =
                 section.custom_columns ||
                 (section.hide_taxable_value
-                    ? AMOUNT_COLUMNS.filter(c => c.fieldname !== "taxable_value")
+                    ? AMOUNT_COLUMNS.filter((c) => c.fieldname !== "taxable_value")
                     : AMOUNT_COLUMNS);
 
             if (section.bifurcated_rows) {
@@ -656,12 +607,7 @@ class GSTR9 {
                 );
             } else {
                 $wrapper.append(
-                    this._build_section_html(
-                        section.title,
-                        section_rows,
-                        tab_name === "books",
-                        section_cols,
-                    ),
+                    this._build_section_html(section.title, section_rows, tab_name === "books", section_cols),
                 );
             }
         }
@@ -686,7 +632,7 @@ class GSTR9 {
             // For bifurcated sections, check sub-rows for differences
             let keys_to_check;
             if (section.bifurcated_rows) {
-                keys_to_check = section.rows.flatMap(key => {
+                keys_to_check = section.rows.flatMap((key) => {
                     const subs = section.bifurcated_rows[key];
                     return subs ? subs : [key];
                 });
@@ -694,13 +640,13 @@ class GSTR9 {
                 keys_to_check = section.rows;
             }
 
-            const section_diffs = keys_to_check.filter(key => comparison[key]);
+            const section_diffs = keys_to_check.filter((key) => comparison[key]);
             if (!section_diffs.length) continue;
 
             const cmp_cols =
                 section.custom_columns ||
                 (section.hide_taxable_value
-                    ? AMOUNT_COLUMNS.filter(c => c.fieldname !== "taxable_value")
+                    ? AMOUNT_COLUMNS.filter((c) => c.fieldname !== "taxable_value")
                     : AMOUNT_COLUMNS);
 
             html += `<div class="gstr9-section">
@@ -729,15 +675,21 @@ class GSTR9 {
                     <td rowspan="3" class="gstr9-col-desc">${__(desc)}</td>
                     <td class="gstr9-col-source"><span class="badge badge-info">${__("Books")}</span></td>`;
                 for (const col of cmp_cols) {
-                    html += `<td class="text-right">${format_currency(diff.books?.[col.fieldname] || 0)}</td>`;
+                    html += `<td class="text-right">${format_currency(
+                        diff.books?.[col.fieldname] || 0,
+                    )}</td>`;
                 }
                 html += `</tr>`;
 
                 // Portal row
                 html += `<tr class="gstr9-comparison-portal">
-                    <td class="gstr9-col-source"><span class="badge badge-warning">${__("Portal")}</span></td>`;
+                    <td class="gstr9-col-source"><span class="badge badge-warning">${__(
+                        "Portal",
+                    )}</span></td>`;
                 for (const col of cmp_cols) {
-                    html += `<td class="text-right">${format_currency(diff.portal?.[col.fieldname] || 0)}</td>`;
+                    html += `<td class="text-right">${format_currency(
+                        diff.portal?.[col.fieldname] || 0,
+                    )}</td>`;
                 }
                 html += `</tr>`;
 
@@ -759,13 +711,7 @@ class GSTR9 {
         $wrapper.html(html);
     }
 
-    _build_section_with_type_column_html(
-        section,
-        rows,
-        row_map,
-        is_books = false,
-        columns = AMOUNT_COLUMNS,
-    ) {
+    _build_section_with_type_column_html(section, rows, row_map, is_books = false, columns = AMOUNT_COLUMNS) {
         const bifurcated_rows = section.bifurcated_rows || {};
 
         let html = `<div class="gstr9-section">
@@ -826,13 +772,15 @@ class GSTR9 {
                     if (i > 0) html += `<tr>`;
 
                     // Use static ROW_DESCRIPTIONS as primary label (always available)
-                    const type_label =
-                        ROW_DESCRIPTIONS[sub_key] || sub_row.description || "";
+                    const type_label = ROW_DESCRIPTIONS[sub_key] || sub_row.description || "";
 
                     if (is_books && DETAIL_VIEW_ROWS.has(sub_key)) {
                         html += `<td><a href="#" class="gstr9-detail-link"
                             data-row-key="${sub_key}"
-                            data-description="${(row.description || "").replace(/"/g, "&quot;")} - ${type_label.replace(/"/g, "&quot;")}"
+                            data-description="${(row.description || "").replace(
+                                /"/g,
+                                "&quot;",
+                            )} - ${type_label.replace(/"/g, "&quot;")}"
                             >${__(type_label)}</a></td>`;
                     } else {
                         html += `<td>${__(type_label)}</td>`;
@@ -842,7 +790,9 @@ class GSTR9 {
                         if (sub_disabled?.has(col.fieldname)) {
                             html += `<td class="gstr9-cell-disabled"></td>`;
                         } else {
-                            html += `<td class="text-right">${format_currency(sub_row[col.fieldname] || 0)}</td>`;
+                            html += `<td class="text-right">${format_currency(
+                                sub_row[col.fieldname] || 0,
+                            )}</td>`;
                         }
                     }
 
@@ -912,8 +862,7 @@ class GSTR9 {
             const is_manual_entry = MANUAL_ENTRY_ROWS.has(row.row_key);
             let row_class = "";
             if (is_auto) row_class = "gstr9-row-auto";
-            else if (is_portal || is_not_supported || is_manual_entry)
-                row_class = "gstr9-row-portal";
+            else if (is_portal || is_not_supported || is_manual_entry) row_class = "gstr9-row-portal";
 
             html += `<tr class="${row_class}">
                 <td class="gstr9-col-sno">${row.row_key}</td>
@@ -995,7 +944,7 @@ class GSTR9 {
                     </thead>
                     <tbody>`;
 
-            rows.forEach(row => {
+            rows.forEach((row) => {
                 html += `<tr class="gstr9-row-portal">
                     <td>${row.row_label || ""}</td>
                     <td>${__(row.tax_head || "")}</td>
@@ -1111,11 +1060,7 @@ class GSTR9 {
             html += this._build_hsn_sub_table_html(__("Part A - Goods"), goods, false);
         }
         if (services.length) {
-            html += this._build_hsn_sub_table_html(
-                __("Part B - Services"),
-                services,
-                true,
-            );
+            html += this._build_hsn_sub_table_html(__("Part B - Services"), services, true);
         }
 
         html += `</div>`;
@@ -1196,7 +1141,7 @@ class GSTR9 {
     // ───── Detail view ─────
 
     _setup_detail_view_listeners() {
-        this.$wrapper.on("click", ".gstr9-detail-link", async e => {
+        this.$wrapper.on("click", ".gstr9-detail-link", async (e) => {
             e.preventDefault();
             const $link = $(e.currentTarget);
             const row_key = $link.data("row-key");
@@ -1235,11 +1180,7 @@ class GSTR9 {
             return;
         }
 
-        this._show_detail_dialog(
-            row_key,
-            description,
-            result || { is_purchase: false, data: [] },
-        );
+        this._show_detail_dialog(row_key, description, result || { is_purchase: false, data: [] });
     }
 
     _show_detail_dialog(row_key, description, result) {
@@ -1248,21 +1189,14 @@ class GSTR9 {
         if (!data || !data.length) {
             frappe.msgprint({
                 title: __("No Records"),
-                message: __("No records found for {0} — {1}", [
-                    row_key,
-                    __(description),
-                ]),
+                message: __("No records found for {0} — {1}", [row_key, __(description)]),
             });
             return;
         }
 
         const route = is_purchase ? "purchase-invoice" : "sales-invoice";
-        const party_gstin_label = is_purchase
-            ? __("Supplier GSTIN")
-            : __("Customer GSTIN");
-        const party_name_label = is_purchase
-            ? __("Supplier Name")
-            : __("Customer Name");
+        const party_gstin_label = is_purchase ? __("Supplier GSTIN") : __("Customer GSTIN");
+        const party_name_label = is_purchase ? __("Supplier Name") : __("Customer Name");
         const doc_label = is_purchase ? __("Bill No.") : __("Invoice No.");
         const class_label = is_purchase ? __("Classification") : __("Type");
 
@@ -1277,7 +1211,7 @@ class GSTR9 {
         const party_gstin_field = is_purchase ? "supplier_gstin" : "customer_gstin";
         const party_name_field = is_purchase ? "supplier_name" : "customer_name";
 
-        const rows = data.map(row => {
+        const rows = data.map((row) => {
             totals.total_taxable_value += row.total_taxable_value || 0;
             totals.total_igst_amount += row.total_igst_amount || 0;
             totals.total_cgst_amount += row.total_cgst_amount || 0;
@@ -1307,7 +1241,7 @@ class GSTR9 {
             "total_cess_amount",
         ]);
 
-        const fmt_currency = value => format_currency(value || 0);
+        const fmt_currency = (value) => format_currency(value || 0);
 
         const columns = [
             {
@@ -1322,7 +1256,9 @@ class GSTR9 {
                 field: "document_number",
                 width: 190,
                 format: (value, _row, _col, data) =>
-                    `<a href="/app/${data?.doc_route || route}/${encodeURIComponent(value || "")}" target="_blank">${frappe.utils.escape_html(value || "")}</a>`,
+                    `<a href="/app/${data?.doc_route || route}/${encodeURIComponent(
+                        value || "",
+                    )}" target="_blank">${frappe.utils.escape_html(value || "")}</a>`,
             },
             {
                 id: "party_gstin",
@@ -1438,7 +1374,7 @@ class GSTR9 {
 
         // Primary: Generate
         this.frm.page.set_primary_action(__("Generate"), () => {
-            this.frm.taxpayer_api_call("generate_gstr9").then(r => {
+            this.frm.taxpayer_api_call("generate_gstr9").then((r) => {
                 if (!r.message) return;
                 this.frm.doc.__gst_data = r.message;
                 this.frm.trigger("load_gstr9_data");
@@ -1452,7 +1388,7 @@ class GSTR9 {
                 this._recomputing = true;
                 this.frm
                     .taxpayer_api_call("recompute_books")
-                    .then(r => {
+                    .then((r) => {
                         if (!r.message) return;
                         this.frm.doc.__gst_data = r.message;
                         this.frm.trigger("load_gstr9_data");
@@ -1463,8 +1399,7 @@ class GSTR9 {
             });
 
             this.frm.add_custom_button(__("Export Books as Excel"), () => {
-                const url =
-                    "india_compliance.gst_india.doctype.gstr_9.gstr_9.export_gstr9_books_as_excel";
+                const url = "india_compliance.gst_india.doctype.gstr_9.gstr_9.export_gstr9_books_as_excel";
 
                 open_url_post(`/api/method/${url}`, {
                     company_gstin: this.frm.doc.company_gstin,
@@ -1475,7 +1410,7 @@ class GSTR9 {
             if (is_gstr9_api_enabled()) {
                 this.frm.add_custom_button(__("Download Portal Data"), () => {
                     frappe.show_alert(__("Downloading portal data from GSTN..."));
-                    this.frm.taxpayer_api_call("download_portal_data").then(r => {
+                    this.frm.taxpayer_api_call("download_portal_data").then((r) => {
                         if (!r.message) return;
                         this.frm.doc.__gst_data = r.message;
                         this.frm.trigger("load_gstr9_data");
@@ -1491,9 +1426,5 @@ class GSTR9 {
 }
 
 function is_gstr9_api_enabled() {
-    return (
-        india_compliance.is_api_enabled() &&
-        !gst_settings.sandbox_mode &&
-        gst_settings.enable_gstr_9_api
-    );
+    return india_compliance.is_api_enabled() && !gst_settings.sandbox_mode && gst_settings.enable_gstr_9_api;
 }

--- a/india_compliance/gst_india/doctype/gstr_9/gstr_9.js
+++ b/india_compliance/gst_india/doctype/gstr_9/gstr_9.js
@@ -1463,13 +1463,13 @@ class GSTR9 {
             });
 
             this.frm.add_custom_button(__("Export Books as Excel"), () => {
-                open_url_post(
-                    "/api/method/india_compliance.gst_india.doctype.gstr_9.gstr_9.export_gstr9_books_as_excel",
-                    {
-                        company_gstin: this.frm.doc.company_gstin,
-                        financial_year: this.frm.doc.financial_year,
-                    },
-                );
+                const url =
+                    "india_compliance.gst_india.doctype.gstr_9.gstr_9.export_gstr9_books_as_excel";
+
+                open_url_post(`/api/method/${url}`, {
+                    company_gstin: this.frm.doc.company_gstin,
+                    financial_year: this.frm.doc.financial_year,
+                });
             });
 
             if (is_gstr9_api_enabled()) {

--- a/india_compliance/gst_india/doctype/gstr_9/gstr_9.json
+++ b/india_compliance/gst_india/doctype/gstr_9/gstr_9.json
@@ -1,0 +1,113 @@
+{
+ "actions": [],
+ "creation": "2026-03-18 00:00:00",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "form",
+  "company",
+  "column_break_1",
+  "company_gstin",
+  "column_break_2",
+  "financial_year",
+  "data_section",
+  "tabs_html",
+  "tabs_empty_state",
+  "tabs_no_data"
+ ],
+ "fields": [
+  {
+   "fieldname": "form",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "company",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Company",
+   "options": "Company",
+   "reqd": 1
+  },
+  {
+   "fieldname": "column_break_1",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "company_gstin",
+   "fieldtype": "Autocomplete",
+   "label": "Company GSTIN",
+   "reqd": 1
+  },
+  {
+   "fieldname": "column_break_2",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "financial_year",
+   "fieldtype": "Select",
+   "label": "Financial Year",
+   "options": "\n2025-26\n2024-25\n2023-24\n2022-23",
+   "reqd": 1
+  },
+  {
+   "fieldname": "data_section",
+   "fieldtype": "Section Break"
+  },
+  {
+   "depends_on": "eval: doc.__gst_data && Object.keys(doc.__gst_data).length",
+   "fieldname": "tabs_html",
+   "fieldtype": "HTML"
+  },
+  {
+   "depends_on": "eval: !doc.__gst_data",
+   "fieldname": "tabs_empty_state",
+   "fieldtype": "HTML",
+   "options": "<img alt=\"No Data\" src=\"/assets/frappe/images/ui-states/list-empty-state.svg\">\n\t<p class=\"text-muted\">{{ __(\"Generate to view the data\") }}</p>"
+  },
+  {
+   "depends_on": "eval: doc.__gst_data && Object.keys(doc.__gst_data).length === 0",
+   "fieldname": "tabs_no_data",
+   "fieldtype": "HTML",
+   "options": "<img alt=\"No Data\" src=\"/assets/frappe/images/ui-states/list-empty-state.svg\">\n\t<p class=\"text-muted\">{{ __(\"No data available for selected filters\") }}</p>"
+  }
+ ],
+ "hide_toolbar": 1,
+ "index_web_pages_for_search": 1,
+ "issingle": 1,
+ "links": [],
+ "modified": "2026-04-07 12:18:49.082007",
+ "modified_by": "Administrator",
+ "module": "GST India",
+ "name": "GSTR-9",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "read": 1,
+   "role": "System Manager",
+   "write": 1
+  },
+  {
+   "create": 1,
+   "read": 1,
+   "role": "Accounts Manager",
+   "write": 1
+  },
+  {
+   "create": 1,
+   "read": 1,
+   "role": "Accounts User",
+   "write": 1
+  },
+  {
+   "create": 1,
+   "read": 1,
+   "role": "Auditor",
+   "write": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/india_compliance/gst_india/doctype/gstr_9/gstr_9.py
+++ b/india_compliance/gst_india/doctype/gstr_9/gstr_9.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, Resilient Tech and contributors
+# Copyright (c) 2026, Resilient Tech and contributors
 # For license information, please see license.txt
 
 import frappe
@@ -10,6 +10,7 @@ from india_compliance.gst_india.doctype.gst_return_log.gst_return_log import (
     get_gst_return_log,
 )
 from india_compliance.gst_india.utils.gstr_9 import (
+    PORTAL_SOURCED_ROWS,
     aggregate_books,
     compute_auto_rows,
     get_fy_dates,
@@ -73,9 +74,7 @@ class GSTR9(Document):
         """
         settings = frappe.get_cached_doc("GST Settings")
         if not settings.is_gstr9_api_enabled(self.company_gstin):
-            frappe.throw(
-                _("GSTR-9 API features are not enabled in GST Settings.")
-            )
+            frappe.throw(_("GSTR-9 API features are not enabled in GST Settings."))
         period = get_fy_period(self.financial_year)
         log_name = f"GSTR9-{period}-{self.company_gstin}"
 
@@ -84,7 +83,9 @@ class GSTR9(Document):
         books_data = gstr9_log.get_json_for("books")
         if not books_data:
             frappe.throw(
-                _("Please generate GSTR-9 books data first before downloading portal data.")
+                _(
+                    "Please generate GSTR-9 books data first before downloading portal data."
+                )
             )
 
         from_date, to_date = get_fy_dates(self.financial_year)
@@ -96,8 +97,7 @@ class GSTR9(Document):
             to_date=to_date,
         )
 
-        # Remove cached portal data to force fresh download
-        gstr9_log.remove_json_for("portal")
+        gstr9_log.remove_json_for("unfiled")
 
         portal_data = gstr9_log._get_gstr9_portal_data(filters)
         if not portal_data:
@@ -109,7 +109,14 @@ class GSTR9(Document):
             )
 
         row_data = aggregate_books(books_data)
+
+        # Merge portal-sourced rows into books before computing auto rows
+        for row_key in PORTAL_SOURCED_ROWS:
+            if row_key in portal_data:
+                row_data[row_key] = portal_data[row_key]
+
         compute_auto_rows(row_data)
+        compute_auto_rows(portal_data)
 
         gstr9_log._compare_books_and_portal(row_data, portal_data)
         gstr9_log._summarize_gstr9_data({"row_data": row_data, "portal": portal_data})
@@ -164,7 +171,7 @@ class GSTR9(Document):
 
 
 @frappe.whitelist()
-def get_gstr9_invoice_detail(company: str, company_gstin: str, financial_year: str, row_key: str):
+def get_gstr9_invoice_detail(company_gstin: str, financial_year: str, row_key: str):
     """
     Return individual invoice / bill records for the given GSTR-9 row.
     Reads from stored books data to ensure consistency with the generated snapshot.

--- a/india_compliance/gst_india/doctype/gstr_9/gstr_9.py
+++ b/india_compliance/gst_india/doctype/gstr_9/gstr_9.py
@@ -240,7 +240,6 @@ def export_gstr9_books_as_excel(company_gstin: str, financial_year: str):
 
     from india_compliance.gst_india.utils.exporter import ExcelExporter
     from india_compliance.gst_india.utils.gstr_9 import (
-        GSTR9_ROW_DESCRIPTION,
         PURCHASE_ROW_KEYS,
     )
 
@@ -282,14 +281,9 @@ def export_gstr9_books_as_excel(company_gstin: str, financial_year: str):
             continue
 
         is_purchase = row_key in PURCHASE_ROW_KEYS
-        description = GSTR9_ROW_DESCRIPTION.get(row_key, row_key)
-        # Excel sheet name: max 31 chars; use description truncated
-        sheet_name = description[:28] or row_key
-        # Avoid duplicate sheet names by appending row_key suffix
-        sheet_name = f"{sheet_name} ({row_key})"[:31]
 
         excel.create_sheet(
-            sheet_name=sheet_name,
+            sheet_name=row_key,
             headers=_get_invoice_excel_headers(is_purchase),
             data=rows,
             add_totals=False,
@@ -302,7 +296,7 @@ def export_gstr9_books_as_excel(company_gstin: str, financial_year: str):
             _("No invoice-level data found. Please regenerate GSTR-9 books data.")
         )
 
-    excel.export(f"GSTR-9 Books - {financial_year}")
+    excel.export(f"GSTR-9-Books-{company_gstin}-{financial_year}")
 
 
 def _get_invoice_excel_headers(is_purchase):

--- a/india_compliance/gst_india/doctype/gstr_9/gstr_9.py
+++ b/india_compliance/gst_india/doctype/gstr_9/gstr_9.py
@@ -1,0 +1,205 @@
+# Copyright (c) 2025, Resilient Tech and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe import _
+from frappe.model.document import Document
+
+from india_compliance.gst_india.api_classes.taxpayer_base import otp_handler
+from india_compliance.gst_india.doctype.gst_return_log.gst_return_log import (
+    get_gst_return_log,
+)
+from india_compliance.gst_india.utils.gstr_9 import (
+    aggregate_books,
+    compute_auto_rows,
+    get_fy_dates,
+    get_fy_period,
+)
+
+
+class GSTR9(Document):
+    @frappe.whitelist()
+    def generate_gstr9(self):
+        """
+        Permission check not required as user has access to doc.
+        Validates inputs and enqueues GSTR-9 data generation.
+        """
+        period = get_fy_period(self.financial_year)
+        log_name = f"GSTR9-{period}-{self.company_gstin}"
+
+        gstr9_log = get_gst_return_log(log_name, company=self.company)
+
+        if gstr9_log.status == "In Progress":
+            frappe.msgprint(
+                _("GSTR-9 is being prepared. Please wait for the process to complete."),
+                title=_("GSTR-9 Generation In Progress"),
+            )
+            return
+
+        if gstr9_log.is_latest_data and gstr9_log.get("books"):
+            data = gstr9_log.get_gstr9_data()
+            if data:
+                return data
+
+        gstr9_log.update_status("In Progress")
+        frappe.enqueue(
+            self._generate_gstr9,
+            queue="long",
+            enqueue_after_commit=True,
+        )
+
+        frappe.msgprint(_("GSTR-9 is being prepared"), alert=True)
+
+    @frappe.whitelist()
+    def recompute_books(self):
+        """
+        Permission check not required as user has access to doc.
+        Forces recomputation of books data.
+        """
+        period = get_fy_period(self.financial_year)
+        log_name = f"GSTR9-{period}-{self.company_gstin}"
+
+        gstr9_log = get_gst_return_log(log_name, company=self.company)
+        gstr9_log.remove_json_for("books")
+
+        return self.generate_gstr9()
+
+    @frappe.whitelist()
+    @otp_handler
+    def download_portal_data(self):
+        """
+        Download auto-drafted GSTR-9 data from GST portal, update comparison,
+        and return the merged data for frontend display.
+        """
+        settings = frappe.get_cached_doc("GST Settings")
+        if not settings.is_gstr9_api_enabled(self.company_gstin):
+            frappe.throw(
+                _("GSTR-9 API features are not enabled in GST Settings.")
+            )
+        period = get_fy_period(self.financial_year)
+        log_name = f"GSTR9-{period}-{self.company_gstin}"
+
+        gstr9_log = get_gst_return_log(log_name, company=self.company)
+
+        books_data = gstr9_log.get_json_for("books")
+        if not books_data:
+            frappe.throw(
+                _("Please generate GSTR-9 books data first before downloading portal data.")
+            )
+
+        from_date, to_date = get_fy_dates(self.financial_year)
+        filters = frappe._dict(
+            company=self.company,
+            company_gstin=self.company_gstin,
+            financial_year=self.financial_year,
+            from_date=from_date,
+            to_date=to_date,
+        )
+
+        # Remove cached portal data to force fresh download
+        gstr9_log.remove_json_for("portal")
+
+        portal_data = gstr9_log._get_gstr9_portal_data(filters)
+        if not portal_data:
+            frappe.throw(
+                _(
+                    "Failed to download portal data from GSTN. "
+                    "Please check your API connection and credentials."
+                )
+            )
+
+        row_data = aggregate_books(books_data)
+        compute_auto_rows(row_data)
+
+        gstr9_log._compare_books_and_portal(row_data, portal_data)
+        gstr9_log._summarize_gstr9_data({"row_data": row_data, "portal": portal_data})
+
+        return gstr9_log.get_gstr9_data()
+
+    def _generate_gstr9(self):
+        """Wrapper that runs in background queue."""
+        period = get_fy_period(self.financial_year)
+        log_name = f"GSTR9-{period}-{self.company_gstin}"
+        gstr9_log = get_gst_return_log(log_name, company=self.company)
+
+        from_date, to_date = get_fy_dates(self.financial_year)
+
+        filters = frappe._dict(
+            company=self.company,
+            company_gstin=self.company_gstin,
+            financial_year=self.financial_year,
+            from_date=from_date,
+            to_date=to_date,
+        )
+
+        try:
+            gstr9_log.generate_gstr9_data(filters, callback=self.on_generate)
+        except Exception as e:
+            gstr9_log.update_status("Failed", commit=True)
+
+            frappe.publish_realtime(
+                "gstr9_generation_failed",
+                message={"error": str(e), "filters": filters},
+                user=frappe.session.user,
+            )
+            raise
+
+    def on_generate(self, filters=None):
+        """Publish realtime event when generation completes."""
+        period = get_fy_period(self.financial_year)
+        log_name = f"GSTR9-{period}-{self.company_gstin}"
+
+        if frappe.db.exists("GST Return Log", log_name):
+            frappe.db.set_value(
+                "GST Return Log",
+                log_name,
+                {"generation_status": "Generated", "is_latest_data": 1},
+            )
+
+        frappe.publish_realtime(
+            "gstr9_data_prepared",
+            message={"filters": filters or self},
+            user=frappe.session.user,
+        )
+
+
+@frappe.whitelist()
+def get_gstr9_invoice_detail(company: str, company_gstin: str, financial_year: str, row_key: str):
+    """
+    Return individual invoice / bill records for the given GSTR-9 row.
+    Reads from stored books data to ensure consistency with the generated snapshot.
+    """
+    frappe.has_permission("GSTR-9", throw=True)
+
+    from india_compliance.gst_india.utils.gstr_9 import PURCHASE_ROW_KEYS
+
+    period = get_fy_period(financial_year)
+    log_name = f"GSTR9-{period}-{company_gstin}"
+
+    gstr9_log = get_gst_return_log(log_name)
+    books = gstr9_log.get_json_for("books")
+
+    if not books:
+        frappe.throw(_("Please generate GSTR-9 data first."))
+
+    # Parent rows (6B, 6C, 6D, 6E) combine sub-row invoice lists
+    _PARENT_SUB_ROWS = {
+        "6B": ["6B_ip", "6B_cg", "6B_is"],
+        "6C": ["6C_ip", "6C_cg", "6C_is"],
+        "6D": ["6D_ip", "6D_cg", "6D_is"],
+        "6E": ["6E_ip", "6E_cg"],
+    }
+
+    if row_key in _PARENT_SUB_ROWS:
+        invoices = []
+        for sub_key in _PARENT_SUB_ROWS[row_key]:
+            sub_value = books.get(sub_key, [])
+            if isinstance(sub_value, list):
+                invoices.extend(sub_value)
+        return {"is_purchase": row_key in PURCHASE_ROW_KEYS, "data": invoices}
+
+    value = books.get(row_key)
+    if isinstance(value, list):
+        return {"is_purchase": row_key in PURCHASE_ROW_KEYS, "data": value}
+
+    return {"is_purchase": False, "data": []}

--- a/india_compliance/gst_india/doctype/gstr_9/gstr_9.py
+++ b/india_compliance/gst_india/doctype/gstr_9/gstr_9.py
@@ -21,8 +21,7 @@ from india_compliance.gst_india.utils.gstr_9 import (
 class GSTR9(Document):
     @frappe.whitelist()
     def generate_gstr9(self):
-        """
-        Validate inputs and enqueue GSTR-9 data generation.
+        """Validate inputs and enqueue GSTR-9 data generation.
 
         Permission check not required as user already has access to the doc.
         """
@@ -174,6 +173,7 @@ class GSTR9(Document):
 def get_gstr9_invoice_detail(company_gstin: str, financial_year: str, row_key: str):
     """
     Return individual invoice / bill records for the given GSTR-9 row.
+
     Reads from stored books data to ensure consistency with the generated snapshot.
 
     Returns {"too_large": True} when the compressed books file exceeds
@@ -240,6 +240,7 @@ def export_gstr9_books_as_excel(company_gstin: str, financial_year: str):
 
     from india_compliance.gst_india.utils.exporter import ExcelExporter
     from india_compliance.gst_india.utils.gstr_9 import (
+        GSTR9_ROW_DESCRIPTION,
         PURCHASE_ROW_KEYS,
     )
 
@@ -257,7 +258,10 @@ def export_gstr9_books_as_excel(company_gstin: str, financial_year: str):
         excel.remove_sheet("Sheet")
 
     sheets_written = 0
-    for row_key, value in books.items():
+    for row_key in GSTR9_ROW_DESCRIPTION:
+        value = books.get(row_key)
+        if value is None:
+            continue
         # Only drillable rows: {doc_num: invoice_dict}
         if not isinstance(value, dict):
             continue

--- a/india_compliance/gst_india/doctype/gstr_9/gstr_9.py
+++ b/india_compliance/gst_india/doctype/gstr_9/gstr_9.py
@@ -22,8 +22,9 @@ class GSTR9(Document):
     @frappe.whitelist()
     def generate_gstr9(self):
         """
-        Permission check not required as user has access to doc.
-        Validates inputs and enqueues GSTR-9 data generation.
+        Validate inputs and enqueue GSTR-9 data generation.
+
+        Permission check not required as user already has access to the doc.
         """
         period = get_fy_period(self.financial_year)
         log_name = f"GSTR9-{period}-{self.company_gstin}"
@@ -54,8 +55,9 @@ class GSTR9(Document):
     @frappe.whitelist()
     def recompute_books(self):
         """
-        Permission check not required as user has access to doc.
-        Forces recomputation of books data.
+        Force recomputation of books data.
+
+        Permission check not required as user has access to the doc.
         """
         period = get_fy_period(self.financial_year)
         log_name = f"GSTR9-{period}-{self.company_gstin}"
@@ -69,8 +71,10 @@ class GSTR9(Document):
     @otp_handler
     def download_portal_data(self):
         """
-        Download auto-drafted GSTR-9 data from GST portal, update comparison,
-        and return the merged data for frontend display.
+        Download auto-drafted GSTR-9 data and refresh comparison.
+
+        Fetches portal data for the given company GSTIN, merges portal-sourced
+        rows, recomputes auto rows, and returns merged data for frontend display.
         """
         settings = frappe.get_cached_doc("GST Settings")
         if not settings.is_gstr9_api_enabled(self.company_gstin):
@@ -82,11 +86,7 @@ class GSTR9(Document):
 
         books_data = gstr9_log.get_json_for("books")
         if not books_data:
-            frappe.throw(
-                _(
-                    "Please generate GSTR-9 books data first before downloading portal data."
-                )
-            )
+            frappe.throw(_("Please generate GSTR-9 books data first before downloading portal data."))
 
         from_date, to_date = get_fy_dates(self.financial_year)
         filters = frappe._dict(
@@ -186,7 +186,7 @@ def get_gstr9_invoice_detail(company_gstin: str, financial_year: str, row_key: s
     )
     from india_compliance.gst_india.utils.gstr_9 import PURCHASE_ROW_KEYS
 
-    BOOKS_EXPORT_THRESHOLD = 200 * 1024  # 200 KB compressed
+    BOOKS_EXPORT_THRESHOLD = 200 * 1024  #    b compressed
 
     period = get_fy_period(financial_year)
     log_name = f"GSTR9-{period}-{company_gstin}"
@@ -292,9 +292,7 @@ def export_gstr9_books_as_excel(company_gstin: str, financial_year: str):
         sheets_written += 1
 
     if not sheets_written:
-        frappe.throw(
-            _("No invoice-level data found. Please regenerate GSTR-9 books data.")
-        )
+        frappe.throw(_("No invoice-level data found. Please regenerate GSTR-9 books data."))
 
     excel.export(f"GSTR-9-Books-{company_gstin}-{financial_year}")
 

--- a/india_compliance/gst_india/doctype/gstr_9/gstr_9.py
+++ b/india_compliance/gst_india/doctype/gstr_9/gstr_9.py
@@ -175,13 +175,28 @@ def get_gstr9_invoice_detail(company_gstin: str, financial_year: str, row_key: s
     """
     Return individual invoice / bill records for the given GSTR-9 row.
     Reads from stored books data to ensure consistency with the generated snapshot.
+
+    Returns {"too_large": True} when the compressed books file exceeds
+    BOOKS_EXPORT_THRESHOLD — the caller should prompt for Excel export instead.
     """
     frappe.has_permission("GSTR-9", throw=True)
 
+    from india_compliance.gst_india.doctype.gst_return_log.gst_return_log import (
+        get_file_doc,
+    )
     from india_compliance.gst_india.utils.gstr_9 import PURCHASE_ROW_KEYS
+
+    BOOKS_EXPORT_THRESHOLD = 200 * 1024  # 200 KB compressed
 
     period = get_fy_period(financial_year)
     log_name = f"GSTR9-{period}-{company_gstin}"
+
+    books_file = get_file_doc("GST Return Log", log_name, "books")
+    if not books_file:
+        frappe.throw(_("Please generate GSTR-9 data first."))
+
+    if (books_file.file_size or 0) > BOOKS_EXPORT_THRESHOLD:
+        return {"too_large": True}
 
     gstr9_log = get_gst_return_log(log_name)
     books = gstr9_log.get_json_for("books")
@@ -189,7 +204,7 @@ def get_gstr9_invoice_detail(company_gstin: str, financial_year: str, row_key: s
     if not books:
         frappe.throw(_("Please generate GSTR-9 data first."))
 
-    # Parent rows (6B, 6C, 6D, 6E) combine sub-row invoice lists
+    # Parent rows (6B, 6C, 6D, 6E) combine sub-row invoice dicts
     _PARENT_SUB_ROWS = {
         "6B": ["6B_ip", "6B_cg", "6B_is"],
         "6C": ["6C_ip", "6C_cg", "6C_is"],
@@ -200,13 +215,217 @@ def get_gstr9_invoice_detail(company_gstin: str, financial_year: str, row_key: s
     if row_key in _PARENT_SUB_ROWS:
         invoices = []
         for sub_key in _PARENT_SUB_ROWS[row_key]:
-            sub_value = books.get(sub_key, [])
-            if isinstance(sub_value, list):
-                invoices.extend(sub_value)
+            sub_value = books.get(sub_key) or {}
+            if isinstance(sub_value, dict):
+                invoices.extend(sub_value.values())
         return {"is_purchase": row_key in PURCHASE_ROW_KEYS, "data": invoices}
 
     value = books.get(row_key)
-    if isinstance(value, list):
-        return {"is_purchase": row_key in PURCHASE_ROW_KEYS, "data": value}
+    if isinstance(value, dict) and value:
+        return {
+            "is_purchase": row_key in PURCHASE_ROW_KEYS,
+            "data": list(value.values()),
+        }
 
     return {"is_purchase": False, "data": []}
+
+
+@frappe.whitelist()
+def export_gstr9_books_as_excel(company_gstin: str, financial_year: str):
+    """
+    Export all invoice-level books data as a single Excel workbook.
+    Each drillable GSTR-9 row becomes one sheet.
+    """
+    frappe.has_permission("GSTR-9", throw=True)
+
+    from india_compliance.gst_india.utils.exporter import ExcelExporter
+    from india_compliance.gst_india.utils.gstr_9 import (
+        GSTR9_ROW_DESCRIPTION,
+        PURCHASE_ROW_KEYS,
+    )
+
+    period = get_fy_period(financial_year)
+    log_name = f"GSTR9-{period}-{company_gstin}"
+
+    gstr9_log = get_gst_return_log(log_name)
+    books = gstr9_log.get_json_for("books")
+
+    if not books:
+        frappe.throw(_("Please generate GSTR-9 data first."))
+
+    excel = ExcelExporter()
+    if excel.has_sheet("Sheet"):
+        excel.remove_sheet("Sheet")
+
+    sheets_written = 0
+    for row_key, value in books.items():
+        # Only drillable rows: {doc_num: invoice_dict}
+        if not isinstance(value, dict):
+            continue
+        first_val = next(iter(value.values()), None)
+        if not (isinstance(first_val, dict) and "total_taxable_value" in first_val):
+            continue
+        invoices = list(value.values())
+
+        if not invoices:
+            continue
+
+        # Flatten to one row per item (per tax-rate group) — GSTR-1 pattern
+        rows = []
+        for inv in invoices:
+            for it in inv.get("items", []):
+                row = {**inv}
+                row.update(it)
+                rows.append(row)
+
+        if not rows:
+            continue
+
+        is_purchase = row_key in PURCHASE_ROW_KEYS
+        description = GSTR9_ROW_DESCRIPTION.get(row_key, row_key)
+        # Excel sheet name: max 31 chars; use description truncated
+        sheet_name = description[:28] or row_key
+        # Avoid duplicate sheet names by appending row_key suffix
+        sheet_name = f"{sheet_name} ({row_key})"[:31]
+
+        excel.create_sheet(
+            sheet_name=sheet_name,
+            headers=_get_invoice_excel_headers(is_purchase),
+            data=rows,
+            add_totals=False,
+            default_data_format={"height": 15},
+        )
+        sheets_written += 1
+
+    if not sheets_written:
+        frappe.throw(
+            _("No invoice-level data found. Please regenerate GSTR-9 books data.")
+        )
+
+    excel.export(f"GSTR-9 Books - {financial_year}")
+
+
+def _get_invoice_excel_headers(is_purchase):
+    party_gstin_fieldname = "supplier_gstin" if is_purchase else "customer_gstin"
+    party_name_fieldname = "supplier_name" if is_purchase else "customer_name"
+    party_gstin_label = "Supplier GSTIN" if is_purchase else "Customer GSTIN"
+    party_name_label = "Supplier Name" if is_purchase else "Customer Name"
+    doc_label = "Bill No." if is_purchase else "Invoice No."
+
+    headers = [
+        {
+            "label": _("Transaction Type"),
+            "fieldname": "transaction_type",
+            "header_format": {"width": 18},
+        },
+        {
+            "label": _("Date"),
+            "fieldname": "document_date",
+            "header_format": {"width": 14},
+        },
+        {
+            "label": _(doc_label),
+            "fieldname": "document_number",
+            "header_format": {"width": 25},
+        },
+        {
+            "label": _(party_gstin_label),
+            "fieldname": party_gstin_fieldname,
+            "header_format": {"width": 22},
+        },
+        {
+            "label": _(party_name_label),
+            "fieldname": party_name_fieldname,
+            "header_format": {"width": 30},
+        },
+        {
+            "label": _("Document Type"),
+            "fieldname": "gst_category",
+            "header_format": {"width": 22},
+        },
+    ]
+
+    if not is_purchase:
+        headers += [
+            {
+                "label": _("Shipping Bill Number"),
+                "fieldname": "shipping_bill_number",
+                "header_format": {"width": 22},
+            },
+            {
+                "label": _("Shipping Bill Date"),
+                "fieldname": "shipping_bill_date",
+                "header_format": {"width": 16},
+            },
+            {
+                "label": _("Port Code"),
+                "fieldname": "port_code",
+                "header_format": {"width": 14},
+            },
+        ]
+
+    headers += [
+        {
+            "label": _("Reverse Charge"),
+            "fieldname": "reverse_charge",
+            "header_format": {"width": 14},
+        },
+        {
+            "label": _("Place of Supply"),
+            "fieldname": "place_of_supply",
+            "header_format": {"width": 18},
+        },
+        {
+            "label": _("Tax Rate (%)"),
+            "fieldname": "tax_rate",
+            "header_format": {"width": 12},
+            "data_format": {"number_format": "#,##0.00"},
+        },
+        {
+            "label": _("Taxable Value"),
+            "fieldname": "taxable_value",
+            "header_format": {"width": 18},
+            "data_format": {"number_format": "#,##0.00"},
+        },
+        {
+            "label": _("IGST"),
+            "fieldname": "igst_amount",
+            "header_format": {"width": 14},
+            "data_format": {"number_format": "#,##0.00"},
+        },
+        {
+            "label": _("CGST"),
+            "fieldname": "cgst_amount",
+            "header_format": {"width": 14},
+            "data_format": {"number_format": "#,##0.00"},
+        },
+        {
+            "label": _("SGST"),
+            "fieldname": "sgst_amount",
+            "header_format": {"width": 14},
+            "data_format": {"number_format": "#,##0.00"},
+        },
+        {
+            "label": _("Cess"),
+            "fieldname": "cess_amount",
+            "header_format": {"width": 14},
+            "data_format": {"number_format": "#,##0.00"},
+        },
+        {
+            "label": _("Document Value"),
+            "fieldname": "document_value",
+            "header_format": {"width": 18},
+            "data_format": {"number_format": "#,##0.00"},
+        },
+    ]
+
+    if is_purchase:
+        headers.append(
+            {
+                "label": _("ITC Classification"),
+                "fieldname": "itc_classification",
+                "header_format": {"width": 22},
+            }
+        )
+
+    return headers

--- a/india_compliance/gst_india/doctype/gstr_9/test_gstr_9.py
+++ b/india_compliance/gst_india/doctype/gstr_9/test_gstr_9.py
@@ -4,17 +4,6 @@
 # import frappe
 from frappe.tests import IntegrationTestCase
 
-# On IntegrationTestCase, the doctype test records and all
-# link-field test record dependencies are recursively loaded
-# Use these module variables to add/remove to/from that list
-EXTRA_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
-IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
-
 
 class IntegrationTestGSTR9(IntegrationTestCase):
-    """
-    Integration tests for GSTR9.
-    Use this class for testing interactions between multiple components.
-    """
-
     pass

--- a/india_compliance/gst_india/doctype/gstr_9/test_gstr_9.py
+++ b/india_compliance/gst_india/doctype/gstr_9/test_gstr_9.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2026, Resilient Tech and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests import IntegrationTestCase
+
+# On IntegrationTestCase, the doctype test records and all
+# link-field test record dependencies are recursively loaded
+# Use these module variables to add/remove to/from that list
+EXTRA_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+
+
+class IntegrationTestGSTR9(IntegrationTestCase):
+    """
+    Integration tests for GSTR9.
+    Use this class for testing interactions between multiple components.
+    """
+
+    pass

--- a/india_compliance/gst_india/utils/gstr_9/__init__.py
+++ b/india_compliance/gst_india/utils/gstr_9/__init__.py
@@ -448,27 +448,43 @@ def aggregate_books(books):
     """
     Aggregate invoice-level books data into row-level amount dicts.
 
-    - list of invoice dicts → sum AMOUNT_FIELDS across invoices
-    - empty list            → _empty_row()
-    - dict with amount keys → pass through (already aggregated)
-    - other (Table 14/15/17/18 structures) → pass through
+    Books format:
+      {row_key: {doc_number: invoice_dict}}  — drillable invoice rows
+      {row_key: {amount_fields}}             — already-aggregated rows
+      {row_key: list}                        — Table 14/15/17/18 structures
 
-    Credit note rows (4I, 5H) have their sign flipped after summation so the stored value is a positive absolute amount (portal convention).
+    For drillable rows the invoice dicts are summed across AMOUNT_FIELDS.
+    Credit note rows (4I, 5H) have their sign flipped after summation so
+    the stored value is a positive absolute amount (portal convention).
     """
     from frappe.utils import flt
 
     result = {}
     for row_key, value in books.items():
-        if isinstance(value, list):
-            if not value:
+        if isinstance(value, dict):
+            first_val = next(iter(value.values()), None)
+            if first_val is None:
+                # empty invoice dict → empty row
                 result[row_key] = _empty_row()
-            elif isinstance(value[0], dict) and "taxable_value" in value[0]:
+            elif isinstance(first_val, dict) and "total_taxable_value" in first_val:
+                # Drillable row: {doc_num: inv_dict} with total_* amount fields
                 row = _empty_row()
-                for inv in value:
-                    for field in AMOUNT_FIELDS:
-                        row[field] += flt(inv.get(field, 0))
+                for inv in value.values():
+                    row["taxable_value"] += flt(inv.get("total_taxable_value", 0))
+                    row["igst"] += flt(inv.get("total_igst_amount", 0))
+                    row["cgst"] += flt(inv.get("total_cgst_amount", 0))
+                    row["sgst"] += flt(inv.get("total_sgst_amount", 0))
+                    row["cess"] += flt(inv.get("total_cess_amount", 0))
                 result[row_key] = row
             else:
+                # Already aggregated ({field: value}) or
+                # Table 17/18 ({"goods": [...], "services": [...]}) — pass through
+                result[row_key] = value
+        elif isinstance(value, list):
+            if not value:
+                result[row_key] = _empty_row()
+            else:
+                # Table 14/15 structured lists — pass through
                 result[row_key] = value
         else:
             result[row_key] = value

--- a/india_compliance/gst_india/utils/gstr_9/__init__.py
+++ b/india_compliance/gst_india/utils/gstr_9/__init__.py
@@ -1,0 +1,512 @@
+# Copyright (c) 2026, Resilient Tech and contributors
+# For license information, please see license.txt
+
+
+class GSTR9_Row:
+    # Table 4 - Outward supplies (tax payable)
+    TABLE_4A = "4A"
+    TABLE_4B = "4B"
+    TABLE_4C = "4C"
+    TABLE_4D = "4D"
+    TABLE_4E = "4E"
+    TABLE_4F = "4F"
+    TABLE_4G = "4G"
+    TABLE_4G1 = "4G1"
+    TABLE_4H = "4H"
+    TABLE_4I = "4I"
+    TABLE_4J = "4J"
+    TABLE_4K = "4K"
+    TABLE_4L = "4L"
+    TABLE_4M = "4M"
+    TABLE_4N = "4N"
+
+    # Table 5 - Outward supplies (tax not payable)
+    TABLE_5A = "5A"
+    TABLE_5B = "5B"
+    TABLE_5C = "5C"
+    TABLE_5C1 = "5C1"
+    TABLE_5D = "5D"
+    TABLE_5E = "5E"
+    TABLE_5F = "5F"
+    TABLE_5G = "5G"
+    TABLE_5H = "5H"
+    TABLE_5I = "5I"
+    TABLE_5J = "5J"
+    TABLE_5K = "5K"
+    TABLE_5L = "5L"
+    TABLE_5M = "5M"
+    TABLE_5N = "5N"
+
+    # Table 6 - ITC availed
+    TABLE_6A = "6A"
+    TABLE_6A1 = "6A1"
+    TABLE_6A2 = "6A2"
+    TABLE_6B = "6B"
+    TABLE_6B_INPUTS = "6B_ip"
+    TABLE_6B_CAPITAL_GOODS = "6B_cg"
+    TABLE_6B_INPUT_SERVICES = "6B_is"
+    TABLE_6C = "6C"
+    TABLE_6C_INPUTS = "6C_ip"
+    TABLE_6C_CAPITAL_GOODS = "6C_cg"
+    TABLE_6C_INPUT_SERVICES = "6C_is"
+    TABLE_6D = "6D"
+    TABLE_6D_INPUTS = "6D_ip"
+    TABLE_6D_CAPITAL_GOODS = "6D_cg"
+    TABLE_6D_INPUT_SERVICES = "6D_is"
+    TABLE_6E = "6E"
+    TABLE_6E_INPUTS = "6E_ip"
+    TABLE_6E_CAPITAL_GOODS = "6E_cg"
+    TABLE_6F = "6F"
+    TABLE_6G = "6G"
+    TABLE_6H = "6H"
+    TABLE_6I = "6I"
+    TABLE_6J = "6J"
+    TABLE_6K = "6K"
+    TABLE_6L = "6L"
+    TABLE_6M = "6M"
+    TABLE_6N = "6N"
+    TABLE_6O = "6O"
+
+    # Table 7 - ITC reversed
+    TABLE_7A = "7A"
+    TABLE_7A1 = "7A1"
+    TABLE_7A2 = "7A2"
+    TABLE_7B = "7B"
+    TABLE_7C = "7C"
+    TABLE_7D = "7D"
+    TABLE_7E = "7E"
+    TABLE_7F = "7F"
+    TABLE_7G = "7G"
+    TABLE_7H1 = "7H1"
+    TABLE_7I = "7I"
+    TABLE_7J = "7J"
+
+    # Table 8 - Other ITC
+    TABLE_8A = "8A"
+    TABLE_8B = "8B"
+    TABLE_8C = "8C"
+    TABLE_8D = "8D"
+    TABLE_8E = "8E"
+    TABLE_8F = "8F"
+    TABLE_8G = "8G"
+    TABLE_8H = "8H"
+    TABLE_8H1 = "8H1"
+    TABLE_8I = "8I"
+    TABLE_8J = "8J"
+    TABLE_8K = "8K"
+
+    # Table 9 - Tax paid (portal auto-filled, non-editable)
+    TABLE_9 = "9"
+
+    # Tables 10-14 - Previous year (manual)
+    TABLE_10 = "10"
+    TABLE_11 = "11"
+    TABLE_10_11_TURNOVER = "10_11_turnover"  # auto-computed: 5N + 10 - 11
+    TABLE_12 = "12"
+    TABLE_13 = "13"
+    TABLE_14 = "14"
+    TABLE_14A = "14A"  # Integrated Tax sub-row
+    TABLE_14B = "14B"  # Central Tax sub-row
+    TABLE_14C = "14C"  # State/UT Tax sub-row
+    TABLE_14D = "14D"  # Cess sub-row
+    TABLE_14E = "14E"  # Interest sub-row
+
+    # Tables 15-16 - Demands/Refunds, Composition (manual, optional)
+    TABLE_15 = "15"  # nested list of 15A-15G sub-rows
+    TABLE_16A = "16A"
+    TABLE_16B = "16B"
+    TABLE_16C = "16C"
+
+    # Tables 17-18 - HSN
+    TABLE_17 = "17"
+    TABLE_18 = "18"
+
+
+# Row descriptions for display
+GSTR9_ROW_DESCRIPTION = {
+    GSTR9_Row.TABLE_4A: "Supplies made to un-registered persons (B2C)",
+    GSTR9_Row.TABLE_4B: "Supplies made to registered persons (B2B)",
+    GSTR9_Row.TABLE_4C: "Zero rated supply (Export) on payment of tax (except supplies to SEZs)",
+    GSTR9_Row.TABLE_4D: "Supply to SEZs on payment of tax",
+    GSTR9_Row.TABLE_4E: "Deemed Exports",
+    GSTR9_Row.TABLE_4F: "Advances on which tax has been paid but invoice has not been issued (not covered under (4A) to (4E) above)",
+    GSTR9_Row.TABLE_4G: "Inward supplies on which tax is to be paid on reverse charge basis",
+    GSTR9_Row.TABLE_4G1: "Supplies on which e-commerce operator is required to pay tax u/s 9(5) [Operator to report]",
+    GSTR9_Row.TABLE_4H: "Sub-total (4A to 4G1)",
+    GSTR9_Row.TABLE_4I: "Credit Notes issued in respect of transactions in (4B) to (4E)",
+    GSTR9_Row.TABLE_4J: "Debit Notes issued in respect of transactions in (4B) to (4E)",
+    GSTR9_Row.TABLE_4K: "Supplies / tax declared through Amendments (+)",
+    GSTR9_Row.TABLE_4L: "Supplies / tax declared through Amendments (-)",
+    GSTR9_Row.TABLE_4M: "Sub-total (4I to 4L)",
+    GSTR9_Row.TABLE_4N: "Supplies and advances on which tax is to be paid (4H + 4M) above",
+    GSTR9_Row.TABLE_5A: "Zero rated supply (Export) without payment of tax",
+    GSTR9_Row.TABLE_5B: "Supply to SEZs without payment of tax",
+    GSTR9_Row.TABLE_5C: "Supplies on which tax is to be paid by the recipient on reverse charge basis",
+    GSTR9_Row.TABLE_5C1: "Supplies on which tax is to be paid by e-commerce operators u/s 9(5) [Supplier to report]",
+    GSTR9_Row.TABLE_5D: "Exempted",
+    GSTR9_Row.TABLE_5E: "Nil Rated",
+    GSTR9_Row.TABLE_5F: "Non-GST supply (includes 'no supply')",
+    GSTR9_Row.TABLE_5G: "Sub-total (5A to 5F)",
+    GSTR9_Row.TABLE_5H: "Credit Notes issued in respect of transactions in (5A) to (5F)",
+    GSTR9_Row.TABLE_5I: "Debit Notes issued in respect of transactions in (5A) to (5F)",
+    GSTR9_Row.TABLE_5J: "Supplies declared through Amendments (+)",
+    GSTR9_Row.TABLE_5K: "Supplies declared through Amendments (-)",
+    GSTR9_Row.TABLE_5L: "Sub-total (5H to 5K)",
+    GSTR9_Row.TABLE_5M: "Turnover on which tax is not to be paid  (5G + 5L) above",
+    GSTR9_Row.TABLE_5N: "Total Turnover (including advances) (4N + 5M - 4G - 4G1)",
+    GSTR9_Row.TABLE_6A: "Total amount of input tax credit availed through FORM GSTR-3B (Sum total of table 4A of FORM GSTR-3B)",
+    GSTR9_Row.TABLE_6A1: "ITC of any preceding financial year availed in the financial year (which is included in 6A above) other than reclaim",
+    GSTR9_Row.TABLE_6A2: "Net ITC of the financial year (A-A1)",
+    GSTR9_Row.TABLE_6B: "Inward supplies (other than imports and inward supplies liable to reverse charge but includes services received from SEZs)",
+    GSTR9_Row.TABLE_6B_INPUTS: "Inputs",
+    GSTR9_Row.TABLE_6B_CAPITAL_GOODS: "Capital Goods",
+    GSTR9_Row.TABLE_6B_INPUT_SERVICES: "Input Services",
+    GSTR9_Row.TABLE_6C: "Inward supplies received from unregistered persons liable to reverse charge (other than B above) on which tax is paid & ITC availed",
+    GSTR9_Row.TABLE_6C_INPUTS: "Inputs",
+    GSTR9_Row.TABLE_6C_CAPITAL_GOODS: "Capital Goods",
+    GSTR9_Row.TABLE_6C_INPUT_SERVICES: "Input Services",
+    GSTR9_Row.TABLE_6D: "Inward supplies received from registered persons liable to reverse charge (other than B above) on which tax is paid and ITC availed",
+    GSTR9_Row.TABLE_6D_INPUTS: "Inputs",
+    GSTR9_Row.TABLE_6D_CAPITAL_GOODS: "Capital Goods",
+    GSTR9_Row.TABLE_6D_INPUT_SERVICES: "Input Services",
+    GSTR9_Row.TABLE_6E: "Import of goods (including supplies from SEZ)",
+    GSTR9_Row.TABLE_6E_INPUTS: "Inputs",
+    GSTR9_Row.TABLE_6E_CAPITAL_GOODS: "Capital Goods",
+    GSTR9_Row.TABLE_6F: "Import of services (excluding inward supplies from SEZs)",
+    GSTR9_Row.TABLE_6G: "Input Tax credit received from ISD",
+    GSTR9_Row.TABLE_6H: "Amount of ITC reclaimed under the provisions of the Act",
+    GSTR9_Row.TABLE_6I: "Sub-total (B to H above)",
+    GSTR9_Row.TABLE_6J: "Difference (I - A2 above)",
+    GSTR9_Row.TABLE_6K: "Transition Credit through TRAN-1 (including revisions if any)",
+    GSTR9_Row.TABLE_6L: "Transition Credit through TRAN-2",
+    GSTR9_Row.TABLE_6M: "ITC availed through ITC-01, ITC-02, and ITC-02A (other than GSTR-3B and TRAN Forms)",
+    GSTR9_Row.TABLE_6N: "Sub-total (K to M above)",
+    GSTR9_Row.TABLE_6O: "Total ITC availed (I + N) above",
+    GSTR9_Row.TABLE_7A: "As per Rule 37",
+    GSTR9_Row.TABLE_7A1: "As per Rule 37A",
+    GSTR9_Row.TABLE_7A2: "As per Rule 38",
+    GSTR9_Row.TABLE_7B: "As per Rule 39",
+    GSTR9_Row.TABLE_7C: "As per Rule 42",
+    GSTR9_Row.TABLE_7D: "As per Rule 43",
+    GSTR9_Row.TABLE_7E: "As per section 17(5)",
+    GSTR9_Row.TABLE_7F: "Reversal of TRAN-I credit",
+    GSTR9_Row.TABLE_7G: "Reversal of TRAN-II credit",
+    GSTR9_Row.TABLE_7H1: "Other reversals (specify)",
+    GSTR9_Row.TABLE_7I: "Total ITC Reversed (A to H)",
+    GSTR9_Row.TABLE_7J: "Net ITC Available for Utilization (6O - 7I)",
+    GSTR9_Row.TABLE_8A: "ITC as per GSTR-2B",
+    GSTR9_Row.TABLE_8B: "ITC as per sum total of 6B above",
+    GSTR9_Row.TABLE_8C: "ITC on inward supplies (other than imports and inward supplies liable to reverse charge but includes services received from SEZs) received during the financial year but availed in the next financial year upto specified period",
+    GSTR9_Row.TABLE_8D: "Difference [8A - (8B + 8C)]",
+    GSTR9_Row.TABLE_8E: "ITC available but not availed",
+    GSTR9_Row.TABLE_8F: "ITC available but ineligible",
+    GSTR9_Row.TABLE_8G: "IGST paid  on import of goods (including supplies from SEZ)",
+    GSTR9_Row.TABLE_8H: "IGST credit availed on import of goods (as per 6(E) above) in financial year",
+    GSTR9_Row.TABLE_8H1: "IGST Credit availed on Import of goods in next financial year",
+    GSTR9_Row.TABLE_8I: "Difference (8G - 8H - 8H1)",
+    GSTR9_Row.TABLE_8J: "ITC available but not availed on import of goods (Equal to 8I)",
+    GSTR9_Row.TABLE_8K: "Total ITC to be lapsed in current financial year (8E + 8F + 8J)",
+    GSTR9_Row.TABLE_9: "Details of tax paid as declared in returns filed during the financial year",
+    GSTR9_Row.TABLE_10: "Supplies / tax declared through Debit Notes (+)",
+    GSTR9_Row.TABLE_11: "Supplies / tax reduced through Credit Notes (-)",
+    GSTR9_Row.TABLE_10_11_TURNOVER: "Total Turnover (5N + 10 - 11)",
+    GSTR9_Row.TABLE_12: "Reversal of ITC availed during previous financial year",
+    GSTR9_Row.TABLE_13: "ITC availed for the previous financial year",
+    GSTR9_Row.TABLE_14: "Differential tax paid on account of declaration in Table 10 & 11",
+    GSTR9_Row.TABLE_15: "Particulars of Demands and Refunds",
+    GSTR9_Row.TABLE_16A: "Inward supplies received from composition taxpayers",
+    GSTR9_Row.TABLE_16B: "Deemed supply under Section 143(3) and (5) by Job Worker",
+    GSTR9_Row.TABLE_16C: "Goods sent on approval basis but not returned within 6 months",
+    GSTR9_Row.TABLE_17: "HSN-wise summary of outward supplies",
+    GSTR9_Row.TABLE_18: "HSN-wise summary of inward supplies",
+}
+
+# Rows sourced from portal (non-editable, require download)
+PORTAL_SOURCED_ROWS = frozenset(
+    {GSTR9_Row.TABLE_6A, GSTR9_Row.TABLE_8A, GSTR9_Row.TABLE_9}
+)
+
+# Rows whose invoice detail comes from Purchase Invoices / BOE (not Sales Invoices)
+PURCHASE_ROW_KEYS = frozenset(
+    {
+        GSTR9_Row.TABLE_4G,
+        GSTR9_Row.TABLE_6B,
+        GSTR9_Row.TABLE_6B_INPUTS,
+        GSTR9_Row.TABLE_6B_CAPITAL_GOODS,
+        GSTR9_Row.TABLE_6B_INPUT_SERVICES,
+        GSTR9_Row.TABLE_6C,
+        GSTR9_Row.TABLE_6C_INPUTS,
+        GSTR9_Row.TABLE_6C_CAPITAL_GOODS,
+        GSTR9_Row.TABLE_6C_INPUT_SERVICES,
+        GSTR9_Row.TABLE_6D,
+        GSTR9_Row.TABLE_6D_INPUTS,
+        GSTR9_Row.TABLE_6D_CAPITAL_GOODS,
+        GSTR9_Row.TABLE_6D_INPUT_SERVICES,
+        GSTR9_Row.TABLE_6E,
+        GSTR9_Row.TABLE_6E_INPUTS,
+        GSTR9_Row.TABLE_6E_CAPITAL_GOODS,
+        GSTR9_Row.TABLE_6F,
+        GSTR9_Row.TABLE_6G,
+    }
+)
+
+# Standard amount columns for Tables 4-8
+AMOUNT_FIELDS = ("taxable_value", "igst", "cgst", "sgst", "cess")
+
+# Auto-computation formulas
+AUTO_COMPUTE_FORMULAS = {
+    GSTR9_Row.TABLE_4H: lambda d: _sum_rows(
+        d,
+        [
+            GSTR9_Row.TABLE_4A,
+            GSTR9_Row.TABLE_4B,
+            GSTR9_Row.TABLE_4C,
+            GSTR9_Row.TABLE_4D,
+            GSTR9_Row.TABLE_4E,
+            GSTR9_Row.TABLE_4F,
+            GSTR9_Row.TABLE_4G,
+            GSTR9_Row.TABLE_4G1,
+        ],
+    ),
+    # 4I (credit notes) is stored as a positive amount and subtracted, matching the portal convention
+    GSTR9_Row.TABLE_4M: lambda d: _sum_rows(
+        d,
+        [
+            GSTR9_Row.TABLE_4J,
+            GSTR9_Row.TABLE_4K,
+        ],
+        subtract=[GSTR9_Row.TABLE_4I, GSTR9_Row.TABLE_4L],
+    ),
+    GSTR9_Row.TABLE_4N: lambda d: _sum_rows(
+        d, [GSTR9_Row.TABLE_4H, GSTR9_Row.TABLE_4M]
+    ),
+    GSTR9_Row.TABLE_5G: lambda d: _sum_rows(
+        d,
+        [
+            GSTR9_Row.TABLE_5A,
+            GSTR9_Row.TABLE_5B,
+            GSTR9_Row.TABLE_5C,
+            GSTR9_Row.TABLE_5C1,
+            GSTR9_Row.TABLE_5D,
+            GSTR9_Row.TABLE_5E,
+            GSTR9_Row.TABLE_5F,
+        ],
+    ),
+    # 5H (credit notes) is stored as a positive amount and subtracted, matching the portal convention
+    GSTR9_Row.TABLE_5L: lambda d: _sum_rows(
+        d,
+        [
+            GSTR9_Row.TABLE_5I,
+            GSTR9_Row.TABLE_5J,
+        ],
+        subtract=[GSTR9_Row.TABLE_5H, GSTR9_Row.TABLE_5K],
+    ),
+    GSTR9_Row.TABLE_5M: lambda d: _sum_rows(
+        d, [GSTR9_Row.TABLE_5G, GSTR9_Row.TABLE_5L]
+    ),
+    GSTR9_Row.TABLE_5N: lambda d: _sum_rows(
+        d,
+        [
+            GSTR9_Row.TABLE_4N,
+            GSTR9_Row.TABLE_5M,
+        ],
+        subtract=[GSTR9_Row.TABLE_4G, GSTR9_Row.TABLE_4G1],
+    ),
+    GSTR9_Row.TABLE_10_11_TURNOVER: lambda d: _sum_rows(
+        d,
+        [
+            GSTR9_Row.TABLE_5N,
+            GSTR9_Row.TABLE_10,
+        ],
+        subtract=[GSTR9_Row.TABLE_11],
+    ),
+    GSTR9_Row.TABLE_6A2: lambda d: _sum_rows(
+        d, [GSTR9_Row.TABLE_6A], subtract=[GSTR9_Row.TABLE_6A1]
+    ),
+    GSTR9_Row.TABLE_6B: lambda d: _sum_rows(
+        d,
+        [
+            GSTR9_Row.TABLE_6B_INPUTS,
+            GSTR9_Row.TABLE_6B_CAPITAL_GOODS,
+            GSTR9_Row.TABLE_6B_INPUT_SERVICES,
+        ],
+    ),
+    GSTR9_Row.TABLE_6C: lambda d: _sum_rows(
+        d,
+        [
+            GSTR9_Row.TABLE_6C_INPUTS,
+            GSTR9_Row.TABLE_6C_CAPITAL_GOODS,
+            GSTR9_Row.TABLE_6C_INPUT_SERVICES,
+        ],
+    ),
+    GSTR9_Row.TABLE_6D: lambda d: _sum_rows(
+        d,
+        [
+            GSTR9_Row.TABLE_6D_INPUTS,
+            GSTR9_Row.TABLE_6D_CAPITAL_GOODS,
+            GSTR9_Row.TABLE_6D_INPUT_SERVICES,
+        ],
+    ),
+    GSTR9_Row.TABLE_6E: lambda d: _sum_rows(
+        d,
+        [
+            GSTR9_Row.TABLE_6E_INPUTS,
+            GSTR9_Row.TABLE_6E_CAPITAL_GOODS,
+        ],
+    ),
+    GSTR9_Row.TABLE_6I: lambda d: _sum_rows(
+        d,
+        [
+            GSTR9_Row.TABLE_6B,
+            GSTR9_Row.TABLE_6C,
+            GSTR9_Row.TABLE_6D,
+            GSTR9_Row.TABLE_6E,
+            GSTR9_Row.TABLE_6F,
+            GSTR9_Row.TABLE_6G,
+            GSTR9_Row.TABLE_6H,
+        ],
+    ),
+    GSTR9_Row.TABLE_6J: lambda d: _sum_rows(
+        d, [GSTR9_Row.TABLE_6I], subtract=[GSTR9_Row.TABLE_6A2]
+    ),
+    GSTR9_Row.TABLE_6N: lambda d: _sum_rows(
+        d, [GSTR9_Row.TABLE_6K, GSTR9_Row.TABLE_6L, GSTR9_Row.TABLE_6M]
+    ),
+    GSTR9_Row.TABLE_6O: lambda d: _sum_rows(
+        d, [GSTR9_Row.TABLE_6I, GSTR9_Row.TABLE_6N]
+    ),
+    GSTR9_Row.TABLE_7I: lambda d: _sum_rows(
+        d,
+        [
+            GSTR9_Row.TABLE_7A,
+            GSTR9_Row.TABLE_7A1,
+            GSTR9_Row.TABLE_7A2,
+            GSTR9_Row.TABLE_7B,
+            GSTR9_Row.TABLE_7C,
+            GSTR9_Row.TABLE_7D,
+            GSTR9_Row.TABLE_7E,
+            GSTR9_Row.TABLE_7F,
+            GSTR9_Row.TABLE_7G,
+            GSTR9_Row.TABLE_7H1,
+        ],
+    ),
+    GSTR9_Row.TABLE_7J: lambda d: _sum_rows(
+        d, [GSTR9_Row.TABLE_6O], subtract=[GSTR9_Row.TABLE_7I]
+    ),
+    GSTR9_Row.TABLE_8B: lambda d: d.get(GSTR9_Row.TABLE_6B, _empty_row()),
+    GSTR9_Row.TABLE_8D: lambda d: _sum_rows(
+        d, [GSTR9_Row.TABLE_8A], subtract=[GSTR9_Row.TABLE_8B, GSTR9_Row.TABLE_8C]
+    ),
+    GSTR9_Row.TABLE_8H: lambda d: d.get(GSTR9_Row.TABLE_6E, _empty_row()),
+    GSTR9_Row.TABLE_8I: lambda d: _sum_rows(
+        d, [GSTR9_Row.TABLE_8G], subtract=[GSTR9_Row.TABLE_8H, GSTR9_Row.TABLE_8H1]
+    ),
+    GSTR9_Row.TABLE_8J: lambda d: d.get(GSTR9_Row.TABLE_8I, _empty_row()),
+    GSTR9_Row.TABLE_8K: lambda d: _sum_rows(
+        d, [GSTR9_Row.TABLE_8E, GSTR9_Row.TABLE_8F, GSTR9_Row.TABLE_8J]
+    ),
+}
+
+
+def _empty_row():
+    return {field: 0 for field in AMOUNT_FIELDS}
+
+
+def _sum_rows(data, add_rows, subtract=None):
+    result = _empty_row()
+    for row_key in add_rows:
+        row = data.get(row_key, _empty_row())
+        for field in AMOUNT_FIELDS:
+            result[field] += row.get(field, 0)
+
+    for row_key in subtract or []:
+        row = data.get(row_key, _empty_row())
+        for field in AMOUNT_FIELDS:
+            result[field] -= row.get(field, 0)
+
+    return result
+
+
+def compute_auto_rows(data):
+    """
+    Compute all auto-computed rows in dependency order.
+    data is a dict of {row_key: {field: value, ...}}
+    """
+    # Compute in defined order (formulas dict is insertion-ordered in Python 3.7+)
+    for row_key, formula in AUTO_COMPUTE_FORMULAS.items():
+        data[row_key] = formula(data)
+
+    return data
+
+
+# Rows whose amounts are derived from credit note documents (negative in ERP).
+# After aggregation these are negated so they display and compare as positive values, matching the portal convention where credit notes are shown as positive and subtracted in the sub-total formula.
+CREDIT_NOTE_ROWS = frozenset({GSTR9_Row.TABLE_4I, GSTR9_Row.TABLE_5H})
+
+
+def aggregate_books(books):
+    """
+    Aggregate invoice-level books data into row-level amount dicts.
+
+    - list of invoice dicts → sum AMOUNT_FIELDS across invoices
+    - empty list            → _empty_row()
+    - dict with amount keys → pass through (already aggregated)
+    - other (Table 14/15/17/18 structures) → pass through
+
+    Credit note rows (4I, 5H) have their sign flipped after summation so the stored value is a positive absolute amount (portal convention).
+    """
+    from frappe.utils import flt
+
+    result = {}
+    for row_key, value in books.items():
+        if isinstance(value, list):
+            if not value:
+                result[row_key] = _empty_row()
+            elif isinstance(value[0], dict) and "taxable_value" in value[0]:
+                row = _empty_row()
+                for inv in value:
+                    for field in AMOUNT_FIELDS:
+                        row[field] += flt(inv.get(field, 0))
+                result[row_key] = row
+            else:
+                result[row_key] = value
+        else:
+            result[row_key] = value
+
+    # Credit note rows are stored as negative in ERP; negate to make them positive
+    for row_key in CREDIT_NOTE_ROWS:
+        if row_key in result and isinstance(result[row_key], dict):
+            result[row_key] = {f: -result[row_key][f] for f in AMOUNT_FIELDS}
+
+    return result
+
+
+def get_fy_dates(financial_year):
+    """
+    Get from_date and to_date for a financial year string.
+    e.g. "2024-25" → (date(2024, 4, 1), date(2025, 3, 31))
+    """
+    from frappe.utils import getdate
+
+    start_year = int(financial_year.split("-")[0])
+    from_date = getdate(f"{start_year}-04-01")
+    to_date = getdate(f"{start_year + 1}-03-31")
+    return from_date, to_date
+
+
+def get_fy_period(financial_year):
+    """
+    Convert financial year to return_period format for GST Return Log naming.
+    e.g. "2024-25" → "202425"
+    """
+    return financial_year.replace("-", "")
+
+
+def get_gstr9_return_period(financial_year):
+    """
+    Convert financial year to GSTN GSTR-9 API ret_period (MMYYYY).
+    GSTR-9 always ends in March of the closing year.
+    e.g. "2024-25" → "032025"
+    """
+    start_year = int(financial_year.split("-")[0])
+    return f"03{start_year + 1}"

--- a/india_compliance/gst_india/utils/gstr_9/__init__.py
+++ b/india_compliance/gst_india/utils/gstr_9/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2026, Resilient Tech and contributors
 # For license information, please see license.txt
+"""Constants, row definitions, and helper utilities for GSTR-9 computation."""
 
 
 class GSTR9_Row:
@@ -414,8 +415,7 @@ def _sum_rows(data, add_rows, subtract=None):
 
 
 def compute_auto_rows(data):
-    """
-    Compute all auto-computed rows in dependency order.
+    """Compute all auto-computed rows in dependency order.
 
     data is a dict of {row_key: {field: value, ...}}
     """
@@ -487,8 +487,8 @@ def aggregate_books(books):
 
 
 def get_fy_dates(financial_year):
-    """
-    Get from_date and to_date for a financial year string.
+    """Get from_date and to_date for a financial year string.
+
     e.g. "2024-25" → (date(2024, 4, 1), date(2025, 3, 31))
     """
     from frappe.utils import getdate

--- a/india_compliance/gst_india/utils/gstr_9/__init__.py
+++ b/india_compliance/gst_india/utils/gstr_9/__init__.py
@@ -196,7 +196,11 @@ GSTR9_ROW_DESCRIPTION = {
     GSTR9_Row.TABLE_7J: "Net ITC Available for Utilization (6O - 7I)",
     GSTR9_Row.TABLE_8A: "ITC as per GSTR-2B",
     GSTR9_Row.TABLE_8B: "ITC as per sum total of 6B above",
-    GSTR9_Row.TABLE_8C: "ITC on inward supplies (other than imports and inward supplies liable to reverse charge but includes services received from SEZs) received during the financial year but availed in the next financial year upto specified period",
+    GSTR9_Row.TABLE_8C: (
+        "ITC on inward supplies (other than imports and inward supplies liable to reverse"
+        " charge but includes services received from SEZs) received during the financial"
+        " year but availed in the next financial year upto specified period"
+    ),
     GSTR9_Row.TABLE_8D: "Difference [8A - (8B + 8C)]",
     GSTR9_Row.TABLE_8E: "ITC available but not availed",
     GSTR9_Row.TABLE_8F: "ITC available but ineligible",
@@ -222,9 +226,7 @@ GSTR9_ROW_DESCRIPTION = {
 }
 
 # Rows sourced from portal (non-editable, require download)
-PORTAL_SOURCED_ROWS = frozenset(
-    {GSTR9_Row.TABLE_6A, GSTR9_Row.TABLE_8A, GSTR9_Row.TABLE_9}
-)
+PORTAL_SOURCED_ROWS = frozenset({GSTR9_Row.TABLE_6A, GSTR9_Row.TABLE_8A, GSTR9_Row.TABLE_9})
 
 # Rows whose invoice detail comes from Purchase Invoices / BOE (not Sales Invoices)
 PURCHASE_ROW_KEYS = frozenset(
@@ -277,9 +279,7 @@ AUTO_COMPUTE_FORMULAS = {
         ],
         subtract=[GSTR9_Row.TABLE_4I, GSTR9_Row.TABLE_4L],
     ),
-    GSTR9_Row.TABLE_4N: lambda d: _sum_rows(
-        d, [GSTR9_Row.TABLE_4H, GSTR9_Row.TABLE_4M]
-    ),
+    GSTR9_Row.TABLE_4N: lambda d: _sum_rows(d, [GSTR9_Row.TABLE_4H, GSTR9_Row.TABLE_4M]),
     GSTR9_Row.TABLE_5G: lambda d: _sum_rows(
         d,
         [
@@ -301,9 +301,7 @@ AUTO_COMPUTE_FORMULAS = {
         ],
         subtract=[GSTR9_Row.TABLE_5H, GSTR9_Row.TABLE_5K],
     ),
-    GSTR9_Row.TABLE_5M: lambda d: _sum_rows(
-        d, [GSTR9_Row.TABLE_5G, GSTR9_Row.TABLE_5L]
-    ),
+    GSTR9_Row.TABLE_5M: lambda d: _sum_rows(d, [GSTR9_Row.TABLE_5G, GSTR9_Row.TABLE_5L]),
     GSTR9_Row.TABLE_5N: lambda d: _sum_rows(
         d,
         [
@@ -320,9 +318,7 @@ AUTO_COMPUTE_FORMULAS = {
         ],
         subtract=[GSTR9_Row.TABLE_11],
     ),
-    GSTR9_Row.TABLE_6A2: lambda d: _sum_rows(
-        d, [GSTR9_Row.TABLE_6A], subtract=[GSTR9_Row.TABLE_6A1]
-    ),
+    GSTR9_Row.TABLE_6A2: lambda d: _sum_rows(d, [GSTR9_Row.TABLE_6A], subtract=[GSTR9_Row.TABLE_6A1]),
     GSTR9_Row.TABLE_6B: lambda d: _sum_rows(
         d,
         [
@@ -366,15 +362,9 @@ AUTO_COMPUTE_FORMULAS = {
             GSTR9_Row.TABLE_6H,
         ],
     ),
-    GSTR9_Row.TABLE_6J: lambda d: _sum_rows(
-        d, [GSTR9_Row.TABLE_6I], subtract=[GSTR9_Row.TABLE_6A2]
-    ),
-    GSTR9_Row.TABLE_6N: lambda d: _sum_rows(
-        d, [GSTR9_Row.TABLE_6K, GSTR9_Row.TABLE_6L, GSTR9_Row.TABLE_6M]
-    ),
-    GSTR9_Row.TABLE_6O: lambda d: _sum_rows(
-        d, [GSTR9_Row.TABLE_6I, GSTR9_Row.TABLE_6N]
-    ),
+    GSTR9_Row.TABLE_6J: lambda d: _sum_rows(d, [GSTR9_Row.TABLE_6I], subtract=[GSTR9_Row.TABLE_6A2]),
+    GSTR9_Row.TABLE_6N: lambda d: _sum_rows(d, [GSTR9_Row.TABLE_6K, GSTR9_Row.TABLE_6L, GSTR9_Row.TABLE_6M]),
+    GSTR9_Row.TABLE_6O: lambda d: _sum_rows(d, [GSTR9_Row.TABLE_6I, GSTR9_Row.TABLE_6N]),
     GSTR9_Row.TABLE_7I: lambda d: _sum_rows(
         d,
         [
@@ -390,9 +380,7 @@ AUTO_COMPUTE_FORMULAS = {
             GSTR9_Row.TABLE_7H1,
         ],
     ),
-    GSTR9_Row.TABLE_7J: lambda d: _sum_rows(
-        d, [GSTR9_Row.TABLE_6O], subtract=[GSTR9_Row.TABLE_7I]
-    ),
+    GSTR9_Row.TABLE_7J: lambda d: _sum_rows(d, [GSTR9_Row.TABLE_6O], subtract=[GSTR9_Row.TABLE_7I]),
     GSTR9_Row.TABLE_8B: lambda d: d.get(GSTR9_Row.TABLE_6B, _empty_row()),
     GSTR9_Row.TABLE_8D: lambda d: _sum_rows(
         d, [GSTR9_Row.TABLE_8A], subtract=[GSTR9_Row.TABLE_8B, GSTR9_Row.TABLE_8C]
@@ -402,9 +390,7 @@ AUTO_COMPUTE_FORMULAS = {
         d, [GSTR9_Row.TABLE_8G], subtract=[GSTR9_Row.TABLE_8H, GSTR9_Row.TABLE_8H1]
     ),
     GSTR9_Row.TABLE_8J: lambda d: d.get(GSTR9_Row.TABLE_8I, _empty_row()),
-    GSTR9_Row.TABLE_8K: lambda d: _sum_rows(
-        d, [GSTR9_Row.TABLE_8E, GSTR9_Row.TABLE_8F, GSTR9_Row.TABLE_8J]
-    ),
+    GSTR9_Row.TABLE_8K: lambda d: _sum_rows(d, [GSTR9_Row.TABLE_8E, GSTR9_Row.TABLE_8F, GSTR9_Row.TABLE_8J]),
 }
 
 
@@ -430,6 +416,7 @@ def _sum_rows(data, add_rows, subtract=None):
 def compute_auto_rows(data):
     """
     Compute all auto-computed rows in dependency order.
+
     data is a dict of {row_key: {field: value, ...}}
     """
     # Compute in defined order (formulas dict is insertion-ordered in Python 3.7+)
@@ -440,7 +427,9 @@ def compute_auto_rows(data):
 
 
 # Rows whose amounts are derived from credit note documents (negative in ERP).
-# After aggregation these are negated so they display and compare as positive values, matching the portal convention where credit notes are shown as positive and subtracted in the sub-total formula.
+# After aggregation these are negated so they display and compare as positive values,
+# matching the portal convention where credit notes are shown as positive and subtracted
+# in the sub-total formula.
 CREDIT_NOTE_ROWS = frozenset({GSTR9_Row.TABLE_4I, GSTR9_Row.TABLE_5H})
 
 

--- a/india_compliance/gst_india/utils/gstr_9/gstr_9_data.py
+++ b/india_compliance/gst_india/utils/gstr_9/gstr_9_data.py
@@ -1,0 +1,832 @@
+# Copyright (c) 2026, Resilient Tech and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe.query_builder import Case, Criterion
+from frappe.query_builder.functions import IfNull, Max, Sum
+from frappe.utils import flt
+
+from india_compliance.gst_india.utils.gstr_1.gstr_1_data import (
+    GSTR1Query,
+    cache_invoice_condition,
+)
+from india_compliance.gst_india.utils.gstr_9 import (
+    AMOUNT_FIELDS,
+    GSTR9_Row,
+    _empty_row,
+)
+
+
+class GSTR9BooksData(GSTR1Query):
+    """
+    Computes GSTR-9 books data from ERP (Sales/Purchase Invoices, Journal Entries) for a given company, GSTIN, and financial year.
+
+    Inherits GSTR1Query to reuse self.si, self.si_item DocType references and get_query_with_common_filters() for applying company/GSTIN/date filters without duplication.
+
+    Uses frappe.db.unbuffered_cursor() (SSCursor) so rows are streamed from the server one at a time — classification happens in a Python loop without loading the full result set into memory.
+
+    Returns classified invoice-level data (books format):
+      {row_key: [invoice_dicts]}   — for drillable rows
+      {row_key: {amount_fields}}   — for manual/aggregated-only rows
+      {row_key: special_structure}  — for Tables 14, 15, 17, 18
+    """
+
+    def __init__(self, filters):
+        # Sets self.si, self.si_item, self.si_taxes, self.filters
+        super().__init__(filters)
+        self.company = self.filters.company
+        self.company_gstin = self.filters.company_gstin
+        self.from_date = self.filters.from_date
+        self.to_date = self.filters.to_date
+
+    def get_data(self):
+        """
+        Returns books data: {row_key → [invoices] | {amounts} | structure}.
+
+        Invoice lists are stored for drillable rows so the detail view can
+        read from the cached snapshot without re-querying.
+        """
+        data = {}
+
+        # Fetch all outward (Sales Invoice) items once, classify into Table 4 & 5
+        data.update(self._get_classified_outward_supplies())
+
+        # Fetch all purchase items once, classify into Table 4G & Table 6
+        data.update(self._get_classified_purchase_invoices())
+
+        # BOE records → split into 6E Inputs / 6E Capital Goods
+        for row_key, records in self._get_boe_books().items():
+            if records:
+                data.setdefault(row_key, []).extend(records)
+
+        # Advances (4F) — reuses GSTR-1 advance query logic
+        data[GSTR9_Row.TABLE_4F] = self._get_advances_data()
+
+        # Manual / empty rows
+        for key in (
+            GSTR9_Row.TABLE_4G1,
+            GSTR9_Row.TABLE_4K,
+            GSTR9_Row.TABLE_4L,
+            GSTR9_Row.TABLE_5J,
+            GSTR9_Row.TABLE_5K,
+        ):
+            data[key] = _empty_row()
+
+        for key in (
+            GSTR9_Row.TABLE_6A,
+            GSTR9_Row.TABLE_6A1,
+            GSTR9_Row.TABLE_6H,
+            GSTR9_Row.TABLE_6K,
+            GSTR9_Row.TABLE_6L,
+            GSTR9_Row.TABLE_6M,
+        ):
+            data[key] = _empty_row()
+
+        # Ensure all drillable row keys exist (empty list if no data)
+        for key in (
+            # Table 4 outward
+            GSTR9_Row.TABLE_4A,
+            GSTR9_Row.TABLE_4B,
+            GSTR9_Row.TABLE_4C,
+            GSTR9_Row.TABLE_4D,
+            GSTR9_Row.TABLE_4E,
+            GSTR9_Row.TABLE_4G,
+            GSTR9_Row.TABLE_4I,
+            GSTR9_Row.TABLE_4J,
+            # Table 5 outward
+            GSTR9_Row.TABLE_5A,
+            GSTR9_Row.TABLE_5B,
+            GSTR9_Row.TABLE_5C,
+            GSTR9_Row.TABLE_5C1,
+            GSTR9_Row.TABLE_5D,
+            GSTR9_Row.TABLE_5E,
+            GSTR9_Row.TABLE_5F,
+            GSTR9_Row.TABLE_5H,
+            GSTR9_Row.TABLE_5I,
+            # Table 6 ITC
+            GSTR9_Row.TABLE_6B_INPUTS,
+            GSTR9_Row.TABLE_6B_CAPITAL_GOODS,
+            GSTR9_Row.TABLE_6B_INPUT_SERVICES,
+            GSTR9_Row.TABLE_6C_INPUTS,
+            GSTR9_Row.TABLE_6C_CAPITAL_GOODS,
+            GSTR9_Row.TABLE_6C_INPUT_SERVICES,
+            GSTR9_Row.TABLE_6D_INPUTS,
+            GSTR9_Row.TABLE_6D_CAPITAL_GOODS,
+            GSTR9_Row.TABLE_6D_INPUT_SERVICES,
+            GSTR9_Row.TABLE_6E_INPUTS,
+            GSTR9_Row.TABLE_6E_CAPITAL_GOODS,
+            GSTR9_Row.TABLE_6F,
+            GSTR9_Row.TABLE_6G,
+        ):
+            data.setdefault(key, [])
+
+        data.update(self._get_table_7_data())
+        data.update(self._get_table_10_to_13_data())
+        data.update(self._get_table_14_data())
+        data.update(self._get_table_15_data())
+        data.update(self._get_table_16_data())
+        data.update(self._get_table_17_data())
+        data.update(self._get_table_18_data())
+
+        return data
+
+    def _get_table_7_data(self):
+        data = {}
+        data[GSTR9_Row.TABLE_7A] = _empty_row()
+        data[GSTR9_Row.TABLE_7A1] = _empty_row()
+        data[GSTR9_Row.TABLE_7A2] = _empty_row()
+        data[GSTR9_Row.TABLE_7B] = _empty_row()
+        data[GSTR9_Row.TABLE_7C] = _empty_row()
+        data[GSTR9_Row.TABLE_7D] = _empty_row()
+        data[GSTR9_Row.TABLE_7E] = _empty_row()
+        data[GSTR9_Row.TABLE_7F] = _empty_row()
+        data[GSTR9_Row.TABLE_7G] = _empty_row()
+        data[GSTR9_Row.TABLE_7H1] = _empty_row()
+
+        return data
+
+    def _get_table_10_to_13_data(self):
+        return {
+            GSTR9_Row.TABLE_10: _empty_row(),
+            GSTR9_Row.TABLE_11: _empty_row(),
+            GSTR9_Row.TABLE_12: _empty_row(),
+            GSTR9_Row.TABLE_13: _empty_row(),
+        }
+
+    def _get_table_14_data(self):
+        return {
+            GSTR9_Row.TABLE_14: [
+                {
+                    "label": "A",
+                    "description": "Integrated Tax",
+                    "payable": 0,
+                    "paid": 0,
+                },
+                {"label": "B", "description": "Central Tax", "payable": 0, "paid": 0},
+                {"label": "C", "description": "State/UT Tax", "payable": 0, "paid": 0},
+                {"label": "D", "description": "Cess", "payable": 0, "paid": 0},
+                {"label": "E", "description": "Interest", "payable": None, "paid": 0},
+            ]
+        }
+
+    def _get_table_15_data(self):
+
+        def _row(label, description):
+            return {
+                "label": label,
+                "description": description,
+                "igst": 0,
+                "cgst": 0,
+                "sgst": 0,
+                "cess": 0,
+                "interest": 0,
+                "penalty": 0,
+                "late_fee": 0,
+            }
+
+        return {
+            GSTR9_Row.TABLE_15: [
+                _row("A", "Total Refund claimed"),
+                _row("B", "Total Refund sanctioned"),
+                _row("C", "Total Refund Rejected"),
+                _row("D", "Total Refund Pending"),
+                _row("E", "Total demand of taxes adjudicated"),
+                _row("F", "Total taxes paid in respect of E above"),
+                _row("G", "Total demands pending out of E above"),
+            ]
+        }
+
+    def _get_table_16_data(self):
+        return {
+            GSTR9_Row.TABLE_16A: _empty_row(),
+            GSTR9_Row.TABLE_16B: _empty_row(),
+            GSTR9_Row.TABLE_16C: _empty_row(),
+        }
+
+    def _get_table_17_data(self):
+        return {GSTR9_Row.TABLE_17: self._get_hsn_data("outward")}
+
+    def _get_table_18_data(self):
+        return {GSTR9_Row.TABLE_18: self._get_hsn_data("inward")}
+
+    def _get_hsn_data(self, direction):
+        """Reuse the standalone HSN report functions for exact data parity.
+
+        Converts report field names to the GSTR-9 display format and splits
+        into goods (HSN not starting with '99') and services (SAC codes).
+        """
+        from india_compliance.gst_india.report.hsn_wise_summary_of_inward_supplies.hsn_wise_summary_of_inward_supplies import (
+            get_data as get_inward_hsn_data,
+        )
+        from india_compliance.gst_india.report.hsn_wise_summary_of_outward_supplies.hsn_wise_summary_of_outward_supplies import (
+            get_hsn_data as get_outward_hsn_data,
+        )
+
+        filters = frappe._dict(
+            company=self.company,
+            company_gstin=self.company_gstin,
+            from_date=self.from_date,
+            to_date=self.to_date,
+            filter_by="Posting Date",  # GSTR-9 always uses posting date range
+        )
+
+        rows = (
+            get_outward_hsn_data(filters)
+            if direction == "outward"
+            else get_inward_hsn_data(filters)
+        )
+
+        goods, services = [], []
+        for row in rows:
+            mapped = {
+                "hsn_code": row.get("hsn_code"),
+                "description": row.get("description"),
+                "uom": row.get("uom"),
+                "tax_rate": row.get("tax_rate"),
+                "quantity": row.get("quantity"),
+                "taxable_value": row.get("total_taxable_value"),
+                "igst": row.get("total_igst_amount"),
+                "cgst": row.get("total_cgst_amount"),
+                "sgst": row.get("total_sgst_amount"),
+                "cess": row.get("total_cess_amount"),
+            }
+            (
+                services if str(row.get("hsn_code") or "").startswith("99") else goods
+            ).append(mapped)
+
+        return {"goods": goods, "services": services}
+
+    # ────────────────────────────────────────────────────────
+    # Outward Supplies — Tables 4 & 5
+    # ────────────────────────────────────────────────────────
+
+    def _get_classified_outward_supplies(self):
+        """
+        Fetch all Sales Invoice items in a single query, classify each item
+        into a GSTR-9 row in Python, and accumulate per (row_key, invoice).
+
+        Uses unbuffered cursor (SSCursor) so rows are streamed from the server
+        one at a time instead of loading the full result set into memory.
+
+        Returns {row_key: [invoice_dicts]}.
+        """
+        query = self._get_outward_items_query()
+        classifier = GSTR9OutwardClassifier()
+        accumulator = {}
+
+        with frappe.db.unbuffered_cursor():
+            for item in frappe.db.sql(query.get_sql(), as_dict=True, as_iterator=True):
+                row_key = classifier.classify(item)
+                if not row_key:
+                    continue
+
+                _accumulate_item(
+                    accumulator,
+                    row_key,
+                    item.name,
+                    item,
+                    party_field="customer",
+                    party_name_field="customer_name",
+                    party_gstin_field="billing_address_gstin",
+                )
+
+        return _build_result(accumulator)
+
+    def _get_outward_items_query(self):
+        """
+        Build the outward supply query using GSTR-1's common filter infrastructure.
+
+        Calls get_query_with_common_filters() (inherited from GSTR1Query) to
+        apply company / company_gstin / from_date / to_date filters — reusing
+        the GSTR-1 filter logic instead of duplicating it.
+        """
+        query = (
+            frappe.qb.from_(self.si)
+            .inner_join(self.si_item)
+            .on(
+                (self.si_item.parent == self.si.name)
+                & (self.si_item.parenttype == "Sales Invoice")
+            )
+            .select(
+                self.si.name,
+                self.si.posting_date,
+                self.si.customer,
+                self.si.customer_name,
+                self.si.billing_address_gstin,
+                self.si.gst_category,
+                self.si.is_return,
+                self.si.is_debit_note,
+                self.si.is_reverse_charge,
+                self.si.is_export_with_gst,
+                IfNull(self.si.ecommerce_gstin, "").as_("ecommerce_gstin"),
+                IfNull(self.si_item.gst_treatment, "").as_("gst_treatment"),
+                self.si_item.taxable_value,
+                self.si_item.igst_amount.as_("igst"),
+                self.si_item.cgst_amount.as_("cgst"),
+                self.si_item.sgst_amount.as_("sgst"),
+                self.si_item.cess_amount.as_("cess"),
+            )
+            .where(self.si.docstatus == 1)
+            .where(self.si.is_opening != "Yes")
+            .orderby(self.si.posting_date)
+        )
+        # Applies company / company_gstin / from_date / to_date — reuses GSTR-1 logic
+        return self.get_query_with_common_filters(query)
+
+    # ────────────────────────────────────────────────────────
+    # Purchase Invoices — Table 4G & Table 6
+    # ────────────────────────────────────────────────────────
+
+    def _get_classified_purchase_invoices(self):
+        """
+        Fetch all relevant Purchase Invoice items in a single query, classify
+        each item for Table 4G (RCM) and/or Table 6 (ITC), and accumulate.
+
+        A single invoice item can contribute to BOTH 4G and a Table 6 row.
+        Uses unbuffered cursor (SSCursor) so rows are streamed from the server
+        one at a time instead of loading the full result set into memory.
+
+        Returns {row_key: [invoice_dicts]}.
+        """
+        query = self._get_purchase_items_query()
+        classifier = GSTR9PurchaseClassifier(self.company_gstin)
+        accumulator = {}
+
+        with frappe.db.unbuffered_cursor():
+            for item in frappe.db.sql(query.get_sql(), as_dict=True, as_iterator=True):
+                rcm_key, itc_key = classifier.classify(item)
+
+                if rcm_key:
+                    _accumulate_item(
+                        accumulator,
+                        rcm_key,
+                        item.name,
+                        item,
+                        party_field="supplier",
+                        party_name_field="supplier_name",
+                        party_gstin_field="supplier_gstin",
+                    )
+
+                if itc_key:
+                    _accumulate_item(
+                        accumulator,
+                        itc_key,
+                        item.name,
+                        item,
+                        party_field="supplier",
+                        party_name_field="supplier_name",
+                        party_gstin_field="supplier_gstin",
+                        extra_fields={"itc_classification": item.itc_classification},
+                    )
+
+        return _build_result(accumulator)
+
+    def _get_purchase_items_query(self):
+        """
+        Build the purchase items query (GSTR-1 has no PI equivalent, so filters
+        are applied directly here rather than via get_query_with_common_filters).
+
+        Includes items from invoices that are EITHER:
+        - Reverse charge (for Table 4G)
+        - Have ITC classification (for Table 6)
+        """
+        pi = frappe.qb.DocType("Purchase Invoice")
+        pi_item = frappe.qb.DocType("Purchase Invoice Item")
+        item_doc = frappe.qb.DocType("Item")
+
+        rcm_condition = pi.is_reverse_charge == 1
+        itc_condition = (IfNull(pi.itc_classification, "") != "") & (
+            pi.company_gstin != IfNull(pi.supplier_gstin, "")
+        )
+
+        return (
+            frappe.qb.from_(pi)
+            .inner_join(pi_item)
+            .on(
+                (pi_item.parent == pi.name) & (pi_item.parenttype == "Purchase Invoice")
+            )
+            .left_join(item_doc)
+            .on(item_doc.name == pi_item.item_code)
+            .select(
+                pi.name,
+                pi.posting_date,
+                pi.supplier,
+                pi.supplier_name,
+                pi.supplier_gstin,
+                pi.gst_category,
+                pi.is_reverse_charge,
+                IfNull(pi.itc_classification, "").as_("itc_classification"),
+                IfNull(pi.ineligibility_reason, "").as_("ineligibility_reason"),
+                pi_item.is_fixed_asset,
+                IfNull(item_doc.is_stock_item, 1).as_("is_stock_item"),
+                pi_item.taxable_value,
+                pi_item.igst_amount.as_("igst"),
+                pi_item.cgst_amount.as_("cgst"),
+                pi_item.sgst_amount.as_("sgst"),
+                pi_item.cess_amount.as_("cess"),
+            )
+            .where(
+                (pi.docstatus == 1)
+                & (pi.is_opening != "Yes")
+                & (pi.company == self.company)
+                & (pi.company_gstin == self.company_gstin)
+                & (pi.posting_date.between(self.from_date, self.to_date))
+                & Criterion.any([rcm_condition, itc_condition])
+            )
+            .orderby(pi.posting_date)
+        )
+
+    def _get_boe_books(self):
+        """
+        Individual Bill of Entry records with IGST/Cess amounts and supplier
+        info resolved from linked Purchase Invoices.
+
+        A single aggregated query joins boe_taxes, boe_item→pi, and
+        boe_item→pi_item so that tax totals, supplier details, and the
+        capital-goods flag are all computed in one database round-trip.
+
+        Returns {TABLE_6E_INPUTS: [...], TABLE_6E_CAPITAL_GOODS: [...]}.
+        """
+        boe = frappe.qb.DocType("Bill of Entry")
+        boe_taxes = frappe.qb.DocType("India Compliance Taxes and Charges")
+        boe_item = frappe.qb.DocType("Bill of Entry Item")
+        pi = frappe.qb.DocType("Purchase Invoice")
+        pi_item = frappe.qb.DocType("Purchase Invoice Item")
+
+        rows = (
+            frappe.qb.from_(boe)
+            .left_join(boe_taxes)
+            .on(
+                (boe_taxes.parent == boe.name)
+                & (boe_taxes.parenttype == "Bill of Entry")
+            )
+            .left_join(boe_item)
+            .on(boe_item.parent == boe.name)
+            .left_join(pi)
+            .on(
+                (pi.name == boe_item.purchase_invoice)
+                & (IfNull(boe_item.purchase_invoice, "") != "")
+            )
+            .left_join(pi_item)
+            .on(boe_item.pi_detail == pi_item.name)
+            .select(
+                boe.name.as_("document_number"),
+                boe.posting_date,
+                boe.total_taxable_value.as_("taxable_value"),
+                Sum(
+                    Case()
+                    .when(boe_taxes.gst_tax_type == "igst", boe_taxes.tax_amount)
+                    .else_(0)
+                ).as_("igst"),
+                Sum(
+                    Case()
+                    .when(
+                        boe_taxes.gst_tax_type.isin(["cess", "cess_non_advol"]),
+                        boe_taxes.tax_amount,
+                    )
+                    .else_(0)
+                ).as_("cess"),
+                Max(IfNull(pi.supplier, "")).as_("party"),
+                Max(IfNull(pi.supplier_name, "")).as_("party_name"),
+                Max(IfNull(pi.supplier_gstin, "")).as_("party_gstin"),
+                Max(IfNull(pi_item.is_fixed_asset, 0)).as_("is_fixed_asset"),
+            )
+            .where(
+                (boe.company == self.company)
+                & (boe.company_gstin == self.company_gstin)
+                & (boe.docstatus == 1)
+                & (boe.posting_date.between(self.from_date, self.to_date))
+            )
+            .groupby(boe.name, boe.posting_date, boe.total_taxable_value)
+        ).run(as_dict=True)
+
+        inputs, capital_goods = [], []
+        for row in rows:
+            is_cg = bool(flt(row.is_fixed_asset))
+            row.update(
+                {
+                    "taxable_value": flt(row.taxable_value),
+                    "igst": flt(row.igst),
+                    "cgst": 0.0,
+                    "sgst": 0.0,
+                    "cess": flt(row.cess),
+                    "itc_classification": "Import Of Goods",
+                    "doc_route": "bill-of-entry",
+                }
+            )
+            (capital_goods if is_cg else inputs).append(row)
+
+        return {
+            GSTR9_Row.TABLE_6E_INPUTS: inputs,
+            GSTR9_Row.TABLE_6E_CAPITAL_GOODS: capital_goods,
+        }
+
+    # ────────────────────────────────────────────────────────
+    # Internal: Advances (Table 4F)
+    # ────────────────────────────────────────────────────────
+
+    def _get_advances_data(self):
+        """
+        Get net advances (received minus adjusted) for the entire FY.
+        Reuses GSTR-1 advance query logic (GSTR11A11BData).
+        """
+        from india_compliance.gst_india.utils import get_gst_accounts_by_type
+        from india_compliance.gst_india.utils.gstr_1.gstr_1_data import GSTR11A11BData
+
+        result = _empty_row()
+        gst_accounts = get_gst_accounts_by_type(self.company, "Output")
+
+        filters = frappe._dict(
+            company=self.company,
+            company_gstin=self.company_gstin,
+            from_date=self.from_date,
+            to_date=self.to_date,
+        )
+
+        adv_data = GSTR11A11BData(filters, gst_accounts)
+
+        for method, multiplier in (("get_11A_query", 1), ("get_11B_query", -1)):
+            rows = getattr(adv_data, method)().run(as_dict=True)
+
+            for row in rows:
+                is_intra = row.get("place_of_supply", "")[:2] == self.company_gstin[:2]
+                tax_amount = flt(row.get("tax_amount", 0)) * multiplier
+
+                result["taxable_value"] += flt(row.get("taxable_value", 0)) * multiplier
+                result["igst"] += 0 if is_intra else tax_amount
+                result["cgst"] += (tax_amount / 2) if is_intra else 0
+                result["sgst"] += (tax_amount / 2) if is_intra else 0
+                result["cess"] += flt(row.get("cess_amount", 0)) * multiplier
+
+        return result
+
+
+# ────────────────────────────────────────────────────────────
+# Classifiers
+# ────────────────────────────────────────────────────────────
+
+
+class GSTR9OutwardClassifier:
+    """
+    Classifies outward supply (Sales Invoice) items into GSTR-9 row keys.
+
+    Reuses the GSTR-1 pattern of per-item Python conditions with
+    cache_invoice_condition for deduplication within a single item row.
+    """
+
+    def classify(self, item):
+        """Returns the GSTR-9 row key for an outward sales invoice item."""
+        self.invoice_conditions = {}
+
+        is_forward = self.is_forward(item)
+        is_b2c = self.is_b2c(item)
+
+        # ── B2C ──
+        if is_b2c:
+            # CN/DN: all items to 4A; Forward: only taxable items to 4A
+            if not is_forward or not self.is_non_taxable_item(item):
+                return GSTR9_Row.TABLE_4A
+
+            # B2C forward non-taxable items fall through to 5D/5E/5F below
+
+        # ── Credit Notes (non-B2C) ──
+        if self.is_cn(item):
+            if self.is_taxable_category(item) and not self.is_non_taxable_item(item):
+                return GSTR9_Row.TABLE_4I
+
+            return GSTR9_Row.TABLE_5H
+
+        # ── Debit Notes (non-B2C) ──
+        if self.is_dn(item):
+            if self.is_taxable_category(item) and not self.is_non_taxable_item(item):
+                return GSTR9_Row.TABLE_4J
+
+            return GSTR9_Row.TABLE_5I
+
+        # ── Forward invoices: non-taxable items by gst_treatment ──
+        if self.is_exempted(item):
+            return GSTR9_Row.TABLE_5D
+
+        if self.is_nil_rated(item):
+            return GSTR9_Row.TABLE_5E
+
+        if self.is_non_gst(item):
+            return GSTR9_Row.TABLE_5F
+
+        # ── Forward invoices: taxable items by gst_category ──
+        cat = item.gst_category
+        has_gstin = self.has_gstin(item)
+
+        if cat == "Registered Regular" and has_gstin and not item.is_reverse_charge:
+            return GSTR9_Row.TABLE_4B
+
+        if cat == "Overseas":
+            if item.is_export_with_gst:
+                return GSTR9_Row.TABLE_4C
+            return GSTR9_Row.TABLE_5A
+
+        if cat == "SEZ":
+            if item.is_export_with_gst and not item.is_reverse_charge:
+                return GSTR9_Row.TABLE_4D
+            if not item.is_export_with_gst:
+                return GSTR9_Row.TABLE_5B
+
+        if cat == "Deemed Export":
+            return GSTR9_Row.TABLE_4E
+
+        if item.is_reverse_charge and not item.ecommerce_gstin:
+            return GSTR9_Row.TABLE_5C
+
+        if self.is_ecom_sec95(item):
+            return GSTR9_Row.TABLE_5C1
+
+        return None
+
+    # ── Conditions (reuses cache_invoice_condition from GSTR-1) ──
+
+    @cache_invoice_condition
+    def is_nil_rated(self, item):
+        return item.gst_treatment == "Nil-Rated"
+
+    @cache_invoice_condition
+    def is_exempted(self, item):
+        return item.gst_treatment == "Exempted"
+
+    @cache_invoice_condition
+    def is_non_gst(self, item):
+        return item.gst_treatment == "Non-GST"
+
+    @cache_invoice_condition
+    def is_non_taxable_item(self, item):
+        return (
+            self.is_nil_rated(item) or self.is_exempted(item) or self.is_non_gst(item)
+        )
+
+    @cache_invoice_condition
+    def is_cn(self, item):
+        return bool(item.is_return)
+
+    @cache_invoice_condition
+    def is_dn(self, item):
+        return bool(item.is_debit_note)
+
+    @cache_invoice_condition
+    def is_forward(self, item):
+        return not self.is_cn(item) and not self.is_dn(item)
+
+    @cache_invoice_condition
+    def has_gstin(self, item):
+        return bool(item.billing_address_gstin)
+
+    @cache_invoice_condition
+    def is_ecom_sec95(self, item):
+        return bool(item.ecommerce_gstin) and bool(item.is_reverse_charge)
+
+    @cache_invoice_condition
+    def is_b2c(self, item):
+        return (
+            item.gst_category in ("Unregistered", "UIN Holders")
+            and not self.has_gstin(item)
+            and not self.is_ecom_sec95(item)
+        )
+
+    @cache_invoice_condition
+    def is_taxable_category(self, item):
+        """Invoice-level check: is the supply category one where tax is payable."""
+        return (
+            (
+                item.gst_category == "Registered Regular"
+                and self.has_gstin(item)
+                and not item.is_reverse_charge
+            )
+            or (item.gst_category == "Overseas" and item.is_export_with_gst)
+            or (item.gst_category == "SEZ" and item.is_export_with_gst)
+            or item.gst_category == "Deemed Export"
+        )
+
+
+class GSTR9PurchaseClassifier:
+    """
+    Classifies Purchase Invoice items into GSTR-9 row keys for
+    Table 4G (RCM tax liability) and Table 6 (ITC availed).
+
+    A single item can contribute to BOTH 4G and a Table 6 row.
+    """
+
+    def __init__(self, company_gstin):
+        self.company_gstin = company_gstin
+
+    def classify(self, item):
+        """
+        Returns (rcm_key, itc_key) — either can be None.
+
+        rcm_key: GSTR9_Row.TABLE_4G if the invoice is reverse charge.
+        itc_key: Table 6 sub-row based on itc_classification + item type.
+        """
+        rcm_key = GSTR9_Row.TABLE_4G if item.is_reverse_charge else None
+        itc_key = self._get_itc_row_key(item)
+
+        return rcm_key, itc_key
+
+    def _get_itc_row_key(self, item):
+        cls = item.itc_classification
+        if not cls:
+            return None
+
+        if self.company_gstin == (item.supplier_gstin or ""):
+            return None
+
+        if item.ineligibility_reason == "ITC restricted due to PoS rules":
+            return None
+
+        is_cg = bool(item.is_fixed_asset)
+        is_service = not item.is_fixed_asset and not item.is_stock_item
+
+        if cls == "Import Of Service":
+            return GSTR9_Row.TABLE_6F
+
+        if cls == "Input Service Distributor":
+            return GSTR9_Row.TABLE_6G
+
+        has_gstin = bool(item.supplier_gstin)
+
+        if cls == "ITC on Reverse Charge":
+            if has_gstin:
+                if is_cg:
+                    return GSTR9_Row.TABLE_6D_CAPITAL_GOODS
+                if is_service:
+                    return GSTR9_Row.TABLE_6D_INPUT_SERVICES
+                return GSTR9_Row.TABLE_6D_INPUTS
+
+            if is_cg:
+                return GSTR9_Row.TABLE_6C_CAPITAL_GOODS
+            if is_service:
+                return GSTR9_Row.TABLE_6C_INPUT_SERVICES
+            return GSTR9_Row.TABLE_6C_INPUTS
+
+        if cls == "Import Of Goods":
+            # ITC for import of goods is claimed via Bill of Entry (BOE), not the PI.
+            return None
+
+        if cls == "All Other ITC":
+            if is_cg:
+                return GSTR9_Row.TABLE_6B_CAPITAL_GOODS
+            if is_service:
+                return GSTR9_Row.TABLE_6B_INPUT_SERVICES
+            return GSTR9_Row.TABLE_6B_INPUTS
+
+        return None
+
+
+# ────────────────────────────────────────────────────────────
+# Accumulation Helpers
+# ────────────────────────────────────────────────────────────
+
+
+def _accumulate_item(
+    accumulator,
+    row_key,
+    document_number,
+    item,
+    party_field,
+    party_name_field,
+    party_gstin_field,
+    extra_fields=None,
+):
+    """
+    Accumulate item-level amounts into per-(row_key, invoice) dicts.
+
+    Multiple items from the same invoice going to the same row_key are
+    summed together, producing one output dict per unique combination.
+    """
+    acc_key = (row_key, document_number)
+
+    if acc_key not in accumulator:
+        accumulator[acc_key] = {
+            "document_number": document_number,
+            "posting_date": item.posting_date,
+            "party": getattr(item, party_field, ""),
+            "party_name": getattr(item, party_name_field, ""),
+            "party_gstin": getattr(item, party_gstin_field, "") or "",
+            "gst_category": item.gst_category,
+            **{field: 0 for field in AMOUNT_FIELDS},
+        }
+
+        if extra_fields:
+            accumulator[acc_key].update(extra_fields)
+
+    entry = accumulator[acc_key]
+    for field in AMOUNT_FIELDS:
+        entry[field] += flt(getattr(item, field, 0))
+
+
+def _build_result(accumulator):
+    """
+    Convert the flat accumulator dict keyed by (row_key, invoice_name)
+    into {row_key: [invoice_dicts]}.
+    """
+    result = {}
+    for (row_key, _), inv_data in accumulator.items():
+        result.setdefault(row_key, []).append(inv_data)
+
+    return result

--- a/india_compliance/gst_india/utils/gstr_9/gstr_9_data.py
+++ b/india_compliance/gst_india/utils/gstr_9/gstr_9_data.py
@@ -15,7 +15,8 @@ from india_compliance.gst_india.utils.gstr_9 import (
 
 
 class GSTR9BooksData(GSTR1Query, GSTR3BQuery):
-    """Computes GSTR-9 books data from ERP transactions for a given company, GSTIN, and financial year.
+    """
+    Computes GSTR-9 books data from ERP transactions for a given company, GSTIN, and financial year.
 
     Returns classified invoice-level data (books format):
       {row_key: {doc_number: invoice_dict}}  — for drillable rows (GSTR-1 style)
@@ -207,8 +208,7 @@ class GSTR9BooksData(GSTR1Query, GSTR3BQuery):
         return {GSTR9_Row.TABLE_18: self._get_hsn_data("inward")}
 
     def _get_hsn_data(self, direction):
-        """
-        Reuse the standalone HSN report functions for exact data parity.
+        """Reuse the standalone HSN report functions for exact data parity.
 
         Converts report field names to the GSTR-9 display format and splits
         into goods (HSN not starting with '99') and services.
@@ -647,8 +647,9 @@ class GSTR9BooksData(GSTR1Query, GSTR3BQuery):
 
     def _build_result(self, accumulator):
         """
-        Convert the flat accumulator dict keyed by (row_key, invoice_name)
-        into {row_key: {invoice_name: invoice_dict}} — the same nested-dict
+        Convert the flat accumulator dict keyed by (row_key, invoice_name).
+
+        Returns {row_key: {invoice_name: invoice_dict}} — the same nested-dict
         format used by GSTR-1 books data.
         """
         result = {}

--- a/india_compliance/gst_india/utils/gstr_9/gstr_9_data.py
+++ b/india_compliance/gst_india/utils/gstr_9/gstr_9_data.py
@@ -40,7 +40,7 @@ class GSTR9BooksData(GSTR1Query):
 
     def get_data(self):
         """
-        Returns books data: {row_key → {doc_number: invoice_dict} | {amounts} | structure}.
+        Returns books data.
 
         Invoice dicts are stored for drillable rows (GSTR-1 nested-dict
         format) so the detail view can read from the cached snapshot
@@ -603,11 +603,6 @@ class GSTR9BooksData(GSTR1Query):
         return result
 
 
-# ────────────────────────────────────────────────────────────
-# Classifiers
-# ────────────────────────────────────────────────────────────
-
-
 class GSTR9OutwardClassifier:
     """
     Classifies outward supply (Sales Invoice) items into GSTR-9 row keys.
@@ -659,7 +654,11 @@ class GSTR9OutwardClassifier:
         cat = item.gst_category
         has_gstin = self.has_gstin(item)
 
-        if cat == "Registered Regular" and has_gstin and not item.is_reverse_charge:
+        if (
+            cat in ("Registered Regular", "UIN Holders")
+            and has_gstin
+            and not item.is_reverse_charge
+        ):
             return GSTR9_Row.TABLE_4B
 
         if cat == "Overseas":
@@ -726,18 +725,14 @@ class GSTR9OutwardClassifier:
 
     @cache_invoice_condition
     def is_b2c(self, item):
-        return (
-            item.gst_category in ("Unregistered", "UIN Holders")
-            and not self.has_gstin(item)
-            and not self.is_ecom_sec95(item)
-        )
+        return item.gst_category == "Unregistered" and not self.is_ecom_sec95(item)
 
     @cache_invoice_condition
     def is_taxable_category(self, item):
         """Invoice-level check: is the supply category one where tax is payable."""
         return (
             (
-                item.gst_category == "Registered Regular"
+                item.gst_category in ("Registered Regular", "UIN Holders")
                 and self.has_gstin(item)
                 and not item.is_reverse_charge
             )
@@ -818,11 +813,6 @@ class GSTR9PurchaseClassifier:
             return GSTR9_Row.TABLE_6B_INPUTS
 
         return None
-
-
-# ────────────────────────────────────────────────────────────
-# Accumulation Helpers
-# ────────────────────────────────────────────────────────────
 
 
 def _get_transaction_type(item, is_purchase):

--- a/india_compliance/gst_india/utils/gstr_9/gstr_9_data.py
+++ b/india_compliance/gst_india/utils/gstr_9/gstr_9_data.py
@@ -259,7 +259,7 @@ class GSTR9BooksData(GSTR1Query, GSTR3BQuery):
         Returns {row_key: [invoice_dicts]}.
         """
         query = self._get_outward_items_query()
-        classifier = GSTR9OutwardClassifier()
+        classifier = GSTR9SalesClassifier()
         accumulator = {}
 
         with frappe.db.unbuffered_cursor():
@@ -268,7 +268,7 @@ class GSTR9BooksData(GSTR1Query, GSTR3BQuery):
                 if not row_key:
                     continue
 
-                _accumulate_item(
+                self._accumulate_item(
                     accumulator,
                     row_key,
                     item.invoice_no,
@@ -279,7 +279,7 @@ class GSTR9BooksData(GSTR1Query, GSTR3BQuery):
                     is_purchase=False,
                 )
 
-        return _build_result(accumulator)
+        return self._build_result(accumulator)
 
     def _get_outward_items_query(self):
         return self.get_base_query()
@@ -303,7 +303,7 @@ class GSTR9BooksData(GSTR1Query, GSTR3BQuery):
                 rcm_key, itc_key = classifier.classify(item)
 
                 if rcm_key:
-                    _accumulate_item(
+                    self._accumulate_item(
                         accumulator,
                         rcm_key,
                         item.voucher_no,
@@ -315,7 +315,7 @@ class GSTR9BooksData(GSTR1Query, GSTR3BQuery):
                     )
 
                 if itc_key:
-                    _accumulate_item(
+                    self._accumulate_item(
                         accumulator,
                         itc_key,
                         item.voucher_no,
@@ -327,7 +327,7 @@ class GSTR9BooksData(GSTR1Query, GSTR3BQuery):
                         extra_fields={"itc_classification": item.itc_classification},
                     )
 
-        return _build_result(accumulator)
+        return self._build_result(accumulator)
 
     def _get_purchase_items_query(self):
         item_doc = frappe.qb.DocType("Item")
@@ -553,68 +553,172 @@ class GSTR9BooksData(GSTR1Query, GSTR3BQuery):
 
         return result
 
+    def _get_transaction_type(self, item, is_purchase):
+        """Determine transaction type string from invoice flags."""
+        if getattr(item, "is_return", False):
+            return "Return" if is_purchase else "Credit Note"
+        if getattr(item, "is_debit_note", False):
+            return "Debit Note"
+        return "Bill" if is_purchase else "Invoice"
 
-class GSTR9OutwardClassifier:
+    def _accumulate_item(
+        self,
+        accumulator,
+        row_key,
+        document_number,
+        item,
+        party_name_field,
+        party_gstin_field,
+        party_gstin_key,
+        is_purchase=False,
+        extra_fields=None,
+    ):
+        """
+        Accumulate item-level amounts into per-(row_key, invoice) dicts.
+
+        Produces GSTR-1-style invoice dicts with an `items` list for per-item
+        tax breakdown and `total_*_amount` fields for invoice-level aggregates.
+        Multiple items from the same invoice going to the same row_key are
+        appended to the `items` list and summed into the totals.
+        """
+        acc_key = (row_key, document_number)
+
+        if acc_key not in accumulator:
+            document_value = flt(item.invoice_total)
+            entry = {
+                "document_number": document_number,
+                "document_date": str(item.posting_date),
+                party_gstin_key: getattr(item, party_gstin_field, "") or "",
+                party_name_field: getattr(item, party_name_field, ""),
+                "gst_category": item.gst_category,
+                "place_of_supply": getattr(item, "place_of_supply", "") or "",
+                "reverse_charge": "Y" if item.is_reverse_charge else "N",
+                "transaction_type": self._get_transaction_type(item, is_purchase),
+                "document_value": document_value,
+                "shipping_bill_number": getattr(item, "shipping_bill_number", "") or "",
+                "shipping_bill_date": str(getattr(item, "shipping_bill_date", "") or ""),
+                "port_code": getattr(item, "shipping_port_code", "") or "",
+                "items": [],
+                "total_taxable_value": 0.0,
+                "total_igst_amount": 0.0,
+                "total_cgst_amount": 0.0,
+                "total_sgst_amount": 0.0,
+                "total_cess_amount": 0.0,
+            }
+            if extra_fields:
+                entry.update(extra_fields)
+            accumulator[acc_key] = entry
+
+        entry = accumulator[acc_key]
+
+        tax_rate = flt(getattr(item, "gst_rate", 0))
+        taxable_value = flt(item.taxable_value)
+        igst_amount = flt(item.igst_amount)
+        cgst_amount = flt(item.cgst_amount)
+        sgst_amount = flt(item.sgst_amount)
+        cess_amount = flt(item.get("total_cess_amount", item.cess_amount))
+
+        # Group items by tax_rate — same rate merges into one item entry (GSTR-1 pattern)
+        existing = next((i for i in entry["items"] if i["tax_rate"] == tax_rate), None)
+        if existing:
+            existing["taxable_value"] += taxable_value
+            existing["igst_amount"] += igst_amount
+            existing["cgst_amount"] += cgst_amount
+            existing["sgst_amount"] += sgst_amount
+            existing["cess_amount"] += cess_amount
+        else:
+            item_dict = {
+                "taxable_value": taxable_value,
+                "igst_amount": igst_amount,
+                "cgst_amount": cgst_amount,
+                "sgst_amount": sgst_amount,
+                "cess_amount": cess_amount,
+                "tax_rate": tax_rate,
+            }
+            if extra_fields and "itc_classification" in extra_fields:
+                item_dict["itc_classification"] = extra_fields["itc_classification"]
+            entry["items"].append(item_dict)
+
+        entry["total_taxable_value"] += taxable_value
+        entry["total_igst_amount"] += igst_amount
+        entry["total_cgst_amount"] += cgst_amount
+        entry["total_sgst_amount"] += sgst_amount
+        entry["total_cess_amount"] += cess_amount
+
+    def _build_result(self, accumulator):
+        """
+        Convert the flat accumulator dict keyed by (row_key, invoice_name)
+        into {row_key: {invoice_name: invoice_dict}} — the same nested-dict
+        format used by GSTR-1 books data.
+        """
+        result = {}
+        for (row_key, doc_num), inv_data in accumulator.items():
+            result.setdefault(row_key, {})[doc_num] = inv_data
+
+        return result
+
+
+class GSTR9SalesClassifier:
     """Classifies outward supply (Sales Invoice) items into GSTR-9 row keys."""
 
     def classify(self, item):
         """Returns the GSTR-9 row key for an outward sales invoice item."""
-        is_forward = self.is_forward(item)
-        is_b2c = self.is_b2c(item)
-
-        # ── B2C ──
-        if is_b2c:
-            # CN/DN: all items to 4A; Forward: only taxable items to 4A
-            if not is_forward or not self.is_non_taxable_item(item):
-                return GSTR9_Row.TABLE_4A
-
-            # B2C forward non-taxable items fall through to 5D/5E/5F below
-
-        # ── Credit Notes (non-B2C) ──
+        if self.is_b2c(item):
+            return self._classify_b2c(item)
         if self.is_cn(item):
-            if self.is_taxable_category(item) and not self.is_non_taxable_item(item):
-                return GSTR9_Row.TABLE_4I
-
-            return GSTR9_Row.TABLE_5H
-
-        # ── Debit Notes (non-B2C) ──
+            return self._classify_cn(item)
         if self.is_dn(item):
-            if self.is_taxable_category(item) and not self.is_non_taxable_item(item):
-                return GSTR9_Row.TABLE_4J
+            return self._classify_dn(item)
+        if self.is_non_taxable_item(item):
+            return self._classify_non_taxable_forward(item)
+        return self._classify_taxable_forward(item)
 
-            return GSTR9_Row.TABLE_5I
+    # ── Per-segment classifiers ──
 
-        # ── Forward invoices: non-taxable items by gst_treatment ──
+    def _classify_b2c(self, item):
+        # CN/DN: all items to 4A; Forward: only taxable items to 4A
+        if not self.is_forward(item) or not self.is_non_taxable_item(item):
+            return GSTR9_Row.TABLE_4A
+        # B2C forward non-taxable → 5D / 5E / 5F
+        return self._classify_non_taxable_forward(item)
+
+    def _classify_cn(self, item):
+        if self.is_taxable_category(item) and not self.is_non_taxable_item(item):
+            return GSTR9_Row.TABLE_4I
+        return GSTR9_Row.TABLE_5H
+
+    def _classify_dn(self, item):
+        if self.is_taxable_category(item) and not self.is_non_taxable_item(item):
+            return GSTR9_Row.TABLE_4J
+        return GSTR9_Row.TABLE_5I
+
+    def _classify_non_taxable_forward(self, item):
         if self.is_exempted(item):
             return GSTR9_Row.TABLE_5D
-
         if self.is_nil_rated(item):
             return GSTR9_Row.TABLE_5E
-
         if self.is_non_gst(item):
             return GSTR9_Row.TABLE_5F
+        return None
 
-        # ── Forward invoices: taxable items by gst_category ──
+    def _classify_taxable_forward(self, item):
         cat = item.gst_category
-        has_gstin = self.has_gstin(item)
 
         if (
             cat in ("Registered Regular", "UIN Holders", "Registered Composition")
-            and has_gstin
+            and self.has_gstin(item)
             and not item.is_reverse_charge
         ):
             return GSTR9_Row.TABLE_4B
 
         if cat == "Overseas":
-            if item.is_export_with_gst:
-                return GSTR9_Row.TABLE_4C
-            return GSTR9_Row.TABLE_5A
+            return GSTR9_Row.TABLE_4C if item.is_export_with_gst else GSTR9_Row.TABLE_5A
 
         if cat == "SEZ":
-            if item.is_export_with_gst and not item.is_reverse_charge:
-                return GSTR9_Row.TABLE_4D
-            if not item.is_export_with_gst:
-                return GSTR9_Row.TABLE_5B
+            sez_row = self._classify_sez(item)
+            if sez_row is not None:
+                return sez_row
+            # SEZ + is_export_with_gst + is_reverse_charge falls through to RC check below
 
         if cat == "Deemed Export":
             return GSTR9_Row.TABLE_4E
@@ -625,6 +729,13 @@ class GSTR9OutwardClassifier:
         if self.is_ecom_sec95(item):
             return GSTR9_Row.TABLE_5C1
 
+        return None
+
+    def _classify_sez(self, item):
+        if item.is_export_with_gst and not item.is_reverse_charge:
+            return GSTR9_Row.TABLE_4D
+        if not item.is_export_with_gst:
+            return GSTR9_Row.TABLE_5B
         return None
 
     # ── Conditions ──
@@ -698,160 +809,57 @@ class GSTR9PurchaseClassifier:
         return rcm_key, itc_key
 
     def _get_itc_row_key(self, item):
+        if not self._is_itc_eligible(item):
+            return None
+
         cls = item.itc_classification
-        if not cls:
-            return None
-
-        if self.company_gstin == (item.supplier_gstin or ""):
-            return None
-
-        if item.ineligibility_reason == "ITC restricted due to PoS rules":
-            return None
-
-        if item.gst_treatment in ("Nil-Rated", "Exempted", "Non-GST"):
-            return None
-
         is_cg = bool(item.is_fixed_asset)
         is_service = not item.is_fixed_asset and not item.is_stock_item
 
         if cls == "Import Of Service":
             return GSTR9_Row.TABLE_6F
-
         if cls == "Input Service Distributor":
             return GSTR9_Row.TABLE_6G
-
-        has_gstin = bool(item.supplier_gstin)
-
         if cls == "ITC on Reverse Charge":
-            if has_gstin:
-                if is_cg:
-                    return GSTR9_Row.TABLE_6D_CAPITAL_GOODS
-                if is_service:
-                    return GSTR9_Row.TABLE_6D_INPUT_SERVICES
-                return GSTR9_Row.TABLE_6D_INPUTS
-
-            if is_cg:
-                return GSTR9_Row.TABLE_6C_CAPITAL_GOODS
-            if is_service:
-                return GSTR9_Row.TABLE_6C_INPUT_SERVICES
-            return GSTR9_Row.TABLE_6C_INPUTS
-
+            return self._get_rcm_row(item, is_cg, is_service)
         if cls == "Import Of Goods":
-            if is_cg:
-                return GSTR9_Row.TABLE_6E_CAPITAL_GOODS
-            return GSTR9_Row.TABLE_6E_INPUTS
-
+            return self._get_import_goods_row(is_cg)
         if cls == "All Other ITC":
-            if is_cg:
-                return GSTR9_Row.TABLE_6B_CAPITAL_GOODS
-            if is_service:
-                return GSTR9_Row.TABLE_6B_INPUT_SERVICES
-            return GSTR9_Row.TABLE_6B_INPUTS
+            return self._get_all_other_itc_row(is_cg, is_service)
 
         return None
 
+    def _is_itc_eligible(self, item):
+        if not item.itc_classification:
+            return False
+        if self.company_gstin == (item.supplier_gstin or ""):
+            return False
+        if item.ineligibility_reason == "ITC restricted due to PoS rules":
+            return False
+        if item.gst_treatment in ("Nil-Rated", "Exempted", "Non-GST"):
+            return False
+        return True
 
-def _get_transaction_type(item, is_purchase):
-    """Determine transaction type string from invoice flags."""
-    if getattr(item, "is_return", False):
-        return "Return" if is_purchase else "Credit Note"
-    if getattr(item, "is_debit_note", False):
-        return "Debit Note"
-    return "Bill" if is_purchase else "Invoice"
+    def _get_rcm_row(self, item, is_cg, is_service):
+        if bool(item.supplier_gstin):
+            if is_cg:
+                return GSTR9_Row.TABLE_6D_CAPITAL_GOODS
+            if is_service:
+                return GSTR9_Row.TABLE_6D_INPUT_SERVICES
+            return GSTR9_Row.TABLE_6D_INPUTS
 
+        if is_cg:
+            return GSTR9_Row.TABLE_6C_CAPITAL_GOODS
+        if is_service:
+            return GSTR9_Row.TABLE_6C_INPUT_SERVICES
+        return GSTR9_Row.TABLE_6C_INPUTS
 
-def _accumulate_item(
-    accumulator,
-    row_key,
-    document_number,
-    item,
-    party_name_field,
-    party_gstin_field,
-    party_gstin_key,
-    is_purchase=False,
-    extra_fields=None,
-):
-    """
-    Accumulate item-level amounts into per-(row_key, invoice) dicts.
+    def _get_import_goods_row(self, is_cg):
+        return GSTR9_Row.TABLE_6E_CAPITAL_GOODS if is_cg else GSTR9_Row.TABLE_6E_INPUTS
 
-    Produces GSTR-1-style invoice dicts with an `items` list for per-item
-    tax breakdown and `total_*_amount` fields for invoice-level aggregates.
-    Multiple items from the same invoice going to the same row_key are
-    appended to the `items` list and summed into the totals.
-    """
-    acc_key = (row_key, document_number)
-
-    if acc_key not in accumulator:
-        document_value = flt(item.invoice_total)
-        entry = {
-            "document_number": document_number,
-            "document_date": str(item.posting_date),
-            party_gstin_key: getattr(item, party_gstin_field, "") or "",
-            party_name_field: getattr(item, party_name_field, ""),
-            "gst_category": item.gst_category,
-            "place_of_supply": getattr(item, "place_of_supply", "") or "",
-            "reverse_charge": "Y" if item.is_reverse_charge else "N",
-            "transaction_type": _get_transaction_type(item, is_purchase),
-            "document_value": document_value,
-            "shipping_bill_number": getattr(item, "shipping_bill_number", "") or "",
-            "shipping_bill_date": str(getattr(item, "shipping_bill_date", "") or ""),
-            "port_code": getattr(item, "shipping_port_code", "") or "",
-            "items": [],
-            "total_taxable_value": 0.0,
-            "total_igst_amount": 0.0,
-            "total_cgst_amount": 0.0,
-            "total_sgst_amount": 0.0,
-            "total_cess_amount": 0.0,
-        }
-        if extra_fields:
-            entry.update(extra_fields)
-        accumulator[acc_key] = entry
-
-    entry = accumulator[acc_key]
-
-    tax_rate = flt(getattr(item, "gst_rate", 0))
-    taxable_value = flt(item.taxable_value)
-    igst_amount = flt(item.igst_amount)
-    cgst_amount = flt(item.cgst_amount)
-    sgst_amount = flt(item.sgst_amount)
-    cess_amount = flt(item.get("total_cess_amount", item.cess_amount))
-
-    # Group items by tax_rate — same rate merges into one item entry (GSTR-1 pattern)
-    existing = next((i for i in entry["items"] if i["tax_rate"] == tax_rate), None)
-    if existing:
-        existing["taxable_value"] += taxable_value
-        existing["igst_amount"] += igst_amount
-        existing["cgst_amount"] += cgst_amount
-        existing["sgst_amount"] += sgst_amount
-        existing["cess_amount"] += cess_amount
-    else:
-        item_dict = {
-            "taxable_value": taxable_value,
-            "igst_amount": igst_amount,
-            "cgst_amount": cgst_amount,
-            "sgst_amount": sgst_amount,
-            "cess_amount": cess_amount,
-            "tax_rate": tax_rate,
-        }
-        if extra_fields and "itc_classification" in extra_fields:
-            item_dict["itc_classification"] = extra_fields["itc_classification"]
-        entry["items"].append(item_dict)
-
-    entry["total_taxable_value"] += taxable_value
-    entry["total_igst_amount"] += igst_amount
-    entry["total_cgst_amount"] += cgst_amount
-    entry["total_sgst_amount"] += sgst_amount
-    entry["total_cess_amount"] += cess_amount
-
-
-def _build_result(accumulator):
-    """
-    Convert the flat accumulator dict keyed by (row_key, invoice_name)
-    into {row_key: {invoice_name: invoice_dict}} — the same nested-dict
-    format used by GSTR-1 books data.
-    """
-    result = {}
-    for (row_key, doc_num), inv_data in accumulator.items():
-        result.setdefault(row_key, {})[doc_num] = inv_data
-
-    return result
+    def _get_all_other_itc_row(self, is_cg, is_service):
+        if is_cg:
+            return GSTR9_Row.TABLE_6B_CAPITAL_GOODS
+        if is_service:
+            return GSTR9_Row.TABLE_6B_INPUT_SERVICES
+        return GSTR9_Row.TABLE_6B_INPUTS

--- a/india_compliance/gst_india/utils/gstr_9/gstr_9_data.py
+++ b/india_compliance/gst_india/utils/gstr_9/gstr_9_data.py
@@ -2,27 +2,21 @@
 # For license information, please see license.txt
 
 import frappe
-from frappe.query_builder import Case, Criterion
-from frappe.query_builder.functions import IfNull, Max, Sum
+from frappe.query_builder import Case
+from frappe.query_builder.functions import IfNull
 from frappe.utils import flt
 
-from india_compliance.gst_india.utils.gstr_1.gstr_1_data import (
-    GSTR1Query,
-    cache_invoice_condition,
-)
+from india_compliance.gst_india.utils.gstr3b.gstr3b_data import GSTR3BQuery
+from india_compliance.gst_india.utils.gstr_1.gstr_1_data import GSTR1Query
 from india_compliance.gst_india.utils.gstr_9 import (
     GSTR9_Row,
     _empty_row,
 )
 
 
-class GSTR9BooksData(GSTR1Query):
+class GSTR9BooksData(GSTR1Query, GSTR3BQuery):
     """
     Computes GSTR-9 books data from ERP (Sales/Purchase Invoices, Journal Entries) for a given company, GSTIN, and financial year.
-
-    Inherits GSTR1Query to reuse self.si, self.si_item DocType references and get_query_with_common_filters() for applying company/GSTIN/date filters without duplication.
-
-    Uses frappe.db.unbuffered_cursor() (SSCursor) so rows are streamed from the server one at a time — classification happens in a Python loop without loading the full result set into memory.
 
     Returns classified invoice-level data (books format):
       {row_key: {doc_number: invoice_dict}}  — for drillable rows (GSTR-1 style)
@@ -31,38 +25,43 @@ class GSTR9BooksData(GSTR1Query):
     """
 
     def __init__(self, filters):
-        # Sets self.si, self.si_item, self.si_taxes, self.filters
-        super().__init__(filters)
+        self.filters = frappe._dict(filters or {})
+        self.si = frappe.qb.DocType("Sales Invoice")
+        self.si_item = frappe.qb.DocType("Sales Invoice Item")
+        self.si_taxes = frappe.qb.DocType("Sales Taxes and Charges")
+        self.additional_si_columns = []
+        self.additional_si_item_columns = []
+        # GSTR3BQuery attrs
+        self.PI = frappe.qb.DocType("Purchase Invoice")
+        self.PI_ITEM = frappe.qb.DocType("Purchase Invoice Item")
+        self.BOE = frappe.qb.DocType("Bill of Entry")
+        self.BOE_ITEM = frappe.qb.DocType("Bill of Entry Item")
+        self.filters.filter_by = "Posting Date"
         self.company = self.filters.company
         self.company_gstin = self.filters.company_gstin
         self.from_date = self.filters.from_date
         self.to_date = self.filters.to_date
 
+    def get_query_with_common_filters(self, query, doc=None):
+        if doc is None:
+            return GSTR1Query.get_query_with_common_filters(self, query)
+        return GSTR3BQuery.get_query_with_common_filters(self, query, doc)
+
     def get_data(self):
         """
         Returns books data.
-
-        Invoice dicts are stored for drillable rows (GSTR-1 nested-dict
-        format) so the detail view can read from the cached snapshot
-        without re-querying.
         """
         data = {}
 
-        # Fetch all outward (Sales Invoice) items once, classify into Table 4 & 5
         data.update(self._get_classified_outward_supplies())
-
-        # Fetch all purchase items once, classify into Table 4G & Table 6
         data.update(self._get_classified_purchase_invoices())
 
-        # BOE records → split into 6E Inputs / 6E Capital Goods
         for row_key, records in self._get_boe_books().items():
             if records:
                 data.setdefault(row_key, {}).update(records)
 
-        # Advances (4F) — reuses GSTR-1 advance query logic
         data[GSTR9_Row.TABLE_4F] = self._get_advances_data()
 
-        # Manual / empty rows
         for key in (
             GSTR9_Row.TABLE_4G1,
             GSTR9_Row.TABLE_4K,
@@ -213,7 +212,7 @@ class GSTR9BooksData(GSTR1Query):
         """Reuse the standalone HSN report functions for exact data parity.
 
         Converts report field names to the GSTR-9 display format and splits
-        into goods (HSN not starting with '99') and services (SAC codes).
+        into goods (HSN not starting with '99') and services.
         """
         from india_compliance.gst_india.report.hsn_wise_summary_of_inward_supplies.hsn_wise_summary_of_inward_supplies import (
             get_data as get_inward_hsn_data,
@@ -230,11 +229,7 @@ class GSTR9BooksData(GSTR1Query):
             filter_by="Posting Date",  # GSTR-9 always uses posting date range
         )
 
-        rows = (
-            get_outward_hsn_data(filters)
-            if direction == "outward"
-            else get_inward_hsn_data(filters)
-        )
+        rows = get_outward_hsn_data(filters) if direction == "outward" else get_inward_hsn_data(filters)
 
         goods, services = [], []
         for row in rows:
@@ -250,9 +245,7 @@ class GSTR9BooksData(GSTR1Query):
                 "sgst": row.get("total_sgst_amount"),
                 "cess": row.get("total_cess_amount"),
             }
-            (
-                services if str(row.get("hsn_code") or "").startswith("99") else goods
-            ).append(mapped)
+            (services if str(row.get("hsn_code") or "").startswith("99") else goods).append(mapped)
 
         return {"goods": goods, "services": services}
 
@@ -264,9 +257,6 @@ class GSTR9BooksData(GSTR1Query):
         """
         Fetch all Sales Invoice items in a single query, classify each item
         into a GSTR-9 row in Python, and accumulate per (row_key, invoice).
-
-        Uses unbuffered cursor (SSCursor) so rows are streamed from the server
-        one at a time instead of loading the full result set into memory.
 
         Returns {row_key: [invoice_dicts]}.
         """
@@ -283,7 +273,7 @@ class GSTR9BooksData(GSTR1Query):
                 _accumulate_item(
                     accumulator,
                     row_key,
-                    item.name,
+                    item.invoice_no,
                     item,
                     party_name_field="customer_name",
                     party_gstin_field="billing_address_gstin",
@@ -294,56 +284,7 @@ class GSTR9BooksData(GSTR1Query):
         return _build_result(accumulator)
 
     def _get_outward_items_query(self):
-        """
-        Build the outward supply query using GSTR-1's common filter infrastructure.
-
-        Calls get_query_with_common_filters() (inherited from GSTR1Query) to
-        apply company / company_gstin / from_date / to_date filters — reusing
-        the GSTR-1 filter logic instead of duplicating it.
-        """
-        query = (
-            frappe.qb.from_(self.si)
-            .inner_join(self.si_item)
-            .on(
-                (self.si_item.parent == self.si.name)
-                & (self.si_item.parenttype == "Sales Invoice")
-            )
-            .select(
-                self.si.name,
-                self.si.posting_date,
-                self.si.customer,
-                self.si.customer_name,
-                self.si.billing_address_gstin,
-                self.si.gst_category,
-                self.si.place_of_supply,
-                self.si.is_return,
-                self.si.is_debit_note,
-                self.si.is_reverse_charge,
-                self.si.is_export_with_gst,
-                self.si.base_rounded_total,
-                self.si.base_grand_total,
-                IfNull(self.si.shipping_bill_number, "").as_("shipping_bill_number"),
-                self.si.shipping_bill_date,
-                IfNull(self.si.port_code, "").as_("port_code"),
-                IfNull(self.si.ecommerce_gstin, "").as_("ecommerce_gstin"),
-                IfNull(self.si_item.gst_treatment, "").as_("gst_treatment"),
-                self.si_item.taxable_value,
-                self.si_item.igst_amount.as_("igst"),
-                self.si_item.cgst_amount.as_("cgst"),
-                self.si_item.sgst_amount.as_("sgst"),
-                self.si_item.cess_amount.as_("cess"),
-                (
-                    self.si_item.igst_rate
-                    + self.si_item.cgst_rate
-                    + self.si_item.sgst_rate
-                ).as_("tax_rate"),
-            )
-            .where(self.si.docstatus == 1)
-            .where(self.si.is_opening != "Yes")
-            .orderby(self.si.posting_date)
-        )
-        # Applies company / company_gstin / from_date / to_date — reuses GSTR-1 logic
-        return self.get_query_with_common_filters(query)
+        return self.get_base_query()
 
     # ────────────────────────────────────────────────────────
     # Purchase Invoices — Table 4G & Table 6
@@ -353,10 +294,6 @@ class GSTR9BooksData(GSTR1Query):
         """
         Fetch all relevant Purchase Invoice items in a single query, classify
         each item for Table 4G (RCM) and/or Table 6 (ITC), and accumulate.
-
-        A single invoice item can contribute to BOTH 4G and a Table 6 row.
-        Uses unbuffered cursor (SSCursor) so rows are streamed from the server
-        one at a time instead of loading the full result set into memory.
 
         Returns {row_key: [invoice_dicts]}.
         """
@@ -372,7 +309,7 @@ class GSTR9BooksData(GSTR1Query):
                     _accumulate_item(
                         accumulator,
                         rcm_key,
-                        item.name,
+                        item.voucher_no,
                         item,
                         party_name_field="supplier_name",
                         party_gstin_field="supplier_gstin",
@@ -384,7 +321,7 @@ class GSTR9BooksData(GSTR1Query):
                     _accumulate_item(
                         accumulator,
                         itc_key,
-                        item.name,
+                        item.voucher_no,
                         item,
                         party_name_field="supplier_name",
                         party_gstin_field="supplier_gstin",
@@ -396,143 +333,85 @@ class GSTR9BooksData(GSTR1Query):
         return _build_result(accumulator)
 
     def _get_purchase_items_query(self):
-        """
-        Build the purchase items query (GSTR-1 has no PI equivalent, so filters
-        are applied directly here rather than via get_query_with_common_filters).
-
-        Includes items from invoices that are EITHER:
-        - Reverse charge (for Table 4G)
-        - Have ITC classification (for Table 6)
-        """
-        pi = frappe.qb.DocType("Purchase Invoice")
-        pi_item = frappe.qb.DocType("Purchase Invoice Item")
         item_doc = frappe.qb.DocType("Item")
-
-        rcm_condition = pi.is_reverse_charge == 1
-        itc_condition = (IfNull(pi.itc_classification, "") != "") & (
-            pi.company_gstin != IfNull(pi.supplier_gstin, "")
-        )
-
         return (
-            frappe.qb.from_(pi)
-            .inner_join(pi_item)
-            .on(
-                (pi_item.parent == pi.name) & (pi_item.parenttype == "Purchase Invoice")
-            )
+            self.get_base_purchase_query()
             .left_join(item_doc)
-            .on(item_doc.name == pi_item.item_code)
+            .on(item_doc.name == self.PI_ITEM.item_code)
             .select(
-                pi.name,
-                pi.posting_date,
-                pi.supplier,
-                pi.supplier_name,
-                pi.supplier_gstin,
-                pi.gst_category,
-                pi.place_of_supply,
-                pi.is_return,
-                pi.is_reverse_charge,
-                pi.base_rounded_total,
-                pi.base_grand_total,
-                IfNull(pi.itc_classification, "").as_("itc_classification"),
-                IfNull(pi.ineligibility_reason, "").as_("ineligibility_reason"),
-                pi_item.is_fixed_asset,
+                self.PI.supplier,
+                self.PI.supplier_name,
+                self.PI.is_return,
+                self.PI.is_reverse_charge,
+                Case()
+                .when(self.PI.base_rounded_total != 0, self.PI.base_rounded_total)
+                .else_(self.PI.base_grand_total)
+                .as_("invoice_total"),
+                self.PI_ITEM.is_fixed_asset,
                 IfNull(item_doc.is_stock_item, 1).as_("is_stock_item"),
-                pi_item.taxable_value,
-                pi_item.igst_amount.as_("igst"),
-                pi_item.cgst_amount.as_("cgst"),
-                pi_item.sgst_amount.as_("sgst"),
-                pi_item.cess_amount.as_("cess"),
-                (pi_item.igst_rate + pi_item.cgst_rate + pi_item.sgst_rate).as_(
-                    "tax_rate"
-                ),
             )
-            .where(
-                (pi.docstatus == 1)
-                & (pi.is_opening != "Yes")
-                & (pi.company == self.company)
-                & (pi.company_gstin == self.company_gstin)
-                & (pi.posting_date.between(self.from_date, self.to_date))
-                & Criterion.any([rcm_condition, itc_condition])
-            )
-            .orderby(pi.posting_date)
         )
 
     def _get_boe_books(self):
         """
-        Individual Bill of Entry records with IGST/Cess amounts and supplier
-        info resolved from linked Purchase Invoices.
+        Bill of Entry records classified into 6E Inputs / 6E Capital Goods.
 
-        A single aggregated query joins boe_taxes, boe_item→pi, and
-        boe_item→pi_item so that tax totals, supplier details, and the
-        capital-goods flag are all computed in one database round-trip.
+        Extends the GSTR-3B BOE base query with supplier info from linked
+        Purchase Invoices, then aggregates per-item rows into per-BOE invoice
+        dicts in Python.
 
-        Returns {TABLE_6E_INPUTS: [...], TABLE_6E_CAPITAL_GOODS: [...]}.
+        Returns {TABLE_6E_INPUTS: {...}, TABLE_6E_CAPITAL_GOODS: {...}}.
         """
-        boe = frappe.qb.DocType("Bill of Entry")
-        boe_taxes = frappe.qb.DocType("India Compliance Taxes and Charges")
-        boe_item = frappe.qb.DocType("Bill of Entry Item")
-        pi = frappe.qb.DocType("Purchase Invoice")
-        pi_item = frappe.qb.DocType("Purchase Invoice Item")
-
         rows = (
-            frappe.qb.from_(boe)
-            .left_join(boe_taxes)
+            self.get_base_boe_query()
+            .left_join(self.PI)
             .on(
-                (boe_taxes.parent == boe.name)
-                & (boe_taxes.parenttype == "Bill of Entry")
+                (self.PI.name == self.BOE_ITEM.purchase_invoice)
+                & (IfNull(self.BOE_ITEM.purchase_invoice, "") != "")
             )
-            .left_join(boe_item)
-            .on(boe_item.parent == boe.name)
-            .left_join(pi)
-            .on(
-                (pi.name == boe_item.purchase_invoice)
-                & (IfNull(boe_item.purchase_invoice, "") != "")
-            )
-            .left_join(pi_item)
-            .on(boe_item.pi_detail == pi_item.name)
+            .left_join(self.PI_ITEM)
+            .on(self.BOE_ITEM.pi_detail == self.PI_ITEM.name)
             .select(
-                boe.name.as_("document_number"),
-                boe.posting_date,
-                boe.total_taxable_value.as_("taxable_value"),
-                Sum(
-                    Case()
-                    .when(boe_taxes.gst_tax_type == "igst", boe_taxes.tax_amount)
-                    .else_(0)
-                ).as_("igst"),
-                Sum(
-                    Case()
-                    .when(
-                        boe_taxes.gst_tax_type.isin(["cess", "cess_non_advol"]),
-                        boe_taxes.tax_amount,
-                    )
-                    .else_(0)
-                ).as_("cess"),
-                Max(IfNull(pi.supplier, "")).as_("party"),
-                Max(IfNull(pi.supplier_name, "")).as_("party_name"),
-                Max(IfNull(pi.supplier_gstin, "")).as_("party_gstin"),
-                Max(IfNull(pi_item.is_fixed_asset, 0)).as_("is_fixed_asset"),
+                IfNull(self.PI.supplier_name, "").as_("supplier_name"),
+                IfNull(self.PI.supplier_gstin, "").as_("supplier_gstin"),
+                IfNull(self.PI_ITEM.is_fixed_asset, 0).as_("is_fixed_asset"),
+                IfNull(self.PI.gst_category, "Overseas").as_("gst_category"),
             )
-            .where(
-                (boe.company == self.company)
-                & (boe.company_gstin == self.company_gstin)
-                & (boe.docstatus == 1)
-                & (boe.posting_date.between(self.from_date, self.to_date))
-            )
-            .groupby(boe.name, boe.posting_date, boe.total_taxable_value)
         ).run(as_dict=True)
 
-        inputs, capital_goods = {}, {}
+        # Aggregate per BOE in Python (base query is per BOE_ITEM)
+        boe_agg = {}
         for row in rows:
-            is_cg = bool(flt(row.is_fixed_asset))
-            taxable_value = flt(row.taxable_value)
-            igst = flt(row.igst)
-            cess = flt(row.cess)
+            entry = boe_agg.setdefault(
+                row.voucher_no,
+                frappe._dict(
+                    document_number=row.voucher_no,
+                    posting_date=row.posting_date,
+                    supplier_gstin=row.supplier_gstin or "",
+                    supplier_name=row.supplier_name or "",
+                    gst_category=row.gst_category or "Overseas",
+                    is_fixed_asset=flt(row.is_fixed_asset),
+                    taxable_value=0.0,
+                    igst=0.0,
+                    cess=0.0,
+                ),
+            )
+            entry.taxable_value += flt(row.taxable_value)
+            entry.igst += flt(row.igst_amount)
+            entry.cess += flt(row.cess_amount)
+
+        inputs, capital_goods = {}, {}
+        for row in boe_agg.values():
+            is_cg = bool(row.is_fixed_asset)
+            taxable_value = row.taxable_value
+            igst = row.igst
+            cess = row.cess
             invoice_dict = {
                 "document_number": row.document_number,
                 "document_date": str(row.posting_date),
-                "supplier_gstin": row.party_gstin or "",
-                "supplier_name": row.party_name or "",
-                "gst_category": "Overseas",
+                "supplier_gstin": row.supplier_gstin,
+                "supplier_name": row.supplier_name,
+                "gst_category": row.gst_category,
                 "place_of_supply": "",
                 "reverse_charge": "N",
                 "transaction_type": "Bill of Entry",
@@ -569,15 +448,21 @@ class GSTR9BooksData(GSTR1Query):
 
     def _get_advances_data(self):
         """
-        Get net advances (received minus adjusted) for the entire FY.
+        Returns drillable advances data for Table 4F as {key: invoice_dict}.
+
+        Produces two separate visible entries per Payment Entry when the same PE
+        appears in both 11A (Advance Received) and 11B (Advance Adjusted):
+          - key "{pe_name}::rcv"  → transaction_type="Advance Received"
+          - key "{pe_name}::adj"  → transaction_type="Advance Adjusted"
+
+        Both entries carry doc_route="payment-entry" so the drill-down link
+        opens the Payment Entry, not a sales/purchase invoice.
         Reuses GSTR-1 advance query logic (GSTR11A11BData).
         """
         from india_compliance.gst_india.utils import get_gst_accounts_by_type
         from india_compliance.gst_india.utils.gstr_1.gstr_1_data import GSTR11A11BData
 
-        result = _empty_row()
         gst_accounts = get_gst_accounts_by_type(self.company, "Output")
-
         filters = frappe._dict(
             company=self.company,
             company_gstin=self.company_gstin,
@@ -586,19 +471,88 @@ class GSTR9BooksData(GSTR1Query):
         )
 
         adv_data = GSTR11A11BData(filters, gst_accounts)
+        pe = adv_data.pe
 
-        for method, multiplier in (("get_11A_query", 1), ("get_11B_query", -1)):
-            rows = getattr(adv_data, method)().run(as_dict=True)
+        # 11A — one row per PE (already grouped by pe.name in get_11A_query)
+        rows_11a = (
+            adv_data.get_11A_query()
+            .select(pe.name, pe.posting_date, pe.party_name)
+            .groupby(pe.posting_date, pe.party_name)
+            .run(as_dict=True)
+        )
 
-            for row in rows:
-                is_intra = row.get("place_of_supply", "")[:2] == self.company_gstin[:2]
-                tax_amount = flt(row.get("tax_amount", 0)) * multiplier
+        # 11B — one row per pe_ref allocation; collapse into one entry per PE in Python
+        rows_11b_raw = (
+            adv_data.get_11B_query()
+            .select(pe.name, pe.posting_date, pe.party_name)
+            .groupby(pe.name, pe.posting_date, pe.party_name)
+            .run(as_dict=True)
+        )
 
-                result["taxable_value"] += flt(row.get("taxable_value", 0)) * multiplier
-                result["igst"] += 0 if is_intra else tax_amount
-                result["cgst"] += (tax_amount / 2) if is_intra else 0
-                result["sgst"] += (tax_amount / 2) if is_intra else 0
-                result["cess"] += flt(row.get("cess_amount", 0)) * multiplier
+        pe_11b = {}
+        for row in rows_11b_raw:
+            entry = pe_11b.setdefault(
+                row.name,
+                frappe._dict(
+                    name=row.name,
+                    posting_date=row.posting_date,
+                    party_name=row.party_name,
+                    place_of_supply=row.get("place_of_supply") or "",
+                    taxable_value=0.0,
+                    tax_amount=0.0,
+                    cess_amount=0.0,
+                ),
+            )
+            entry.taxable_value += flt(row.taxable_value)
+            entry.tax_amount += flt(row.tax_amount)
+            entry.cess_amount += flt(row.cess_amount)
+
+        def _make_entry(row, transaction_type, multiplier=1):
+            is_intra = (row.get("place_of_supply") or "")[:2] == self.company_gstin[:2]
+            tax_amount = flt(row.tax_amount) * multiplier
+            taxable_value = flt(row.taxable_value) * multiplier
+            cess = flt(row.cess_amount) * multiplier
+            igst = 0.0 if is_intra else tax_amount
+            cgst = (tax_amount / 2) if is_intra else 0.0
+            sgst = (tax_amount / 2) if is_intra else 0.0
+            tax_rate = round((tax_amount / taxable_value) * 100) if taxable_value else 0
+            return {
+                "document_number": row.name,
+                "document_date": str(row.posting_date or ""),
+                "customer_gstin": "",
+                "customer_name": row.get("party_name") or "",
+                "gst_category": "",
+                "place_of_supply": row.get("place_of_supply") or "",
+                "reverse_charge": "N",
+                "transaction_type": transaction_type,
+                "document_value": taxable_value + igst + cgst + sgst + cess,
+                "doc_route": "payment-entry",
+                "shipping_bill_number": "",
+                "shipping_bill_date": "",
+                "port_code": "",
+                "items": [
+                    {
+                        "taxable_value": taxable_value,
+                        "igst_amount": igst,
+                        "cgst_amount": cgst,
+                        "sgst_amount": sgst,
+                        "cess_amount": cess,
+                        "tax_rate": tax_rate,
+                    }
+                ],
+                "total_taxable_value": taxable_value,
+                "total_igst_amount": igst,
+                "total_cgst_amount": cgst,
+                "total_sgst_amount": sgst,
+                "total_cess_amount": cess,
+            }
+
+        result = {}
+        for row in rows_11a:
+            result[f"{row.name}::rcv"] = _make_entry(row, "Advance Received")
+
+        for row in pe_11b.values():
+            result[f"{row.name}::adj"] = _make_entry(row, "Advance Adjusted", multiplier=-1)
 
         return result
 
@@ -606,15 +560,10 @@ class GSTR9BooksData(GSTR1Query):
 class GSTR9OutwardClassifier:
     """
     Classifies outward supply (Sales Invoice) items into GSTR-9 row keys.
-
-    Reuses the GSTR-1 pattern of per-item Python conditions with
-    cache_invoice_condition for deduplication within a single item row.
     """
 
     def classify(self, item):
         """Returns the GSTR-9 row key for an outward sales invoice item."""
-        self.invoice_conditions = {}
-
         is_forward = self.is_forward(item)
         is_b2c = self.is_b2c(item)
 
@@ -655,7 +604,7 @@ class GSTR9OutwardClassifier:
         has_gstin = self.has_gstin(item)
 
         if (
-            cat in ("Registered Regular", "UIN Holders")
+            cat in ("Registered Regular", "UIN Holders", "Registered Composition")
             and has_gstin
             and not item.is_reverse_charge
         ):
@@ -683,56 +632,43 @@ class GSTR9OutwardClassifier:
 
         return None
 
-    # ── Conditions (reuses cache_invoice_condition from GSTR-1) ──
+    # ── Conditions ──
 
-    @cache_invoice_condition
     def is_nil_rated(self, item):
         return item.gst_treatment == "Nil-Rated"
 
-    @cache_invoice_condition
     def is_exempted(self, item):
         return item.gst_treatment == "Exempted"
 
-    @cache_invoice_condition
     def is_non_gst(self, item):
         return item.gst_treatment == "Non-GST"
 
-    @cache_invoice_condition
     def is_non_taxable_item(self, item):
-        return (
-            self.is_nil_rated(item) or self.is_exempted(item) or self.is_non_gst(item)
-        )
+        return self.is_nil_rated(item) or self.is_exempted(item) or self.is_non_gst(item)
 
-    @cache_invoice_condition
     def is_cn(self, item):
         return bool(item.is_return)
 
-    @cache_invoice_condition
     def is_dn(self, item):
         return bool(item.is_debit_note)
 
-    @cache_invoice_condition
     def is_forward(self, item):
         return not self.is_cn(item) and not self.is_dn(item)
 
-    @cache_invoice_condition
     def has_gstin(self, item):
         return bool(item.billing_address_gstin)
 
-    @cache_invoice_condition
     def is_ecom_sec95(self, item):
         return bool(item.ecommerce_gstin) and bool(item.is_reverse_charge)
 
-    @cache_invoice_condition
     def is_b2c(self, item):
         return item.gst_category == "Unregistered" and not self.is_ecom_sec95(item)
 
-    @cache_invoice_condition
     def is_taxable_category(self, item):
         """Invoice-level check: is the supply category one where tax is payable."""
         return (
             (
-                item.gst_category in ("Registered Regular", "UIN Holders")
+                item.gst_category in ("Registered Regular", "UIN Holders", "Registered Composition")
                 and self.has_gstin(item)
                 and not item.is_reverse_charge
             )
@@ -776,6 +712,9 @@ class GSTR9PurchaseClassifier:
         if item.ineligibility_reason == "ITC restricted due to PoS rules":
             return None
 
+        if item.gst_treatment in ("Nil-Rated", "Exempted", "Non-GST"):
+            return None
+
         is_cg = bool(item.is_fixed_asset)
         is_service = not item.is_fixed_asset and not item.is_stock_item
 
@@ -802,8 +741,9 @@ class GSTR9PurchaseClassifier:
             return GSTR9_Row.TABLE_6C_INPUTS
 
         if cls == "Import Of Goods":
-            # ITC for import of goods is claimed via Bill of Entry (BOE), not the PI.
-            return None
+            if is_cg:
+                return GSTR9_Row.TABLE_6E_CAPITAL_GOODS
+            return GSTR9_Row.TABLE_6E_INPUTS
 
         if cls == "All Other ITC":
             if is_cg:
@@ -846,11 +786,7 @@ def _accumulate_item(
     acc_key = (row_key, document_number)
 
     if acc_key not in accumulator:
-        document_value = (
-            flt(item.base_rounded_total)
-            if flt(item.base_rounded_total)
-            else flt(item.base_grand_total)
-        )
+        document_value = flt(item.invoice_total)
         entry = {
             "document_number": document_number,
             "document_date": str(item.posting_date),
@@ -863,7 +799,7 @@ def _accumulate_item(
             "document_value": document_value,
             "shipping_bill_number": getattr(item, "shipping_bill_number", "") or "",
             "shipping_bill_date": str(getattr(item, "shipping_bill_date", "") or ""),
-            "port_code": getattr(item, "port_code", "") or "",
+            "port_code": getattr(item, "shipping_port_code", "") or "",
             "items": [],
             "total_taxable_value": 0.0,
             "total_igst_amount": 0.0,
@@ -877,12 +813,12 @@ def _accumulate_item(
 
     entry = accumulator[acc_key]
 
-    tax_rate = flt(getattr(item, "tax_rate", 0))
+    tax_rate = flt(getattr(item, "gst_rate", 0))
     taxable_value = flt(item.taxable_value)
-    igst_amount = flt(item.igst)
-    cgst_amount = flt(item.cgst)
-    sgst_amount = flt(item.sgst)
-    cess_amount = flt(item.cess)
+    igst_amount = flt(item.igst_amount)
+    cgst_amount = flt(item.cgst_amount)
+    sgst_amount = flt(item.sgst_amount)
+    cess_amount = flt(item.get("total_cess_amount", item.cess_amount))
 
     # Group items by tax_rate — same rate merges into one item entry (GSTR-1 pattern)
     existing = next((i for i in entry["items"] if i["tax_rate"] == tax_rate), None)

--- a/india_compliance/gst_india/utils/gstr_9/gstr_9_data.py
+++ b/india_compliance/gst_india/utils/gstr_9/gstr_9_data.py
@@ -11,7 +11,6 @@ from india_compliance.gst_india.utils.gstr_1.gstr_1_data import (
     cache_invoice_condition,
 )
 from india_compliance.gst_india.utils.gstr_9 import (
-    AMOUNT_FIELDS,
     GSTR9_Row,
     _empty_row,
 )
@@ -26,9 +25,9 @@ class GSTR9BooksData(GSTR1Query):
     Uses frappe.db.unbuffered_cursor() (SSCursor) so rows are streamed from the server one at a time — classification happens in a Python loop without loading the full result set into memory.
 
     Returns classified invoice-level data (books format):
-      {row_key: [invoice_dicts]}   — for drillable rows
-      {row_key: {amount_fields}}   — for manual/aggregated-only rows
-      {row_key: special_structure}  — for Tables 14, 15, 17, 18
+      {row_key: {doc_number: invoice_dict}}  — for drillable rows (GSTR-1 style)
+      {row_key: {amount_fields}}             — for manual/aggregated-only rows
+      {row_key: special_structure}           — for Tables 14, 15, 17, 18
     """
 
     def __init__(self, filters):
@@ -41,10 +40,11 @@ class GSTR9BooksData(GSTR1Query):
 
     def get_data(self):
         """
-        Returns books data: {row_key → [invoices] | {amounts} | structure}.
+        Returns books data: {row_key → {doc_number: invoice_dict} | {amounts} | structure}.
 
-        Invoice lists are stored for drillable rows so the detail view can
-        read from the cached snapshot without re-querying.
+        Invoice dicts are stored for drillable rows (GSTR-1 nested-dict
+        format) so the detail view can read from the cached snapshot
+        without re-querying.
         """
         data = {}
 
@@ -57,7 +57,7 @@ class GSTR9BooksData(GSTR1Query):
         # BOE records → split into 6E Inputs / 6E Capital Goods
         for row_key, records in self._get_boe_books().items():
             if records:
-                data.setdefault(row_key, []).extend(records)
+                data.setdefault(row_key, {}).update(records)
 
         # Advances (4F) — reuses GSTR-1 advance query logic
         data[GSTR9_Row.TABLE_4F] = self._get_advances_data()
@@ -285,9 +285,10 @@ class GSTR9BooksData(GSTR1Query):
                     row_key,
                     item.name,
                     item,
-                    party_field="customer",
                     party_name_field="customer_name",
                     party_gstin_field="billing_address_gstin",
+                    party_gstin_key="customer_gstin",
+                    is_purchase=False,
                 )
 
         return _build_result(accumulator)
@@ -314,10 +315,16 @@ class GSTR9BooksData(GSTR1Query):
                 self.si.customer_name,
                 self.si.billing_address_gstin,
                 self.si.gst_category,
+                self.si.place_of_supply,
                 self.si.is_return,
                 self.si.is_debit_note,
                 self.si.is_reverse_charge,
                 self.si.is_export_with_gst,
+                self.si.base_rounded_total,
+                self.si.base_grand_total,
+                IfNull(self.si.shipping_bill_number, "").as_("shipping_bill_number"),
+                self.si.shipping_bill_date,
+                IfNull(self.si.port_code, "").as_("port_code"),
                 IfNull(self.si.ecommerce_gstin, "").as_("ecommerce_gstin"),
                 IfNull(self.si_item.gst_treatment, "").as_("gst_treatment"),
                 self.si_item.taxable_value,
@@ -325,6 +332,11 @@ class GSTR9BooksData(GSTR1Query):
                 self.si_item.cgst_amount.as_("cgst"),
                 self.si_item.sgst_amount.as_("sgst"),
                 self.si_item.cess_amount.as_("cess"),
+                (
+                    self.si_item.igst_rate
+                    + self.si_item.cgst_rate
+                    + self.si_item.sgst_rate
+                ).as_("tax_rate"),
             )
             .where(self.si.docstatus == 1)
             .where(self.si.is_opening != "Yes")
@@ -362,9 +374,10 @@ class GSTR9BooksData(GSTR1Query):
                         rcm_key,
                         item.name,
                         item,
-                        party_field="supplier",
                         party_name_field="supplier_name",
                         party_gstin_field="supplier_gstin",
+                        party_gstin_key="supplier_gstin",
+                        is_purchase=True,
                     )
 
                 if itc_key:
@@ -373,9 +386,10 @@ class GSTR9BooksData(GSTR1Query):
                         itc_key,
                         item.name,
                         item,
-                        party_field="supplier",
                         party_name_field="supplier_name",
                         party_gstin_field="supplier_gstin",
+                        party_gstin_key="supplier_gstin",
+                        is_purchase=True,
                         extra_fields={"itc_classification": item.itc_classification},
                     )
 
@@ -414,7 +428,11 @@ class GSTR9BooksData(GSTR1Query):
                 pi.supplier_name,
                 pi.supplier_gstin,
                 pi.gst_category,
+                pi.place_of_supply,
+                pi.is_return,
                 pi.is_reverse_charge,
+                pi.base_rounded_total,
+                pi.base_grand_total,
                 IfNull(pi.itc_classification, "").as_("itc_classification"),
                 IfNull(pi.ineligibility_reason, "").as_("ineligibility_reason"),
                 pi_item.is_fixed_asset,
@@ -424,6 +442,9 @@ class GSTR9BooksData(GSTR1Query):
                 pi_item.cgst_amount.as_("cgst"),
                 pi_item.sgst_amount.as_("sgst"),
                 pi_item.cess_amount.as_("cess"),
+                (pi_item.igst_rate + pi_item.cgst_rate + pi_item.sgst_rate).as_(
+                    "tax_rate"
+                ),
             )
             .where(
                 (pi.docstatus == 1)
@@ -500,21 +521,42 @@ class GSTR9BooksData(GSTR1Query):
             .groupby(boe.name, boe.posting_date, boe.total_taxable_value)
         ).run(as_dict=True)
 
-        inputs, capital_goods = [], []
+        inputs, capital_goods = {}, {}
         for row in rows:
             is_cg = bool(flt(row.is_fixed_asset))
-            row.update(
-                {
-                    "taxable_value": flt(row.taxable_value),
-                    "igst": flt(row.igst),
-                    "cgst": 0.0,
-                    "sgst": 0.0,
-                    "cess": flt(row.cess),
-                    "itc_classification": "Import Of Goods",
-                    "doc_route": "bill-of-entry",
-                }
-            )
-            (capital_goods if is_cg else inputs).append(row)
+            taxable_value = flt(row.taxable_value)
+            igst = flt(row.igst)
+            cess = flt(row.cess)
+            invoice_dict = {
+                "document_number": row.document_number,
+                "document_date": str(row.posting_date),
+                "supplier_gstin": row.party_gstin or "",
+                "supplier_name": row.party_name or "",
+                "gst_category": "Overseas",
+                "place_of_supply": "",
+                "reverse_charge": "N",
+                "transaction_type": "Bill of Entry",
+                "document_value": taxable_value + igst + cess,
+                "itc_classification": "Import Of Goods",
+                "doc_route": "bill-of-entry",
+                "items": [
+                    {
+                        "taxable_value": taxable_value,
+                        "igst_amount": igst,
+                        "cgst_amount": 0.0,
+                        "sgst_amount": 0.0,
+                        "cess_amount": cess,
+                        "tax_rate": 0.0,
+                    }
+                ],
+                "total_taxable_value": taxable_value,
+                "total_igst_amount": igst,
+                "total_cgst_amount": 0.0,
+                "total_sgst_amount": 0.0,
+                "total_cess_amount": cess,
+            }
+            target = capital_goods if is_cg else inputs
+            target[row.document_number] = invoice_dict
 
         return {
             GSTR9_Row.TABLE_6E_INPUTS: inputs,
@@ -783,50 +825,111 @@ class GSTR9PurchaseClassifier:
 # ────────────────────────────────────────────────────────────
 
 
+def _get_transaction_type(item, is_purchase):
+    """Determine transaction type string from invoice flags."""
+    if getattr(item, "is_return", False):
+        return "Return" if is_purchase else "Credit Note"
+    if getattr(item, "is_debit_note", False):
+        return "Debit Note"
+    return "Bill" if is_purchase else "Invoice"
+
+
 def _accumulate_item(
     accumulator,
     row_key,
     document_number,
     item,
-    party_field,
     party_name_field,
     party_gstin_field,
+    party_gstin_key,
+    is_purchase=False,
     extra_fields=None,
 ):
     """
     Accumulate item-level amounts into per-(row_key, invoice) dicts.
 
+    Produces GSTR-1-style invoice dicts with an `items` list for per-item
+    tax breakdown and `total_*_amount` fields for invoice-level aggregates.
     Multiple items from the same invoice going to the same row_key are
-    summed together, producing one output dict per unique combination.
+    appended to the `items` list and summed into the totals.
     """
     acc_key = (row_key, document_number)
 
     if acc_key not in accumulator:
-        accumulator[acc_key] = {
+        document_value = (
+            flt(item.base_rounded_total)
+            if flt(item.base_rounded_total)
+            else flt(item.base_grand_total)
+        )
+        entry = {
             "document_number": document_number,
-            "posting_date": item.posting_date,
-            "party": getattr(item, party_field, ""),
-            "party_name": getattr(item, party_name_field, ""),
-            "party_gstin": getattr(item, party_gstin_field, "") or "",
+            "document_date": str(item.posting_date),
+            party_gstin_key: getattr(item, party_gstin_field, "") or "",
+            party_name_field: getattr(item, party_name_field, ""),
             "gst_category": item.gst_category,
-            **{field: 0 for field in AMOUNT_FIELDS},
+            "place_of_supply": getattr(item, "place_of_supply", "") or "",
+            "reverse_charge": "Y" if item.is_reverse_charge else "N",
+            "transaction_type": _get_transaction_type(item, is_purchase),
+            "document_value": document_value,
+            "shipping_bill_number": getattr(item, "shipping_bill_number", "") or "",
+            "shipping_bill_date": str(getattr(item, "shipping_bill_date", "") or ""),
+            "port_code": getattr(item, "port_code", "") or "",
+            "items": [],
+            "total_taxable_value": 0.0,
+            "total_igst_amount": 0.0,
+            "total_cgst_amount": 0.0,
+            "total_sgst_amount": 0.0,
+            "total_cess_amount": 0.0,
         }
-
         if extra_fields:
-            accumulator[acc_key].update(extra_fields)
+            entry.update(extra_fields)
+        accumulator[acc_key] = entry
 
     entry = accumulator[acc_key]
-    for field in AMOUNT_FIELDS:
-        entry[field] += flt(getattr(item, field, 0))
+
+    tax_rate = flt(getattr(item, "tax_rate", 0))
+    taxable_value = flt(item.taxable_value)
+    igst_amount = flt(item.igst)
+    cgst_amount = flt(item.cgst)
+    sgst_amount = flt(item.sgst)
+    cess_amount = flt(item.cess)
+
+    # Group items by tax_rate — same rate merges into one item entry (GSTR-1 pattern)
+    existing = next((i for i in entry["items"] if i["tax_rate"] == tax_rate), None)
+    if existing:
+        existing["taxable_value"] += taxable_value
+        existing["igst_amount"] += igst_amount
+        existing["cgst_amount"] += cgst_amount
+        existing["sgst_amount"] += sgst_amount
+        existing["cess_amount"] += cess_amount
+    else:
+        item_dict = {
+            "taxable_value": taxable_value,
+            "igst_amount": igst_amount,
+            "cgst_amount": cgst_amount,
+            "sgst_amount": sgst_amount,
+            "cess_amount": cess_amount,
+            "tax_rate": tax_rate,
+        }
+        if extra_fields and "itc_classification" in extra_fields:
+            item_dict["itc_classification"] = extra_fields["itc_classification"]
+        entry["items"].append(item_dict)
+
+    entry["total_taxable_value"] += taxable_value
+    entry["total_igst_amount"] += igst_amount
+    entry["total_cgst_amount"] += cgst_amount
+    entry["total_sgst_amount"] += sgst_amount
+    entry["total_cess_amount"] += cess_amount
 
 
 def _build_result(accumulator):
     """
     Convert the flat accumulator dict keyed by (row_key, invoice_name)
-    into {row_key: [invoice_dicts]}.
+    into {row_key: {invoice_name: invoice_dict}} — the same nested-dict
+    format used by GSTR-1 books data.
     """
     result = {}
-    for (row_key, _), inv_data in accumulator.items():
-        result.setdefault(row_key, []).append(inv_data)
+    for (row_key, doc_num), inv_data in accumulator.items():
+        result.setdefault(row_key, {})[doc_num] = inv_data
 
     return result

--- a/india_compliance/gst_india/utils/gstr_9/gstr_9_data.py
+++ b/india_compliance/gst_india/utils/gstr_9/gstr_9_data.py
@@ -15,8 +15,7 @@ from india_compliance.gst_india.utils.gstr_9 import (
 
 
 class GSTR9BooksData(GSTR1Query, GSTR3BQuery):
-    """
-    Computes GSTR-9 books data from ERP (Sales/Purchase Invoices, Journal Entries) for a given company, GSTIN, and financial year.
+    """Computes GSTR-9 books data from ERP transactions for a given company, GSTIN, and financial year.
 
     Returns classified invoice-level data (books format):
       {row_key: {doc_number: invoice_dict}}  — for drillable rows (GSTR-1 style)
@@ -25,6 +24,7 @@ class GSTR9BooksData(GSTR1Query, GSTR3BQuery):
     """
 
     def __init__(self, filters):
+        """Initialize DocType refs and common filter attributes."""
         self.filters = frappe._dict(filters or {})
         self.si = frappe.qb.DocType("Sales Invoice")
         self.si_item = frappe.qb.DocType("Sales Invoice Item")
@@ -48,9 +48,7 @@ class GSTR9BooksData(GSTR1Query, GSTR3BQuery):
         return GSTR3BQuery.get_query_with_common_filters(self, query, doc)
 
     def get_data(self):
-        """
-        Returns books data.
-        """
+        """Return books data."""
         data = {}
 
         data.update(self._get_classified_outward_supplies())
@@ -209,7 +207,8 @@ class GSTR9BooksData(GSTR1Query, GSTR3BQuery):
         return {GSTR9_Row.TABLE_18: self._get_hsn_data("inward")}
 
     def _get_hsn_data(self, direction):
-        """Reuse the standalone HSN report functions for exact data parity.
+        """
+        Reuse the standalone HSN report functions for exact data parity.
 
         Converts report field names to the GSTR-9 display format and splits
         into goods (HSN not starting with '99') and services.
@@ -255,8 +254,7 @@ class GSTR9BooksData(GSTR1Query, GSTR3BQuery):
 
     def _get_classified_outward_supplies(self):
         """
-        Fetch all Sales Invoice items in a single query, classify each item
-        into a GSTR-9 row in Python, and accumulate per (row_key, invoice).
+        Fetch all Sales Invoice items in a single query and classify into GSTR-9 rows.
 
         Returns {row_key: [invoice_dicts]}.
         """
@@ -292,8 +290,7 @@ class GSTR9BooksData(GSTR1Query, GSTR3BQuery):
 
     def _get_classified_purchase_invoices(self):
         """
-        Fetch all relevant Purchase Invoice items in a single query, classify
-        each item for Table 4G (RCM) and/or Table 6 (ITC), and accumulate.
+        Fetch all relevant Purchase Invoice items, classify for Table 4G and Table 6.
 
         Returns {row_key: [invoice_dicts]}.
         """
@@ -558,9 +555,7 @@ class GSTR9BooksData(GSTR1Query, GSTR3BQuery):
 
 
 class GSTR9OutwardClassifier:
-    """
-    Classifies outward supply (Sales Invoice) items into GSTR-9 row keys.
-    """
+    """Classifies outward supply (Sales Invoice) items into GSTR-9 row keys."""
 
     def classify(self, item):
         """Returns the GSTR-9 row key for an outward sales invoice item."""
@@ -687,6 +682,7 @@ class GSTR9PurchaseClassifier:
     """
 
     def __init__(self, company_gstin):
+        """Initialize the classifier with the company GSTIN."""
         self.company_gstin = company_gstin
 
     def classify(self, item):

--- a/india_compliance/gst_india/utils/gstr_9/gstr_9_download.py
+++ b/india_compliance/gst_india/utils/gstr_9/gstr_9_download.py
@@ -1,0 +1,224 @@
+# Copyright (c) 2026, Resilient Tech and contributors
+# For license information, please see license.txt
+
+from india_compliance.gst_india.api_classes.taxpayer_returns import GSTR9API
+from india_compliance.gst_india.utils.gstr_9 import (
+    PORTAL_SOURCED_ROWS,
+    GSTR9_Row,
+    _empty_row,
+    get_gstr9_return_period,
+)
+
+PORTAL_TABLE_MAP = {
+    "table4": {
+        GSTR9_Row.TABLE_4A: "b2c",
+        GSTR9_Row.TABLE_4B: "b2b",
+        GSTR9_Row.TABLE_4C: "exp",
+        GSTR9_Row.TABLE_4D: "sez",
+        GSTR9_Row.TABLE_4E: "deemed",
+        GSTR9_Row.TABLE_4F: "at",  # advance tax
+        GSTR9_Row.TABLE_4G: "rchrg",  # inward RCM
+        GSTR9_Row.TABLE_4G1: "ecom",  # e-commerce 9(5)
+        GSTR9_Row.TABLE_4I: "cr_nt",
+        GSTR9_Row.TABLE_4J: "dr_nt",
+        GSTR9_Row.TABLE_4K: "amd_pos",
+        GSTR9_Row.TABLE_4L: "amd_neg",
+    },
+    "table5": {
+        GSTR9_Row.TABLE_5A: "zero_rtd",
+        GSTR9_Row.TABLE_5B: "sez",
+        GSTR9_Row.TABLE_5C: "rchrg",
+        GSTR9_Row.TABLE_5C1: "ecom_14",  # e-commerce 9(5) supplier-side
+        GSTR9_Row.TABLE_5D: "exmt",
+        GSTR9_Row.TABLE_5E: "nil",
+        GSTR9_Row.TABLE_5F: "non_gst",
+        GSTR9_Row.TABLE_5H: "cr_nt",
+        GSTR9_Row.TABLE_5I: "dr_nt",
+        GSTR9_Row.TABLE_5J: "amd_pos",
+        GSTR9_Row.TABLE_5K: "amd_neg",
+    },
+    "table6": {
+        # Simple objects
+        GSTR9_Row.TABLE_6A: "itc_3b",
+        GSTR9_Row.TABLE_6F: "ios",
+        GSTR9_Row.TABLE_6G: "isd",
+        GSTR9_Row.TABLE_6H: "itc_clmd",
+        GSTR9_Row.TABLE_6K: "tran1",
+        GSTR9_Row.TABLE_6L: "tran2",
+        # Arrays with itc_typ breakdown — handled separately in convert_portal_data
+        GSTR9_Row.TABLE_6B: "supp_non_rchrg",
+        GSTR9_Row.TABLE_6C: "supp_rchrg_unreg",
+        GSTR9_Row.TABLE_6D: "supp_rchrg_reg",
+        GSTR9_Row.TABLE_6E: "iog",
+    },
+    "table8": {
+        GSTR9_Row.TABLE_8A: "itc_2b",
+    },
+    # table9 keys are handled separately in _parse_table_9
+}
+
+
+def download_gstr9_data(gstr9_log, filters):
+    """
+    Download auto-drafted GSTR-9 data from the GST portal.
+
+    Returns a dict of row_key → amounts for portal-sourced rows.
+    """
+    api = GSTR9API(gstr9_log.gstin, get_gstr9_return_period(filters.financial_year))
+    return convert_portal_data(api.get_data())
+
+
+# Table 6 rows whose API value is an array of {itc_typ, iamt, camt, samt, csamt}
+_TABLE6_ARRAY_ROWS = {
+    GSTR9_Row.TABLE_6B,
+    GSTR9_Row.TABLE_6C,
+    GSTR9_Row.TABLE_6D,
+    GSTR9_Row.TABLE_6E,
+}
+
+# Map portal itc_typ code → sub-row suffix
+_ITC_TYP_SUFFIX = {"ip": "_ip", "cg": "_cg", "is": "_is"}
+
+
+def convert_portal_data(response):
+    """
+    Convert GSTN API response to internal row-based format.
+    """
+    data = {}
+
+    for table_key, mapping in PORTAL_TABLE_MAP.items():
+        table_data = response.get(table_key, {})
+        if not table_data:
+            continue
+
+        for row_key, portal_key in mapping.items():
+            row_data = table_data.get(portal_key)
+            if not row_data:
+                continue
+
+            if row_key in _TABLE6_ARRAY_ROWS:
+                sub_rows = _parse_itc_array_sub_rows(row_data, row_key)
+                data.update(sub_rows)
+            else:
+                data[row_key] = _parse_amount_row(row_data)
+
+    # Table 9 — tax-head objects sit directly in table9
+    table9 = response.get("table9", {})
+    if table9:
+        data[GSTR9_Row.TABLE_9] = _parse_table_9(table9)
+
+    # Initialize portal-sourced rows absent from the response
+    for row_key in PORTAL_SOURCED_ROWS:
+        if row_key not in data and row_key != GSTR9_Row.TABLE_9:
+            data[row_key] = _empty_row()
+
+    return data
+
+
+def _parse_amount_row(row_data):
+    """Parse a standard amount row from portal response."""
+    if isinstance(row_data, dict):
+        return {
+            "taxable_value": row_data.get("txval", 0),
+            "igst": row_data.get("iamt", 0),
+            "cgst": row_data.get("camt", 0),
+            "sgst": row_data.get("samt", 0),
+            "cess": row_data.get("csamt", 0),
+        }
+
+    return _empty_row()
+
+
+def _parse_itc_array_sub_rows(row_data, row_key):
+    """
+    Parse a Table 6 ITC array into sub-rows keyed by itc_typ.
+    e.g. 6B → {"6B_ip": {...}, "6B_cg": {...}, "6B_is": {...}}
+    Each element: {itc_typ: "ip"/"cg"/"is", iamt, camt, samt, csamt}
+    Note: taxable_value is not applicable for ITC rows.
+    """
+    result = {}
+
+    if not isinstance(row_data, list):
+        return result
+
+    for entry in row_data:
+        itc_typ = (entry.get("itc_typ") or "").lower()
+        suffix = _ITC_TYP_SUFFIX.get(itc_typ)
+        if not suffix:
+            continue
+
+        sub_key = f"{row_key}{suffix}"
+        if sub_key not in result:
+            result[sub_key] = _empty_row()
+
+        result[sub_key]["igst"] += entry.get("iamt", 0)
+        result[sub_key]["cgst"] += entry.get("camt", 0)
+        result[sub_key]["sgst"] += entry.get("samt", 0)
+        result[sub_key]["cess"] += entry.get("csamt", 0)
+
+    return result
+
+
+def _parse_table_9(table9_data):
+    """
+    Parse Table 9 (tax paid details) from CALRCDS portal response.
+
+    Portal rows: A=IGST, B=CGST, C=SGST/UTGST, D=Cess, E=Interest, F=Late Fee,
+                 G=Penalty, H=Other
+    API head keys: iamt, camt, samt, csamt, intr, fee, pnlty, others
+
+    Each head object has:
+      txpyble          — tax payable
+      txpaid_cash      — paid through cash
+      tax_paid_itc_iamt/camt/samt/csamt — ITC paid using each tax head
+
+    Stored per row:
+      tax_head, tax_payable, paid_through_cash,
+      itc_igst, itc_cgst, itc_sgst, itc_cess,
+      total_paid, difference
+    """
+    # (api_key, display_label, row_label)
+    TAX_HEAD_ROWS = [
+        ("iamt", "Integrated Tax", "A"),
+        ("camt", "Central Tax", "B"),
+        ("samt", "State/UT Tax", "C"),
+        ("csamt", "Cess", "D"),
+        ("intr", "Interest", "E"),
+        ("fee", "Late Fee", "F"),
+        ("pnlty", "Penalty", "G"),
+        ("others", "Other", "H"),
+    ]
+
+    result = []
+    if not isinstance(table9_data, dict):
+        return result
+
+    for head_key, label, row_label in TAX_HEAD_ROWS:
+        head_data = table9_data.get(head_key) or {}
+
+        tax_payable = head_data.get("txpyble", 0)
+        paid_through_cash = head_data.get("txpaid_cash", 0)
+        itc_igst = head_data.get("tax_paid_itc_iamt", 0)
+        itc_cgst = head_data.get("tax_paid_itc_camt", 0)
+        itc_sgst = head_data.get("tax_paid_itc_samt", 0)
+        itc_cess = head_data.get("tax_paid_itc_csamt", 0)
+        total_itc = itc_igst + itc_cgst + itc_sgst + itc_cess
+        total_paid = paid_through_cash + total_itc
+        difference = tax_payable - total_paid
+
+        result.append(
+            {
+                "row_label": row_label,
+                "tax_head": label,
+                "tax_payable": tax_payable,
+                "paid_through_cash": paid_through_cash,
+                "itc_igst": itc_igst,
+                "itc_cgst": itc_cgst,
+                "itc_sgst": itc_sgst,
+                "itc_cess": itc_cess,
+                "total_paid": total_paid,
+                "difference": difference,
+            }
+        )
+
+    return result

--- a/india_compliance/gst_india/utils/gstr_9/gstr_9_download.py
+++ b/india_compliance/gst_india/utils/gstr_9/gstr_9_download.py
@@ -9,175 +9,89 @@ from india_compliance.gst_india.utils.gstr_9 import (
     get_gstr9_return_period,
 )
 
-PORTAL_TABLE_MAP = {
-    "table4": {
-        GSTR9_Row.TABLE_4A: "b2c",
-        GSTR9_Row.TABLE_4B: "b2b",
-        GSTR9_Row.TABLE_4C: "exp",
-        GSTR9_Row.TABLE_4D: "sez",
-        GSTR9_Row.TABLE_4E: "deemed",
-        GSTR9_Row.TABLE_4F: "at",  # advance tax
-        GSTR9_Row.TABLE_4G: "rchrg",  # inward RCM
-        GSTR9_Row.TABLE_4G1: "ecom",  # e-commerce 9(5)
-        GSTR9_Row.TABLE_4I: "cr_nt",
-        GSTR9_Row.TABLE_4J: "dr_nt",
-        GSTR9_Row.TABLE_4K: "amd_pos",
-        GSTR9_Row.TABLE_4L: "amd_neg",
-    },
-    "table5": {
-        GSTR9_Row.TABLE_5A: "zero_rtd",
-        GSTR9_Row.TABLE_5B: "sez",
-        GSTR9_Row.TABLE_5C: "rchrg",
-        GSTR9_Row.TABLE_5C1: "ecom_14",  # e-commerce 9(5) supplier-side
-        GSTR9_Row.TABLE_5D: "exmt",
-        GSTR9_Row.TABLE_5E: "nil",
-        GSTR9_Row.TABLE_5F: "non_gst",
-        GSTR9_Row.TABLE_5H: "cr_nt",
-        GSTR9_Row.TABLE_5I: "dr_nt",
-        GSTR9_Row.TABLE_5J: "amd_pos",
-        GSTR9_Row.TABLE_5K: "amd_neg",
-    },
-    "table6": {
-        # Simple objects
-        GSTR9_Row.TABLE_6A: "itc_3b",
-        GSTR9_Row.TABLE_6F: "ios",
-        GSTR9_Row.TABLE_6G: "isd",
-        GSTR9_Row.TABLE_6H: "itc_clmd",
-        GSTR9_Row.TABLE_6K: "tran1",
-        GSTR9_Row.TABLE_6L: "tran2",
-        # Arrays with itc_typ breakdown — handled separately in convert_portal_data
-        GSTR9_Row.TABLE_6B: "supp_non_rchrg",
-        GSTR9_Row.TABLE_6C: "supp_rchrg_unreg",
-        GSTR9_Row.TABLE_6D: "supp_rchrg_reg",
-        GSTR9_Row.TABLE_6E: "iog",
-    },
-    "table8": {
-        GSTR9_Row.TABLE_8A: "itc_2b",
-    },
-    # table9 keys are handled separately in _parse_table_9
+# Maps internal row_key → (table_key, portal_key) for all portal-provided rows.
+# Table 6 sub-rows (6B/6C/6D/6E/6F/6H) are books-computed — portal does not send them.
+# Table 9 is handled separately in _parse_table_9 due to its different structure.
+PORTAL_ROW_MAP = {
+    # Table 4
+    GSTR9_Row.TABLE_4A: ("table4", "b2c"),
+    GSTR9_Row.TABLE_4B: ("table4", "b2b"),
+    GSTR9_Row.TABLE_4C: ("table4", "exp"),
+    GSTR9_Row.TABLE_4D: ("table4", "sez"),
+    GSTR9_Row.TABLE_4E: ("table4", "deemed"),
+    GSTR9_Row.TABLE_4F: ("table4", "at"),
+    GSTR9_Row.TABLE_4G: ("table4", "rchrg"),
+    GSTR9_Row.TABLE_4G1: ("table4", "ecom"),
+    GSTR9_Row.TABLE_4I: ("table4", "cr_nt"),
+    GSTR9_Row.TABLE_4J: ("table4", "dr_nt"),
+    GSTR9_Row.TABLE_4K: ("table4", "amd_pos"),
+    GSTR9_Row.TABLE_4L: ("table4", "amd_neg"),
+    # Table 5
+    GSTR9_Row.TABLE_5A: ("table5", "zero_rtd"),
+    GSTR9_Row.TABLE_5B: ("table5", "sez"),
+    GSTR9_Row.TABLE_5C: ("table5", "rchrg"),
+    GSTR9_Row.TABLE_5C1: ("table5", "ecom_14"),
+    GSTR9_Row.TABLE_5D: ("table5", "exmt"),
+    GSTR9_Row.TABLE_5E: ("table5", "nil"),
+    GSTR9_Row.TABLE_5F: ("table5", "non_gst"),
+    GSTR9_Row.TABLE_5H: ("table5", "cr_nt"),
+    GSTR9_Row.TABLE_5I: ("table5", "dr_nt"),
+    GSTR9_Row.TABLE_5J: ("table5", "amd_pos"),
+    GSTR9_Row.TABLE_5K: ("table5", "amd_neg"),
+    # Table 6 — only the rows the portal actually sends
+    GSTR9_Row.TABLE_6A: ("table6", "itc_3b"),
+    GSTR9_Row.TABLE_6G: ("table6", "isd"),
+    GSTR9_Row.TABLE_6K: ("table6", "tran1"),
+    GSTR9_Row.TABLE_6L: ("table6", "tran2"),
+    # Table 8
+    GSTR9_Row.TABLE_8A: ("table8", "itc_2b"),
 }
 
 
 def download_gstr9_data(gstr9_log, filters):
-    """
-    Download auto-drafted GSTR-9 data from the GST portal.
-
-    Returns a dict of row_key → amounts for portal-sourced rows.
-    """
+    """Download auto-drafted GSTR-9 data from the GST portal."""
     api = GSTR9API(gstr9_log.gstin, get_gstr9_return_period(filters.financial_year))
     return convert_portal_data(api.get_data())
 
 
-# Table 6 rows whose API value is an array of {itc_typ, iamt, camt, samt, csamt}
-_TABLE6_ARRAY_ROWS = {
-    GSTR9_Row.TABLE_6B,
-    GSTR9_Row.TABLE_6C,
-    GSTR9_Row.TABLE_6D,
-    GSTR9_Row.TABLE_6E,
-}
-
-# Map portal itc_typ code → sub-row suffix
-_ITC_TYP_SUFFIX = {"ip": "_ip", "cg": "_cg", "is": "_is"}
-
-
 def convert_portal_data(response):
-    """
-    Convert GSTN API response to internal row-based format.
-    """
+    """Convert GSTN API response to {row_key: amount_dict}."""
     data = {}
 
-    for table_key, mapping in PORTAL_TABLE_MAP.items():
-        table_data = response.get(table_key, {})
-        if not table_data:
-            continue
+    for row_key, (table_key, portal_key) in PORTAL_ROW_MAP.items():
+        row_data = response.get(table_key, {}).get(portal_key)
+        if row_data:
+            data[row_key] = _parse_amount_row(row_data)
 
-        for row_key, portal_key in mapping.items():
-            row_data = table_data.get(portal_key)
-            if not row_data:
-                continue
-
-            if row_key in _TABLE6_ARRAY_ROWS:
-                sub_rows = _parse_itc_array_sub_rows(row_data, row_key)
-                data.update(sub_rows)
-            else:
-                data[row_key] = _parse_amount_row(row_data)
-
-    # Table 9 — tax-head objects sit directly in table9
     table9 = response.get("table9", {})
     if table9:
         data[GSTR9_Row.TABLE_9] = _parse_table_9(table9)
 
-    # Initialize portal-sourced rows absent from the response
+    # Ensure portal-sourced rows are always present (even if absent from response)
     for row_key in PORTAL_SOURCED_ROWS:
-        if row_key not in data and row_key != GSTR9_Row.TABLE_9:
-            data[row_key] = _empty_row()
+        data.setdefault(row_key, _empty_row())
 
     return data
 
 
 def _parse_amount_row(row_data):
-    """Parse a standard amount row from portal response."""
-    if isinstance(row_data, dict):
-        return {
-            "taxable_value": row_data.get("txval", 0),
-            "igst": row_data.get("iamt", 0),
-            "cgst": row_data.get("camt", 0),
-            "sgst": row_data.get("samt", 0),
-            "cess": row_data.get("csamt", 0),
-        }
-
-    return _empty_row()
-
-
-def _parse_itc_array_sub_rows(row_data, row_key):
-    """
-    Parse a Table 6 ITC array into sub-rows keyed by itc_typ.
-    e.g. 6B → {"6B_ip": {...}, "6B_cg": {...}, "6B_is": {...}}
-    Each element: {itc_typ: "ip"/"cg"/"is", iamt, camt, samt, csamt}
-    Note: taxable_value is not applicable for ITC rows.
-    """
-    result = {}
-
-    if not isinstance(row_data, list):
-        return result
-
-    for entry in row_data:
-        itc_typ = (entry.get("itc_typ") or "").lower()
-        suffix = _ITC_TYP_SUFFIX.get(itc_typ)
-        if not suffix:
-            continue
-
-        sub_key = f"{row_key}{suffix}"
-        if sub_key not in result:
-            result[sub_key] = _empty_row()
-
-        result[sub_key]["igst"] += entry.get("iamt", 0)
-        result[sub_key]["cgst"] += entry.get("camt", 0)
-        result[sub_key]["sgst"] += entry.get("samt", 0)
-        result[sub_key]["cess"] += entry.get("csamt", 0)
-
-    return result
+    return {
+        "taxable_value": row_data.get("txval", 0),
+        "igst": row_data.get("iamt", 0),
+        "cgst": row_data.get("camt", 0),
+        "sgst": row_data.get("samt", 0),
+        "cess": row_data.get("csamt", 0),
+    }
 
 
 def _parse_table_9(table9_data):
     """
-    Parse Table 9 (tax paid details) from CALRCDS portal response.
+    Parse Table 9 (tax paid details).
 
-    Portal rows: A=IGST, B=CGST, C=SGST/UTGST, D=Cess, E=Interest, F=Late Fee,
-                 G=Penalty, H=Other
-    API head keys: iamt, camt, samt, csamt, intr, fee, pnlty, others
-
-    Each head object has:
-      txpyble          — tax payable
-      txpaid_cash      — paid through cash
-      tax_paid_itc_iamt/camt/samt/csamt — ITC paid using each tax head
-
-    Stored per row:
-      tax_head, tax_payable, paid_through_cash,
-      itc_igst, itc_cgst, itc_sgst, itc_cess,
-      total_paid, difference
+    Portal head keys: iamt, camt, samt, csamt, intr, fee, pnlty, others
+    Each head object: txpyble, txpaid_cash,
+                      tax_paid_itc_iamt/camt/samt/csamt
     """
-    # (api_key, display_label, row_label)
     TAX_HEAD_ROWS = [
         ("iamt", "Integrated Tax", "A"),
         ("camt", "Central Tax", "B"),
@@ -190,34 +104,28 @@ def _parse_table_9(table9_data):
     ]
 
     result = []
-    if not isinstance(table9_data, dict):
-        return result
-
     for head_key, label, row_label in TAX_HEAD_ROWS:
-        head_data = table9_data.get(head_key) or {}
-
-        tax_payable = head_data.get("txpyble", 0)
-        paid_through_cash = head_data.get("txpaid_cash", 0)
-        itc_igst = head_data.get("tax_paid_itc_iamt", 0)
-        itc_cgst = head_data.get("tax_paid_itc_camt", 0)
-        itc_sgst = head_data.get("tax_paid_itc_samt", 0)
-        itc_cess = head_data.get("tax_paid_itc_csamt", 0)
-        total_itc = itc_igst + itc_cgst + itc_sgst + itc_cess
-        total_paid = paid_through_cash + total_itc
-        difference = tax_payable - total_paid
+        head = table9_data.get(head_key) or {}
+        tax_payable = head.get("txpyble", 0)
+        paid_cash = head.get("txpaid_cash", 0)
+        itc_igst = head.get("tax_paid_itc_iamt", 0)
+        itc_cgst = head.get("tax_paid_itc_camt", 0)
+        itc_sgst = head.get("tax_paid_itc_samt", 0)
+        itc_cess = head.get("tax_paid_itc_csamt", 0)
+        total_paid = paid_cash + itc_igst + itc_cgst + itc_sgst + itc_cess
 
         result.append(
             {
                 "row_label": row_label,
                 "tax_head": label,
                 "tax_payable": tax_payable,
-                "paid_through_cash": paid_through_cash,
+                "paid_through_cash": paid_cash,
                 "itc_igst": itc_igst,
                 "itc_cgst": itc_cgst,
                 "itc_sgst": itc_sgst,
                 "itc_cess": itc_cess,
                 "total_paid": total_paid,
-                "difference": difference,
+                "difference": tax_payable - total_paid,
             }
         )
 

--- a/india_compliance/gst_india/utils/gstr_9/gstr_9_download.py
+++ b/india_compliance/gst_india/utils/gstr_9/gstr_9_download.py
@@ -85,8 +85,7 @@ def _parse_amount_row(row_data):
 
 
 def _parse_table_9(table9_data):
-    """
-    Parse Table 9 (tax paid details).
+    """Parse Table 9 (tax paid details).
 
     Portal head keys: iamt, camt, samt, csamt, intr, fee, pnlty, others
     Each head object: txpyble, txpaid_cash,


### PR DESCRIPTION
## Summary

Implements full GSTR-9 annual return automation — books data computation, GST portal data download, row-by-row comparison, invoice drill-down, and multi-sheet Excel export.

---

## Books data engine

`GSTR9BooksData` inherits both `GSTR1Query` and `GSTR3BQuery`:

- Outward supplies: delegates directly to `GSTR1Query.get_base_query()` — same SI+SI_Item unbuffered SSCursor query used by GSTR-1, no duplication.
- Inward supplies: extends `GSTR3BQuery.get_base_purchase_query()` with Item master join for `is_stock_item` / `is_fixed_asset`.
- BOE books: extends `get_base_boe_query()` with PI join to fetch `supplier_name`, `supplier_gstin`, and `gst_category`.
- `get_query_with_common_filters(query, doc=None)` MRO disambiguator dispatches to the correct parent by `doc` presence.

**Classifiers:**

- `GSTR9OutwardClassifier` — maps (gst_category, gst_treatment, is_return, is_debit_note, ecommerce_gstin) → row key (4A–5F, 4I/4J/5H/5I)
- `GSTR9PurchaseClassifier` — maps (itc_classification, is_reverse_charge, supplier_gstin, is_fixed_asset, is_stock_item) → (rcm_key, itc_key)

---

## Advance data

Advances produce two drillable entries per Payment Entry — `"{pe_name}::rcv"` (advance received, 11A) and `"{pe_name}::adj"` (advance adjusted, 11B) — with intra/inter-state tax split and `doc_route="payment-entry"`.

---

## Size gate & Excel export

- Drill-down compressed JSON > 200 KB → returns `{too_large: True}` → frontend redirects to Excel export.
- `export_gstr9_books_as_excel` flattens all drillable rows to one Excel row per item (tax-rate group), one sheet per row key — matching the GSTR-1 export pattern.
