### PR TITLE
fix: respect field set by fetch from

### DIFF
--- a/india_compliance/gst_india/client_scripts/journal_entry.js
+++ b/india_compliance/gst_india/client_scripts/journal_entry.js
@@ -10,7 +10,10 @@ async function set_gstin_options(frm, set_value) {
     const options = await india_compliance.get_gstin_options(company);
     frm.get_field("company_gstin").set_data(options);
 
-    if (set_value) frm.set_value("company_gstin", options.length === 1 ? options[0] : "");
+    if (set_value) {
+        if (options.includes(frm.doc.company_gstin)) return;
+        frm.set_value("company_gstin", options.length === 1 ? options[0] : "");
+    }
 }
 
 frappe.ui.form.on("Journal Entry Account", {


### PR DESCRIPTION
Steps to replicate:

- Apply fetch from the company GSTIN field.
- Select a company with multiple addresses.
- Field will be unset even though it was fetched from the company.