### PR TITLE
fix: update place of_supply and address if erpnext updates party address on new doc

### DIFF
--- a/india_compliance/gst_india/overrides/test_ineligible_itc.py
+++ b/india_compliance/gst_india/overrides/test_ineligible_itc.py
@@ -245,6 +245,7 @@ class TestIneligibleITC(IntegrationTestCase):
             "items": SAMPLE_ITEM_LIST,
             "place_of_supply": "27-Maharashtra",
             "is_out_state": 1,
+            "supplier_address": "_Test Registered Supplier-Billing",
         }
 
         doc = create_transaction(**transaction_details)
@@ -410,6 +411,7 @@ class TestIneligibleITC(IntegrationTestCase):
             "items": SAMPLE_ITEM_LIST,
             "place_of_supply": "27-Maharashtra",
             "is_out_state": 1,
+            "supplier_address": "_Test Registered Supplier-Billing",
         }
 
         doc = create_transaction(**transaction_details)

--- a/india_compliance/gst_india/overrides/test_transaction.py
+++ b/india_compliance/gst_india/overrides/test_transaction.py
@@ -524,6 +524,12 @@ class TestTransaction(IntegrationTestCase):
 
     def test_validate_place_of_supply(self):
         doc = create_transaction(**self.transaction_details, do_not_save=True)
+        # Address is required to avoid auto update of place of supply and taxes
+
+        if self.is_sales_doctype:
+            doc.customer_address = "_Test Registered Customer-Billing"
+        else:
+            doc.supplier_address = "_Test Registered Supplier-Billing"
         doc.place_of_supply = "96-Others"
 
         self.assertRaisesRegex(
@@ -745,6 +751,11 @@ class TestTransaction(IntegrationTestCase):
 
     def test_invalid_item_gst_details(self):
         doc = create_transaction(**self.transaction_details, rate=200, is_out_state=True, do_not_save=True)
+        # Address is required to avoid auto update of place of supply and taxes
+        if self.is_sales_doctype:
+            doc.customer_address = "_Test Registered Customer-Billing"
+        else:
+            doc.supplier_address = "_Test Registered Supplier-Billing"
         row = frappe.copy_doc(doc.taxes[0])
         doc.append("taxes", row)
         doc.place_of_supply = "27-Maharashtra"
@@ -854,6 +865,7 @@ class TestTransaction(IntegrationTestCase):
             is_out_state=True,
             do_not_save=True,
         )
+        doc.supplier_address = "_Test Registered Supplier-Billing"
 
         doc.place_of_supply = "27-Maharashtra"
         doc.save()
@@ -1483,3 +1495,23 @@ class TestPlaceOfSupply(IntegrationTestCase):
 
         doc = create_transaction(**doc_args)
         self.assertEqual(doc.place_of_supply, "24-Gujarat")  # Company GSTIN
+
+    def test_correct_place_of_supply_on_address_update_by_erpnext(self):
+        """
+        With change in address of party by erpnexr, place of supply should be corrected
+        and taxes should be applied accordingly on new document creation.
+        """
+        doc = create_transaction(
+            doctype="Sales Invoice",
+            customer="_Test Registered Composition Customer",
+            do_not_save=True,
+        )
+        doc.place_of_supply = "24-Gujarat"
+        doc.insert()
+
+        # place_of_supply must be corrected to customer's state (Karnataka)
+        self.assertEqual(doc.place_of_supply, "29-Karnataka")
+
+        # check gst_tax_type of tax table
+        for tax in doc.taxes:
+            self.assertIn(tax.gst_tax_type, ["igst"])

--- a/india_compliance/gst_india/overrides/test_transaction.py
+++ b/india_compliance/gst_india/overrides/test_transaction.py
@@ -1498,7 +1498,7 @@ class TestPlaceOfSupply(IntegrationTestCase):
 
     def test_correct_place_of_supply_on_address_update_by_erpnext(self):
         """
-        With change in address of party by erpnexr, place of supply should be corrected
+        With change in address of party by erpnext, place of supply should be corrected
         and taxes should be applied accordingly on new document creation.
         """
         doc = create_transaction(
@@ -1514,4 +1514,4 @@ class TestPlaceOfSupply(IntegrationTestCase):
 
         # check gst_tax_type of tax table
         for tax in doc.taxes:
-            self.assertIn(tax.gst_tax_type, ["igst"])
+            self.assertEqual(tax.gst_tax_type, "igst")

--- a/india_compliance/gst_india/overrides/test_transaction.py
+++ b/india_compliance/gst_india/overrides/test_transaction.py
@@ -1498,6 +1498,8 @@ class TestPlaceOfSupply(IntegrationTestCase):
 
     def test_correct_place_of_supply_on_address_update_by_erpnext(self):
         """
+        Correct place of supply when ERPNext updates the party address.
+
         With change in address of party by erpnext, place of supply should be corrected
         and taxes should be applied accordingly on new document creation.
         """

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -900,7 +900,7 @@ def _get_address_fields(doctype, party_details=None):
         )
 
     elif doctype == "Stock Entry":
-        if party_details.get("is_inward_stock_entry"):
+        if party_details and party_details.get("is_inward_stock_entry"):
             address_fields.update(
                 company_gstin_field="bill_to_gstin",
                 party_gstin_field="bill_from_gstin",
@@ -1644,12 +1644,10 @@ def validate_transaction(doc, method=None):
     is_sales_transaction = _is_sales_transaction(doc.doctype)
 
     if is_sales_transaction:
+        gstin = doc.billing_address_gstin
         if doc.doctype != "Payment Entry":
             validate_hsn_codes(doc)
             validate_sales_reverse_charge(doc)
-            gstin = doc.billing_address_gstin
-        else:
-            gstin = doc.billing_address_gstin
     else:
         gstin = doc.supplier_gstin
 

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -779,37 +779,18 @@ def get_gst_details(
     if not (party_details.company_gstin or is_indian_registered_company(frappe._dict(company=company))):
         return {}
 
-    is_sales_transaction = doctype in SALES_DOCTYPES or doctype == "Payment Entry"
+    is_sales_transaction = _is_sales_transaction(doctype)
     gst_details = frappe._dict()
 
     allow_same_gstin = False
     if party_details.get("is_outward_stock_entry"):
         allow_same_gstin = True
 
-    # Party/Address Defaults
-    if is_sales_transaction:
-        company_gstin_field = "company_gstin"
-        party_gstin_field = "billing_address_gstin"
-        party_address_field = "customer_address"
-        gst_category_field = "gst_category"
-
-    elif doctype == "Stock Entry":
-        if party_details.get("is_inward_stock_entry"):
-            company_gstin_field = "bill_to_gstin"
-            party_gstin_field = "bill_from_gstin"
-            party_address_field = "bill_from_address"
-            gst_category_field = "bill_from_gst_category"
-        else:
-            company_gstin_field = "bill_from_gstin"
-            party_gstin_field = "bill_to_gstin"
-            party_address_field = "bill_to_address"
-            gst_category_field = "bill_to_gst_category"
-
-    else:
-        company_gstin_field = "company_gstin"
-        party_gstin_field = "supplier_gstin"
-        party_address_field = "supplier_address"
-        gst_category_field = "gst_category"
+    address_fields = _get_address_fields(doctype, party_details)
+    company_gstin_field = address_fields.get("company_gstin_field")
+    party_gstin_field = address_fields.get("party_gstin_field")
+    party_address_field = address_fields.get("party_address_field")
+    gst_category_field = address_fields.get("gst_category_field")
 
     if not party_details.get(party_address_field):
         party_gst_details = get_party_gst_details(party_details, is_sales_transaction, party_gstin_field)
@@ -898,6 +879,51 @@ def get_gst_details(
         gst_details.taxes = get_taxes_and_charges(master_doctype, default_tax)
 
     return gst_details
+
+
+def _get_address_fields(doctype, party_details=None):
+    is_sales_transaction = _is_sales_transaction(doctype)
+    address_fields = frappe._dict(
+        {
+            "company_gstin_field": "",
+            "party_gstin_field": "",
+            "party_address_field": "",
+            "gst_category_field": "",
+        }
+    )
+    if is_sales_transaction:
+        address_fields.update(
+            company_gstin_field="company_gstin",
+            party_gstin_field="billing_address_gstin",
+            party_address_field="customer_address",
+            gst_category_field="gst_category",
+        )
+
+    elif doctype == "Stock Entry":
+        if party_details.get("is_inward_stock_entry"):
+            address_fields.update(
+                company_gstin_field="bill_to_gstin",
+                party_gstin_field="bill_from_gstin",
+                party_address_field="bill_from_address",
+                gst_category_field="bill_from_gst_category",
+            )
+        else:
+            address_fields.update(
+                company_gstin_field="bill_from_gstin",
+                party_gstin_field="bill_to_gstin",
+                party_address_field="bill_to_address",
+                gst_category_field="bill_to_gst_category",
+            )
+
+    else:
+        address_fields.update(
+            company_gstin_field="company_gstin",
+            party_gstin_field="supplier_gstin",
+            party_address_field="supplier_address",
+            gst_category_field="gst_category",
+        )
+
+    return address_fields
 
 
 def get_party_gst_details(party_details, is_sales_transaction, gstin_fieldname):
@@ -1348,7 +1374,7 @@ class ItemGSTDetails:
 class ItemGSTTreatment:
     def set(self, doc):
         self.doc = doc
-        is_sales_transaction = doc.doctype in SALES_DOCTYPES
+        is_sales_transaction = _is_sales_transaction(doc.doctype)
 
         if is_sales_transaction and is_overseas_doc(doc):
             self.set_for_overseas()
@@ -1540,10 +1566,46 @@ def before_validate_transaction(doc, method=None):
 
     set_reverse_charge_as_per_gst_settings(doc)
 
+    if not doc.is_new():
+        return
+    field = _get_address_fields(doc.doctype).get("party_address_field")
+    if doc.get(field):
+        return
+
+    doc._party_address_not_set = True
+
+
+def _update_place_of_supply_and_taxes(doc):
+    """
+    On new docs, erpnext updates address if missing but
+    place of supply and taxes are not updated based on the new address.
+    """
+
+    if not doc.get("_party_address_not_set"):
+        return
+
+    address_field = _get_address_fields(doc.doctype).get("party_address_field")
+    if not doc.get(address_field):
+        return
+
+    gst_details = get_gst_details(doc.as_dict(), doc.doctype, doc.company, update_place_of_supply=True)
+
+    if gst_details.get("place_of_supply") == doc.place_of_supply:
+        return
+
+    for field in ("place_of_supply", "taxes_and_charges", "taxes"):
+        if field in gst_details:
+            doc.set(field, gst_details[field])
+
+    frappe.msgprint(_("Place of Supply and Taxes have been updated due to change in Party Address."))
+
 
 def validate_transaction(doc, method=None):
     if ignore_gst_validations(doc):
         return False
+
+    if doc.is_new():
+        _update_place_of_supply_and_taxes(doc)
 
     set_gst_tax_type(doc)
     validate_items(doc)
@@ -1579,13 +1641,15 @@ def validate_transaction(doc, method=None):
 
     validate_overseas_gst_category(doc)
 
-    if is_sales_transaction := doc.doctype in SALES_DOCTYPES:
-        validate_hsn_codes(doc)
-        validate_sales_reverse_charge(doc)
-        gstin = doc.billing_address_gstin
-    elif doc.doctype == "Payment Entry":
-        is_sales_transaction = True
-        gstin = doc.billing_address_gstin
+    is_sales_transaction = _is_sales_transaction(doc.doctype)
+
+    if is_sales_transaction:
+        if doc.doctype != "Payment Entry":
+            validate_hsn_codes(doc)
+            validate_sales_reverse_charge(doc)
+            gstin = doc.billing_address_gstin
+        else:
+            gstin = doc.billing_address_gstin
     else:
         gstin = doc.supplier_gstin
 
@@ -1602,6 +1666,10 @@ def validate_transaction(doc, method=None):
         validate_gst_refund_accounts(doc)
     update_taxable_values(doc)
     validate_item_wise_tax_detail(doc)
+
+
+def _is_sales_transaction(doctype):
+    return doctype in SALES_DOCTYPES or doctype == "Payment Entry"
 
 
 def before_print(doc, method=None, print_settings=None):

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -1593,9 +1593,7 @@ def _update_place_of_supply_and_taxes(doc):
     if gst_details.get("place_of_supply") == doc.place_of_supply:
         return
 
-    for field in ("place_of_supply", "taxes_and_charges", "taxes"):
-        if field in gst_details:
-            doc.set(field, gst_details[field])
+    doc.update(gst_details)
 
     frappe.msgprint(_("Place of Supply and Taxes have been updated due to change in Party Address."))
 

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -779,7 +779,7 @@ def get_gst_details(
     if not (party_details.company_gstin or is_indian_registered_company(frappe._dict(company=company))):
         return {}
 
-    is_sales_transaction = _is_sales_transaction(doctype)
+    is_sales_transaction = doctype in SALES_DOCTYPES or doctype == "Payment Entry"
     gst_details = frappe._dict()
 
     allow_same_gstin = False
@@ -882,7 +882,7 @@ def get_gst_details(
 
 
 def _get_address_fields(doctype, party_details=None):
-    is_sales_transaction = _is_sales_transaction(doctype)
+    is_sales_transaction = doctype in SALES_DOCTYPES or doctype == "Payment Entry"
     address_fields = frappe._dict(
         {
             "company_gstin_field": "",
@@ -1374,7 +1374,7 @@ class ItemGSTDetails:
 class ItemGSTTreatment:
     def set(self, doc):
         self.doc = doc
-        is_sales_transaction = _is_sales_transaction(doc.doctype)
+        is_sales_transaction = doc.doctype in SALES_DOCTYPES
 
         if is_sales_transaction and is_overseas_doc(doc):
             self.set_for_overseas()
@@ -1639,13 +1639,13 @@ def validate_transaction(doc, method=None):
 
     validate_overseas_gst_category(doc)
 
-    is_sales_transaction = _is_sales_transaction(doc.doctype)
-
-    if is_sales_transaction:
+    if is_sales_transaction := doc.doctype in SALES_DOCTYPES:
+        validate_hsn_codes(doc)
+        validate_sales_reverse_charge(doc)
         gstin = doc.billing_address_gstin
-        if doc.doctype != "Payment Entry":
-            validate_hsn_codes(doc)
-            validate_sales_reverse_charge(doc)
+    elif doc.doctype == "Payment Entry":
+        is_sales_transaction = True
+        gstin = doc.billing_address_gstin
     else:
         gstin = doc.supplier_gstin
 
@@ -1662,10 +1662,6 @@ def validate_transaction(doc, method=None):
         validate_gst_refund_accounts(doc)
     update_taxable_values(doc)
     validate_item_wise_tax_detail(doc)
-
-
-def _is_sales_transaction(doctype):
-    return doctype in SALES_DOCTYPES or doctype == "Payment Entry"
 
 
 def before_print(doc, method=None, print_settings=None):

--- a/india_compliance/hooks.py
+++ b/india_compliance/hooks.py
@@ -141,6 +141,7 @@ doc_events = {
             "india_compliance.gst_india.overrides.transaction.onload",
         ],
         "before_print": "india_compliance.gst_india.overrides.transaction.before_print",
+        "before_validate": "india_compliance.gst_india.overrides.transaction.before_validate_transaction",
         "before_save": "india_compliance.gst_india.overrides.transaction.update_gst_details",
         "before_submit": "india_compliance.gst_india.overrides.transaction.update_gst_details",
         "before_cancel": "india_compliance.gst_india.utils.e_waybill.before_cancel",
@@ -220,6 +221,7 @@ doc_events = {
             "india_compliance.gst_india.overrides.transaction.onload",
         ],
         "before_print": "india_compliance.gst_india.overrides.transaction.before_print",
+        "before_validate": "india_compliance.gst_india.overrides.transaction.before_validate_transaction",
         "validate": "india_compliance.gst_india.overrides.sales_invoice.validate",
         "before_save": "india_compliance.gst_india.overrides.transaction.update_gst_details",
         "before_submit": "india_compliance.gst_india.overrides.transaction.update_gst_details",
@@ -233,6 +235,7 @@ doc_events = {
     "Sales Order": {
         "onload": "india_compliance.gst_india.overrides.transaction.onload",
         "before_print": "india_compliance.gst_india.overrides.transaction.before_print",
+        "before_validate": "india_compliance.gst_india.overrides.transaction.before_validate_transaction",
         "validate": ("india_compliance.gst_india.overrides.transaction.validate_transaction"),
         "before_save": "india_compliance.gst_india.overrides.transaction.update_gst_details",
         "before_submit": "india_compliance.gst_india.overrides.transaction.update_gst_details",
@@ -281,6 +284,7 @@ doc_events = {
     "POS Invoice": {
         "onload": "india_compliance.gst_india.overrides.transaction.onload",
         "before_print": "india_compliance.gst_india.overrides.transaction.before_print",
+        "before_validate": "india_compliance.gst_india.overrides.transaction.before_validate_transaction",
         "validate": ("india_compliance.gst_india.overrides.transaction.validate_transaction"),
         "before_save": "india_compliance.gst_india.overrides.transaction.update_gst_details",
         "before_submit": "india_compliance.gst_india.overrides.transaction.update_gst_details",
@@ -288,6 +292,7 @@ doc_events = {
     "Quotation": {
         "onload": "india_compliance.gst_india.overrides.transaction.onload",
         "before_print": "india_compliance.gst_india.overrides.transaction.before_print",
+        "before_validate": "india_compliance.gst_india.overrides.transaction.before_validate_transaction",
         "validate": ("india_compliance.gst_india.overrides.transaction.validate_transaction"),
         "before_save": "india_compliance.gst_india.overrides.transaction.update_gst_details",
         "before_submit": "india_compliance.gst_india.overrides.transaction.update_gst_details",


### PR DESCRIPTION
Issue: If the party address is empty in the doc, erpnext updates the party address, but the place of supply remains unchanged.


Frappe Support Issue: https://support.frappe.io/desk/hd-ticket/51240
ref issue: #4054