### PR TITLE
fix: validate ITC claim period for draft and allow changes in draft

### DIFF
--- a/india_compliance/gst_india/doctype/bill_of_entry/bill_of_entry.py
+++ b/india_compliance/gst_india/doctype/bill_of_entry/bill_of_entry.py
@@ -27,7 +27,7 @@ from india_compliance.gst_india.utils import get_gst_accounts_by_type
 from india_compliance.gst_india.utils.itc_claim import (
     _is_gstr3b_filed,
     set_or_validate_itc_claim_period,
-    validate_itc_claim_period,
+    validate_itc_claim_period_on_update_after_submit,
 )
 from india_compliance.gst_india.utils.taxes_controller import (
     CustomTaxController,
@@ -85,7 +85,7 @@ class BillofEntry(Document):
         self.update_pending_boe_qty()
 
     def before_update_after_submit(self):
-        validate_itc_claim_period(self)
+        validate_itc_claim_period_on_update_after_submit(self)
 
     def on_cancel(self):
         self.ignore_linked_doctypes = ("GL Entry",)

--- a/india_compliance/gst_india/overrides/purchase_invoice.py
+++ b/india_compliance/gst_india/overrides/purchase_invoice.py
@@ -27,7 +27,7 @@ from india_compliance.gst_india.utils.e_waybill import get_e_waybill_info
 from india_compliance.gst_india.utils.itc_claim import (
     _is_gstr3b_filed,
     set_or_validate_itc_claim_period,
-    validate_itc_claim_period,
+    validate_itc_claim_period_on_update_after_submit,
 )
 
 
@@ -83,7 +83,7 @@ def before_update_after_submit(doc, method=None):
     if ignore_gst_validations(doc):
         return
 
-    validate_itc_claim_period(doc)
+    validate_itc_claim_period_on_update_after_submit(doc)
 
 
 def on_cancel(doc, method=None):

--- a/india_compliance/gst_india/overrides/test_purchase_invoice.py
+++ b/india_compliance/gst_india/overrides/test_purchase_invoice.py
@@ -1,4 +1,5 @@
 import re
+from contextlib import contextmanager
 
 import frappe
 from frappe.tests import IntegrationTestCase, change_settings
@@ -11,6 +12,29 @@ from india_compliance.gst_india.utils.itc_claim import (
 )
 from india_compliance.gst_india.utils.tests import append_item, create_purchase_invoice
 from india_compliance.tests.erpnext_test_utils import create_account
+
+
+@contextmanager
+def _gstr3b_filed(company_gstin, posting_date):
+    """Context manager that files a GSTR-3B period and always unfiles it on exit."""
+    posting_date = getdate(posting_date)
+    month_or_quarter = posting_date.strftime("%B")
+    year = posting_date.year
+    update_gstr3b_filing_status(
+        company_gstin=company_gstin,
+        month_or_quarter=month_or_quarter,
+        year=year,
+        status="Filed",
+    )
+    try:
+        yield
+    finally:
+        update_gstr3b_filing_status(
+            company_gstin=company_gstin,
+            month_or_quarter=month_or_quarter,
+            year=year,
+            status="Not Filed",
+        )
 
 
 class TestPurchaseInvoice(IntegrationTestCase):
@@ -308,47 +332,28 @@ class TestPurchaseInvoice(IntegrationTestCase):
 
         self.assertEqual(pinv.itc_claim_period, current_period)
 
-        posting_date = getdate(pinv.posting_date)
-        month_or_quarter = posting_date.strftime("%B")
-        year = posting_date.year
+        with _gstr3b_filed(pinv.company_gstin, pinv.posting_date):
+            # Try to change to a different period - should fail
+            next_period = format_period(add_months(pinv.posting_date, 1))
+            pinv.itc_claim_period = next_period
 
-        # Mark GSTR-3B as filed for the current period
-        update_gstr3b_filing_status(
-            company_gstin=pinv.company_gstin,
-            month_or_quarter=month_or_quarter,
-            year=year,
-            status="Filed",
-        )
+            self.assertRaisesRegex(
+                frappe.exceptions.ValidationError,
+                re.compile(r"Cannot change ITC Claim Period from .* to .*\. GSTR-3B already filed for .*\."),
+                pinv.save,
+            )
 
-        # Try to change to a different period - should fail
-        next_period = format_period(add_months(pinv.posting_date, 1))
-        pinv.itc_claim_period = next_period
+            # Reload and try to change to "Deferred" - should also fail
+            pinv.reload()
+            pinv.itc_claim_period = ITC_CLAIM_PERIOD_DEFERRED
 
-        self.assertRaisesRegex(
-            frappe.exceptions.ValidationError,
-            re.compile(r"Cannot change ITC Claim Period from .* to .*\. GSTR-3B already filed for .*\."),
-            pinv.save,
-        )
+            self.assertRaisesRegex(
+                frappe.exceptions.ValidationError,
+                re.compile(r"Cannot change ITC Claim Period from .* to .*\. GSTR-3B already filed for .*\."),
+                pinv.save,
+            )
 
-        # Reload and try to change to "Deferred" - should also fail
-        pinv.reload()
-        pinv.itc_claim_period = ITC_CLAIM_PERIOD_DEFERRED
-
-        self.assertRaisesRegex(
-            frappe.exceptions.ValidationError,
-            re.compile(r"Cannot change ITC Claim Period from .* to .*\. GSTR-3B already filed for .*\."),
-            pinv.save,
-        )
-
-        # Mark the current period as unfiled
-        update_gstr3b_filing_status(
-            company_gstin=pinv.company_gstin,
-            month_or_quarter=month_or_quarter,
-            year=year,
-            status="Not Filed",
-        )
-
-        # Now it should be possible to change
+        # Period is now unfiled — change should be allowed
         pinv.reload()
         pinv.itc_claim_period = ITC_CLAIM_PERIOD_DEFERRED
         pinv.save()
@@ -390,28 +395,13 @@ class TestPurchaseInvoice(IntegrationTestCase):
         next_period = format_period(add_months(pinv.posting_date, 1))
         next_date = getdate(add_months(pinv.posting_date, 1))
 
-        # File the *target* period
-        update_gstr3b_filing_status(
-            company_gstin=pinv.company_gstin,
-            month_or_quarter=next_date.strftime("%B"),
-            year=next_date.year,
-            status="Filed",
-        )
-
-        pinv.itc_claim_period = next_period
-        self.assertRaisesRegex(
-            frappe.exceptions.ValidationError,
-            re.compile(r"GSTR-3B already filed"),
-            pinv.save,
-        )
-
-        # cleanup
-        update_gstr3b_filing_status(
-            company_gstin=pinv.company_gstin,
-            month_or_quarter=next_date.strftime("%B"),
-            year=next_date.year,
-            status="Not Filed",
-        )
+        with _gstr3b_filed(pinv.company_gstin, next_date):
+            pinv.itc_claim_period = next_period
+            self.assertRaisesRegex(
+                frappe.exceptions.ValidationError,
+                re.compile(r"GSTR-3B already filed"),
+                pinv.save,
+            )
 
     def test_itc_claim_period_change_deferred_to_filed_blocked(self):
         """Cannot change from Deferred TO a filed period."""
@@ -422,25 +412,49 @@ class TestPurchaseInvoice(IntegrationTestCase):
         posting_date = getdate(pinv.posting_date)
         posting_period = format_period(posting_date)
 
-        # File the target period
-        update_gstr3b_filing_status(
-            company_gstin=pinv.company_gstin,
-            month_or_quarter=posting_date.strftime("%B"),
-            year=posting_date.year,
-            status="Filed",
-        )
+        with _gstr3b_filed(pinv.company_gstin, posting_date):
+            pinv.itc_claim_period = posting_period
+            self.assertRaisesRegex(
+                frappe.exceptions.ValidationError,
+                re.compile(r"GSTR-3B already filed"),
+                pinv.save,
+            )
 
-        pinv.itc_claim_period = posting_period
-        self.assertRaisesRegex(
-            frappe.exceptions.ValidationError,
-            re.compile(r"GSTR-3B already filed"),
-            pinv.save,
-        )
+    def test_itc_claim_period_change_allowed_for_draft_from_filed_to_unfiled_period(self):
+        """Draft invoice should be editable even if its original period later gets filed."""
+        pinv = create_purchase_invoice(do_not_submit=True)
+        current_date = getdate(pinv.posting_date)
+        next_period = format_period(add_months(current_date, 1))
 
-        # cleanup
-        update_gstr3b_filing_status(
-            company_gstin=pinv.company_gstin,
-            month_or_quarter=posting_date.strftime("%B"),
-            year=posting_date.year,
-            status="Not Filed",
-        )
+        with _gstr3b_filed(pinv.company_gstin, current_date):
+            pinv.itc_claim_period = next_period
+            pinv.save()
+            self.assertEqual(pinv.itc_claim_period, next_period)
+
+    def test_itc_claim_period_for_draft_invoice_cannot_be_filed(self):
+        """Draft invoices should not be saved with a filed ITC Claim Period."""
+        pinv = create_purchase_invoice(do_not_submit=True)
+        posting_date = getdate(pinv.posting_date)
+        posting_period = format_period(posting_date)
+
+        with _gstr3b_filed(pinv.company_gstin, posting_date):
+            pinv.itc_claim_period = posting_period
+            self.assertRaisesRegex(
+                frappe.exceptions.ValidationError,
+                re.compile(r"Cannot set ITC Claim Period to .+\. GSTR-3B is already filed"),
+                pinv.save,
+            )
+
+    def test_itc_claim_period_unchanged_update_after_submit_allowed_even_if_filed(self):
+        """Submitted docs should not be blocked for non-ITC updates if period is unchanged."""
+        pinv = create_purchase_invoice(do_not_submit=True)
+        pinv.submit()
+
+        posting_date = getdate(pinv.posting_date)
+        posting_period = format_period(posting_date)
+
+        with _gstr3b_filed(pinv.company_gstin, posting_date):
+            pinv.reload()
+            pinv.itc_claim_period = posting_period
+            pinv.save()
+            self.assertEqual(pinv.itc_claim_period, posting_period)

--- a/india_compliance/gst_india/overrides/test_purchase_invoice.py
+++ b/india_compliance/gst_india/overrides/test_purchase_invoice.py
@@ -451,10 +451,8 @@ class TestPurchaseInvoice(IntegrationTestCase):
         pinv.submit()
 
         posting_date = getdate(pinv.posting_date)
-        posting_period = format_period(posting_date)
 
         with _gstr3b_filed(pinv.company_gstin, posting_date):
             pinv.reload()
-            pinv.itc_claim_period = posting_period
-            pinv.save()
-            self.assertEqual(pinv.itc_claim_period, posting_period)
+            pinv.remarks = "Updated remarks"
+            pinv.save()  # Should not raise error since period is unchanged

--- a/india_compliance/gst_india/overrides/test_purchase_invoice.py
+++ b/india_compliance/gst_india/overrides/test_purchase_invoice.py
@@ -454,5 +454,20 @@ class TestPurchaseInvoice(IntegrationTestCase):
 
         with _gstr3b_filed(pinv.company_gstin, posting_date):
             pinv.reload()
-            pinv.remarks = "Updated remarks"
-            pinv.save()  # Should not raise error since period is unchanged
+            pinv.title = "Update-after-submit allowed field"
+            pinv.save()
+
+    def test_submit_blocked_if_draft_period_gets_filed_before_submit(self):
+        """Submitting a draft must fail if its unchanged claim period gets filed meanwhile."""
+        pinv = create_purchase_invoice(do_not_submit=True)
+        posting_date = getdate(pinv.posting_date)
+        posting_period = format_period(posting_date)
+
+        self.assertEqual(pinv.itc_claim_period, posting_period)
+
+        with _gstr3b_filed(pinv.company_gstin, posting_date):
+            self.assertRaisesRegex(
+                frappe.exceptions.ValidationError,
+                re.compile(r"Cannot set ITC Claim Period to .+\. GSTR-3B is already filed"),
+                pinv.submit,
+            )

--- a/india_compliance/gst_india/utils/itc_claim.py
+++ b/india_compliance/gst_india/utils/itc_claim.py
@@ -351,25 +351,35 @@ def validate_itc_claim_period(doc) -> None:
 
 
 def _validate_itc_claim_period_as_per_filing(doc) -> None:
-    previous = doc.get_doc_before_save()
-    if not previous:
+    # For draft docs, target period must not be filed.
+    if doc.docstatus == 0:
+        if _is_gstr3b_filed(doc.company_gstin, doc.itc_claim_period):
+            frappe.throw(
+                _("Cannot set ITC Claim Period to {0}. GSTR-3B is already filed.").format(
+                    doc.itc_claim_period
+                )
+            )
         return
 
-    if previous.itc_claim_period != doc.itc_claim_period:
-        filed_period = None
-        if _is_gstr3b_filed(doc.company_gstin, previous.itc_claim_period):
-            filed_period = previous.itc_claim_period
-        if _is_gstr3b_filed(doc.company_gstin, doc.itc_claim_period):
-            filed_period = doc.itc_claim_period
+    # For submitted docs, if period is being changed, both old and new periods must not be filed.
+    previous = doc.get_doc_before_save()
+    if not previous or previous.itc_claim_period == doc.itc_claim_period:
+        return
 
-        if not filed_period:
-            return
+    filed_period = None
+    if _is_gstr3b_filed(doc.company_gstin, previous.itc_claim_period):
+        filed_period = previous.itc_claim_period
+    if _is_gstr3b_filed(doc.company_gstin, doc.itc_claim_period):
+        filed_period = doc.itc_claim_period
 
-        frappe.throw(
-            _("Cannot change ITC Claim Period from {0} to {1}. GSTR-3B already filed for {2}.").format(
-                previous.itc_claim_period, doc.itc_claim_period, filed_period
-            )
+    if not filed_period:
+        return
+
+    frappe.throw(
+        _("Cannot change ITC Claim Period from {0} to {1}. GSTR-3B already filed for {2}.").format(
+            previous.itc_claim_period, doc.itc_claim_period, filed_period
         )
+    )
 
 
 def _validate_itc_claim_period_for_rcm_invoice(doc) -> None:

--- a/india_compliance/gst_india/utils/itc_claim.py
+++ b/india_compliance/gst_india/utils/itc_claim.py
@@ -347,23 +347,20 @@ def validate_itc_claim_period(doc) -> None:
     validate_mandatory_fields(doc, "itc_claim_period")
     _validate_period_format(doc.itc_claim_period)
     _validate_itc_claim_period_for_rcm_invoice(doc)
-    _validate_itc_claim_period_as_per_filing(doc)
+    _validate_itc_claim_period_as_per_filling(doc)
 
 
-def _validate_itc_claim_period_as_per_filing(doc) -> None:
-    # For draft docs, target period must not be filed.
-    if doc.docstatus == 0:
-        if _is_gstr3b_filed(doc.company_gstin, doc.itc_claim_period):
-            frappe.throw(
-                _("Cannot set ITC Claim Period to {0}. GSTR-3B is already filed.").format(
-                    doc.itc_claim_period
-                )
-            )
+def validate_itc_claim_period_on_update_after_submit(doc) -> None:
+    validate_mandatory_fields(doc, "itc_claim_period")
+    _validate_period_format(doc.itc_claim_period)
+    _validate_itc_claim_period_for_rcm_invoice(doc)
+
+    # On update-after-submit, period checks are needed only if period changed.
+    previous = doc.get_doc_before_save()
+    if not previous:
         return
 
-    # For submitted docs, if period is being changed, both old and new periods must not be filed.
-    previous = doc.get_doc_before_save()
-    if not previous or previous.itc_claim_period == doc.itc_claim_period:
+    if previous.itc_claim_period == doc.itc_claim_period:
         return
 
     filed_period = None
@@ -380,6 +377,13 @@ def _validate_itc_claim_period_as_per_filing(doc) -> None:
             previous.itc_claim_period, doc.itc_claim_period, filed_period
         )
     )
+
+
+def _validate_itc_claim_period_as_per_filling(doc) -> None:
+    if _is_gstr3b_filed(doc.company_gstin, doc.itc_claim_period):
+        frappe.throw(
+            _("Cannot set ITC Claim Period to {0}. GSTR-3B is already filed.").format(doc.itc_claim_period)
+        )
 
 
 def _validate_itc_claim_period_for_rcm_invoice(doc) -> None:


### PR DESCRIPTION
Issue: Changes in the ITC claim from the filed to the unfiled period in the draft invoice were restricted.

- Allow changes in the ITC Claim Period for the draft invoice.
- Validate ITC claim period in draft invoice
- Refactored test cases for better handling of failed test cases