### PR TITLE
fix: remove conditional check for transported GSTIN for extend e-waybill

### DIFF
--- a/india_compliance/gst_india/client_scripts/e_waybill_actions.js
+++ b/india_compliance/gst_india/client_scripts/e_waybill_actions.js
@@ -1216,12 +1216,6 @@ async function auto_generate_e_waybill(frm) {
     return await new E_WAYBILL_CLASS[frm.doctype](frm).auto_generate_e_waybill();
 }
 
-function can_extend_e_waybill(frm) {
-    if (frm.doc.gst_transporter_id && frm.doc.gst_transporter_id != frm.doc.company_gstin) return false;
-
-    return true;
-}
-
 function get_hours(date, hours, date_time_format = frappe.defaultDatetimeFormat) {
     return moment(date).add(hours, "hours").format(date_time_format);
 }

--- a/india_compliance/gst_india/client_scripts/e_waybill_actions.js
+++ b/india_compliance/gst_india/client_scripts/e_waybill_actions.js
@@ -119,15 +119,11 @@ function setup_e_waybill_actions(doctype) {
                 frappe.perm.has_perm(frm.doctype, 0, "submit", frm.doc.name) &&
                 !has_extend_validity_expired(frm)
             ) {
-                const can_extend = can_extend_e_waybill(frm);
-                let btn = frm.add_custom_button(
+                frm.add_custom_button(
                     __("Extend Validity"),
-                    can_extend ? () => show_extend_validity_dialog(frm) : null,
+                    () => show_extend_validity_dialog(frm),
                     "e-Waybill",
                 );
-                if (!can_extend) {
-                    btn.addClass("disabled");
-                }
             }
 
             if (frappe.model.can_print("e-Waybill Log")) {


### PR DESCRIPTION
there is no reliable way to determine upfront whether the user is actually eligible to extend.

GST Transporter ID set may not necessarily be valid GST Transporter ID.
Only if Valid GST transporter ID is set, user cannot extend.

Keeping things simpler, by letting GST portal validate this after API call is made.

---

This is for both workflows:
- Immediately extend
- Schedule

As after user has scheduled, transporter GSTIN can change.