### PR TITLE
fix: handle empty vehicle details in e-way bill detailed print format

### DIFF
--- a/india_compliance/gst_india/print_format/e_waybill_detailed/e_waybill_detailed.html
+++ b/india_compliance/gst_india/print_format/e_waybill_detailed/e_waybill_detailed.html
@@ -49,9 +49,9 @@
                     </tr>
                     <tr>
                         <td>
-                            {% set lastVehicleDetails = data.VehiclListDetails | last %}
+                            {% set lastVehicleDetails = data.VehiclListDetails | last if data.VehiclListDetails else None %}
                             <span class="attribute">Mode: </span>
-                            <span class="attribute-value">{{ get_transport_mode(lastVehicleDetails.transMode)  }}</span>
+                            <span class="attribute-value">{{ get_transport_mode(lastVehicleDetails.transMode) if lastVehicleDetails else "" }}</span>
                         </td>
                         <td>
                             <span class="attribute">Approx Distance: </span>
@@ -293,7 +293,7 @@
                             Multi Veh. Info (If any)
                         </td>
                     </tr>
-                    <tr>
+                    {% if data.VehiclListDetails %}
                         {% for detail in data.VehiclListDetails %}
                             <tr>
                                 <td>
@@ -323,10 +323,19 @@
                                 <td>
                                     {{ detail.multiVehInfo | default('-') }}
                                 </td>
-
                             </tr>
                         {% endfor %}
-                    </tr>
+                    {% else %}
+                        <tr>
+                            <td></td>
+                            <td></td>
+                            <td></td>
+                            <td></td>
+                            <td></td>
+                            <td></td>
+                            <td></td>
+                        </tr>
+                    {% endif %}
                 </tbody>
             </table>
 

--- a/india_compliance/gst_india/print_format/e_waybill_detailed/e_waybill_detailed.html
+++ b/india_compliance/gst_india/print_format/e_waybill_detailed/e_waybill_detailed.html
@@ -327,13 +327,7 @@
                         {% endfor %}
                     {% else %}
                         <tr>
-                            <td></td>
-                            <td></td>
-                            <td></td>
-                            <td></td>
-                            <td></td>
-                            <td></td>
-                            <td></td>
+                            <td colspan="7" style="text-align: center;">No vehicle details available</td>
                         </tr>
                     {% endif %}
                 </tbody>


### PR DESCRIPTION
<img width="827" height="841" alt="image" src="https://github.com/user-attachments/assets/e0218c58-0625-46bc-b95e-0ab28ad69f98" />
