### PR TITLE
fix: simplify permission check in check_duplicate_party function

### DIFF
--- a/india_compliance/gst_india/utils/__init__.py
+++ b/india_compliance/gst_india/utils/__init__.py
@@ -1115,7 +1115,7 @@ def check_duplicate_party(field: str, value: str, party_type: str, party: str | 
     if party_type not in GST_PARTY_TYPES:
         return
 
-    frappe.has_permission(party_type, doc=party, throw=True)
+    frappe.has_permission(party_type, throw=True)
 
     value = value.upper().strip()
 


### PR DESCRIPTION
continues: https://github.com/resilient-tech/india-compliance/pull/4167
Issue:  When a user creates a new, unsaved Supplier/Customer/Company and adds a GSTIN, a `DoesNotExistError` is thrown.
Party permission is sufficient for GSTIN and PAN info.