### PR TITLE
fix: updated fix for the permission issue according to new structure

### DIFF
--- a/india_compliance/gst_india/utils/__init__.py
+++ b/india_compliance/gst_india/utils/__init__.py
@@ -1115,7 +1115,7 @@ def check_duplicate_party(field: str, value: str, party_type: str, party: str | 
     if party_type not in GST_PARTY_TYPES:
         return
 
-    frappe.has_permission(party_type, doc=party, throw=True)
+    frappe.has_permission(party_type, throw=True)
 
     value = value.upper().strip()
 


### PR DESCRIPTION
Issue
When user makes a new, unsaved Supplier/Customer/Company and adds GSTIN to it, the system gives a DoesNotExistError error.