### PR TITLE
fix: update validation logic for non-GST items

### DIFF
--- a/india_compliance/gst_india/doctype/gstr_3b_report/test_gstr_3b_report.py
+++ b/india_compliance/gst_india/doctype/gstr_3b_report/test_gstr_3b_report.py
@@ -89,7 +89,6 @@ class TestGSTR3BReport(FrappeTestCase):
                 "doctype": "GSTR 3B Report",
                 "company": "_Test Indian Registered Company",
                 "company_gstin": "24AAQCA8719H1ZC",
-                "filter_by": "Posting Date",
                 "year": today.year,
                 "month_or_quarter": get_month(today),
             }

--- a/india_compliance/gst_india/overrides/test_purchase_invoice.py
+++ b/india_compliance/gst_india/overrides/test_purchase_invoice.py
@@ -305,6 +305,16 @@ class TestPurchaseInvoice(FrappeTestCase):
             pinv.save,
         )
 
+    def test_itc_claim_period_is_set_for_non_gst_invoice(self):
+        """Non-GST purchase invoices should still get a posting-period ITC claim period."""
+        pinv = create_purchase_invoice(
+            item_code="_Test Non GST Item",
+            do_not_submit=True,
+        )
+
+        self.assertEqual(pinv.items[0].gst_treatment, "Non-GST")
+        self.assertEqual(pinv.itc_claim_period, format_period(pinv.posting_date))
+
     def test_itc_claim_period_deferred(self):
         """
         Test that 'Deferred' is a valid ITC Claim Period for regular invoices

--- a/india_compliance/gst_india/overrides/test_transaction.py
+++ b/india_compliance/gst_india/overrides/test_transaction.py
@@ -600,6 +600,22 @@ class TestTransaction(FrappeTestCase):
             doc.insert,
         )
 
+    def test_non_gst_transaction_with_gst_accounts(self):
+        doc = create_transaction(
+            **self.transaction_details,
+            item_code="_Test Non GST Item",
+            is_in_state=True,
+            do_not_save=True,
+        )
+        doc.set("taxes", [])
+        _append_taxes(doc, ["CGST", "SGST"], charge_type="Actual", tax_amount=9)
+
+        self.assertRaisesRegex(
+            frappe.exceptions.ValidationError,
+            re.compile(r"^(Row #\d+: Cannot charge GST for Non GST Items)$"),
+            doc.insert,
+        )
+
     def test_invalid_charge_type_as_actual(self):
         doc = create_transaction(**self.transaction_details, do_not_save=True)
         _append_taxes(doc, ["CGST", "SGST"], charge_type="Actual", tax_amount=9)

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -323,6 +323,7 @@ class GSTAccounts:
 
         self.setup_defaults()
 
+        self.validate_tax_accounts_for_non_gst()
         self.validate_invalid_account_for_transaction()  # Sales / Purchase
         self.validate_for_same_party_gstin()
         self.validate_reverse_charge_accounts()
@@ -532,23 +533,22 @@ class GSTAccounts:
                     indicator="orange",
                 )
 
+    def validate_tax_accounts_for_non_gst(self):
+        """GST Tax Accounts should not be charged for Non GST Items"""
+        has_non_gst_items = any(row for row in self.doc.items if row.gst_treatment == "Non-GST")
+        if not has_non_gst_items:
+            return
+
+        self._throw(
+            _("Row #{0}: Cannot charge GST for Non GST Items").format(self.first_gst_idx),
+            title=_("Invalid Taxes"),
+        )
+
     def _get_matched_idx(self, rows_to_search, tax_types):
         return next((row.idx for row in rows_to_search if row.gst_tax_type in tax_types), None)
 
     def _throw(self, message, title=None):
         frappe.throw(message, title=title or _("Invalid GST Account"))
-
-
-def validate_tax_accounts_for_non_gst(doc):
-    """GST Tax Accounts should not be charged for Non GST Items"""
-    accounts_list = get_all_gst_accounts(doc.company)
-
-    for row in doc.taxes:
-        if row.account_head in accounts_list and row.tax_amount:
-            frappe.throw(
-                _("Row #{0}: Cannot charge GST for Non GST Items").format(row.idx, row.account_head),
-                title=_("Invalid Taxes"),
-            )
 
 
 def validate_items(doc, throw):
@@ -579,13 +579,7 @@ def validate_items(doc, throw):
         if row.item_tax_template != item_tax_templates[item_key]:
             items_with_duplicate_taxes.append(bold(item_key))
 
-    if not has_gst_items:
-        update_taxable_values(doc)
-        validate_tax_accounts_for_non_gst(doc)
-
-        return False
-
-    if non_gst_items:
+    if non_gst_items and has_gst_items:
         if not throw:
             return False
         frappe.throw(
@@ -1905,7 +1899,6 @@ def ignore_gst_validations(doc, throw=True):
     if (
         not is_indian_registered_company(doc)
         or doc.get("is_opening") == "Yes"
-        # If there are no GST items, then no need to proceed further
         # Also returning if item with multiple taxes
         or validate_items(doc, throw) is False
     ):

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -535,7 +535,7 @@ class GSTAccounts:
 
     def validate_tax_accounts_for_non_gst(self):
         """GST Tax Accounts should not be charged for Non GST Items"""
-        has_non_gst_items = any(row for row in self.doc.get("items", []) if row.gst_treatment == "Non-GST")
+        has_non_gst_items = any(row for row in self.doc.get("items") or [] if row.gst_treatment == "Non-GST")
         if not has_non_gst_items:
             return
 

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -535,7 +535,7 @@ class GSTAccounts:
 
     def validate_tax_accounts_for_non_gst(self):
         """GST Tax Accounts should not be charged for Non GST Items"""
-        has_non_gst_items = any(row for row in self.doc.items if row.gst_treatment == "Non-GST")
+        has_non_gst_items = any(row for row in self.doc.get("items", []) if row.gst_treatment == "Non-GST")
         if not has_non_gst_items:
             return
 


### PR DESCRIPTION
Issue: Validation for non-GST items was skipped due to which mandatory fields and status were not set.
Now all the validations are run for non gst items also.

- Now, the HSN Code will also be validated as per the GST Settings.
