### PR TITLE
fix: move ic setup wizard update to before_load

### DIFF
--- a/india_compliance/public/js/setup_wizard.js
+++ b/india_compliance/public/js/setup_wizard.js
@@ -23,9 +23,6 @@ frappe.setup.on("before_load", function () {
             });
         }
     };
-});
-
-frappe.setup.on("after_load", function () {
     update_erpnext_slides_settings();
 });
 


### PR DESCRIPTION
Issue: The company GSTIN change trigger is not registered because it is getting registered in after load, but onload is set before that.
regression: https://github.com/resilient-tech/india-compliance/pull/3996

closes: https://github.com/frappe/erpnext/issues/54817