### PR TITLE
fix: reset gst details on cross doctype mapping

### DIFF
--- a/india_compliance/gst_india/overrides/test_transaction.py
+++ b/india_compliance/gst_india/overrides/test_transaction.py
@@ -19,6 +19,7 @@ from erpnext.stock.doctype.delivery_note.delivery_note import make_sales_invoice
 from erpnext.stock.doctype.purchase_receipt.purchase_receipt import (
     update_regional_gl_entries,
 )
+from frappe.model.mapper import get_mapped_doc
 from frappe.tests import IntegrationTestCase, change_settings
 from frappe.utils import add_days, getdate, today
 from parameterized import parameterized_class
@@ -1542,3 +1543,107 @@ class TestPlaceOfSupply(IntegrationTestCase):
         # Both supplier and company are in Gujarat (24), so the PO is intra-state
         # and place_of_supply must NOT inherit the customer's state from the SO.
         self.assertEqual(po.place_of_supply, "24-Gujarat")
+
+    def test_place_of_supply_when_sales_order_mapped_from_purchase_order(self):
+        """
+        Place_of_supply on a Sales Order mapped from a Purchase Order.
+        (make_inter_company_sales_order)
+        """
+
+        po = create_transaction(
+            doctype="Purchase Order",
+            supplier="_Test Registered InterState Supplier",
+        )
+        # Supplier is in Tamil Nadu (33), company is in Gujarat (24);
+        # for a purchase, place_of_supply tracks the company side.
+        self.assertEqual(po.place_of_supply, "24-Gujarat")
+
+        def set_customer(source, target):
+            target.customer = "_Test Registered Composition Customer"
+            target.delivery_date = po.transaction_date
+
+        so = get_mapped_doc(
+            "Purchase Order",
+            po.name,
+            {
+                "Purchase Order": {
+                    "doctype": "Sales Order",
+                    "field_no_map": ["taxes_and_charges"],
+                },
+                "Purchase Order Item": {
+                    "doctype": "Sales Order Item",
+                    "field_map": {"schedule_date": "delivery_date"},
+                },
+            },
+            postprocess=set_customer,
+        )
+
+        # Customer is in Karnataka (29). place_of_supply on the SO must reflect
+        # that, not the PO's "24-Gujarat".
+        self.assertEqual(so.place_of_supply, "29-Karnataka")
+
+    def test_place_of_supply_when_purchase_receipt_mapped_from_delivery_note(self):
+        """
+        place_of_supply on a Purchase Receipt mapped from a Delivery Note
+        (make_inter_company_purchase_receipt).
+        """
+        dn = create_transaction(
+            doctype="Delivery Note",
+            customer="_Test Registered Composition Customer",
+        )
+        # Customer is in Karnataka (29), so the DN's place_of_supply is 29.
+        self.assertEqual(dn.place_of_supply, "29-Karnataka")
+
+        def set_supplier(source, target):
+            target.supplier = "_Test Registered Supplier"
+
+        pr = get_mapped_doc(
+            "Delivery Note",
+            dn.name,
+            {
+                "Delivery Note": {
+                    "doctype": "Purchase Receipt",
+                    "field_no_map": ["taxes_and_charges"],
+                },
+                "Delivery Note Item": {
+                    "doctype": "Purchase Receipt Item",
+                },
+            },
+            postprocess=set_supplier,
+        )
+
+        # Supplier and company are both in Gujarat (24). place_of_supply on the
+        # PR must reflect the receiving-company side, not the DN's Karnataka.
+        self.assertEqual(pr.place_of_supply, "24-Gujarat")
+
+    def test_place_of_supply_when_delivery_note_mapped_from_purchase_receipt(self):
+        """
+        place_of_supply on a Delivery Note mapped from a Purchase Receipt
+        (make_inter_company_delivery_note)
+        """
+
+        pr = create_transaction(doctype="Purchase Receipt")
+        # Supplier and company are in Gujarat (24), so the PR's POS is 24-Gujarat.
+        self.assertEqual(pr.place_of_supply, "24-Gujarat")
+
+        def set_customer(source, target):
+            target.customer = "_Test Registered Composition Customer"
+
+        dn = get_mapped_doc(
+            "Purchase Receipt",
+            pr.name,
+            {
+                "Purchase Receipt": {
+                    "doctype": "Delivery Note",
+                    "field_no_map": ["taxes_and_charges"],
+                },
+                "Purchase Receipt Item": {
+                    "doctype": "Delivery Note Item",
+                },
+            },
+            postprocess=set_customer,
+        )
+
+        # Customer is in Karnataka (29). place_of_supply on the DN must reflect
+        # that, not the PR's "24-Gujarat".
+        self.assertEqual(dn.place_of_supply, "29-Karnataka")

--- a/india_compliance/gst_india/overrides/test_transaction.py
+++ b/india_compliance/gst_india/overrides/test_transaction.py
@@ -14,6 +14,7 @@ from erpnext.controllers.accounts_controller import (
 )
 from erpnext.controllers.sales_and_purchase_return import make_return_doc
 from erpnext.controllers.taxes_and_totals import get_regional_round_off_accounts
+from erpnext.selling.doctype.sales_order.sales_order import make_purchase_order
 from erpnext.stock.doctype.delivery_note.delivery_note import make_sales_invoice
 from erpnext.stock.doctype.purchase_receipt.purchase_receipt import (
     update_regional_gl_entries,
@@ -1517,3 +1518,27 @@ class TestPlaceOfSupply(IntegrationTestCase):
         # check gst_tax_type of tax table
         for tax in doc.taxes:
             self.assertEqual(tax.gst_tax_type, "igst")
+
+    def test_place_of_supply_when_purchase_order_created_from_sales_order(self):
+        """
+        Place_of_supply on a Purchase Order created from a Sales Order must
+        reflect the buyer/company context, not the customer's state inherited
+        from the source Sales Order.
+        """
+        so = create_transaction(
+            doctype="Sales Order",
+            customer="_Test Registered Composition Customer",
+            do_not_submit=True,
+        )
+        so.submit()
+        self.assertEqual(so.place_of_supply, "29-Karnataka")
+
+        selected_items = [{"item_code": so.items[0].item_code, "supplier": "_Test Registered Supplier"}]
+
+        purchase_orders = make_purchase_order(so.name, selected_items=selected_items)
+        self.assertTrue(purchase_orders)
+
+        po = purchase_orders[0]
+        # Both supplier and company are in Gujarat (24), so the PO is intra-state
+        # and place_of_supply must NOT inherit the customer's state from the SO.
+        self.assertEqual(po.place_of_supply, "24-Gujarat")

--- a/india_compliance/gst_india/overrides/test_transaction.py
+++ b/india_compliance/gst_india/overrides/test_transaction.py
@@ -1544,6 +1544,11 @@ class TestPlaceOfSupply(IntegrationTestCase):
         # and place_of_supply must NOT inherit the customer's state from the SO.
         self.assertEqual(po.place_of_supply, "24-Gujarat")
 
+        # Supplier GST category and taxes must be correctly set
+        self.assertEqual(po.gst_category, "Registered Regular")
+        self.assertTrue(po.taxes_and_charges)
+        self.assertTrue(po.taxes)
+
     def test_place_of_supply_when_sales_order_mapped_from_purchase_order(self):
         """
         Place_of_supply on a Sales Order mapped from a Purchase Order.

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -1780,6 +1780,20 @@ def reset_gst_details_on_cross_mapping(target_doc, source_doc):
     if is_source_sales == is_target_sales:
         return
 
+    # Re-fetch address-based fields (gst_category, party_gstin) from the
+    # target's own party address before evaluating GST details.
+    # Need to be fixed in Frappe where on set of values link fields
+    # should be updated in update if missing.
+    party_address_field = _get_address_fields(target_doc.doctype).get("party_address_field")
+    if party_address_field and target_doc.get(party_address_field):
+        target_doc.update(
+            get_fetch_values(
+                target_doc.doctype,
+                party_address_field,
+                target_doc.get(party_address_field),
+            )
+        )
+
     gst_details = get_gst_details(
         target_doc.as_dict(),
         target_doc.doctype,

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -1752,16 +1752,44 @@ def validate_item_tax_template(doc):
 
 
 def after_mapping(target_doc, method=None, source_doc=None):
+    if not source_doc:
+        return
+
+    reset_gst_details_on_cross_mapping(target_doc, source_doc)
+
     # Copy e-Waybill fields only from DN to SI
-    if not source_doc or source_doc.doctype not in (
-        "Delivery Note",
-        "Purchase Receipt",
-    ):
+    if source_doc.doctype not in ("Delivery Note", "Purchase Receipt"):
         return
 
     for field in E_WAYBILL_INV_FIELDS:
         fieldname = field.get("fieldname")
         target_doc.set(fieldname, source_doc.get(fieldname))
+
+
+def reset_gst_details_on_cross_mapping(target_doc, source_doc):
+    """
+    When mapping between sales and purchase doctypes (e.g. Purchase Order
+    from Sales Order), reset GST details.
+    """
+    if ignore_gst_validations(target_doc):
+        return
+
+    is_source_sales = source_doc.doctype in SALES_DOCTYPES
+    is_target_sales = target_doc.doctype in SALES_DOCTYPES
+
+    if is_source_sales == is_target_sales:
+        return
+
+    gst_details = get_gst_details(
+        target_doc.as_dict(),
+        target_doc.doctype,
+        target_doc.company,
+        update_place_of_supply=True,
+    )
+    if not gst_details:
+        return
+
+    target_doc.update(gst_details)
 
 
 def ignore_gst_validations(doc):

--- a/india_compliance/hooks.py
+++ b/india_compliance/hooks.py
@@ -146,6 +146,7 @@ doc_events = {
         "before_submit": "india_compliance.gst_india.overrides.transaction.update_gst_details",
         "before_cancel": "india_compliance.gst_india.utils.e_waybill.before_cancel",
         "validate": "india_compliance.gst_india.overrides.delivery_note.validate",
+        "after_mapping": "india_compliance.gst_india.overrides.transaction.after_mapping",
     },
     "Email Template": {
         "after_rename": "india_compliance.gst_india.overrides.email_template.after_rename",
@@ -215,6 +216,7 @@ doc_events = {
             "india_compliance.gst_india.overrides.transaction.update_gst_details",
         ],
         "before_cancel": "india_compliance.gst_india.utils.e_waybill.before_cancel",
+        "after_mapping": "india_compliance.gst_india.overrides.transaction.after_mapping",
     },
     "Sales Invoice": {
         "onload": [

--- a/india_compliance/hooks.py
+++ b/india_compliance/hooks.py
@@ -195,6 +195,7 @@ doc_events = {
         "before_save": "india_compliance.gst_india.overrides.transaction.update_gst_details",
         "before_submit": "india_compliance.gst_india.overrides.transaction.update_gst_details",
         "before_update_after_submit": "india_compliance.gst_india.overrides.transaction.before_update_after_submit",
+        "after_mapping": "india_compliance.gst_india.overrides.transaction.after_mapping",
     },
     "Purchase Order Item": {
         "on_change": "india_compliance.gst_india.overrides.transaction.on_change_item",
@@ -240,6 +241,7 @@ doc_events = {
         "before_save": "india_compliance.gst_india.overrides.transaction.update_gst_details",
         "before_submit": "india_compliance.gst_india.overrides.transaction.update_gst_details",
         "before_update_after_submit": "india_compliance.gst_india.overrides.transaction.before_update_after_submit",
+        "after_mapping": "india_compliance.gst_india.overrides.transaction.after_mapping",
     },
     "Sales Order Item": {
         "on_change": "india_compliance.gst_india.overrides.transaction.on_change_item",


### PR DESCRIPTION
Issue: hen creating a Purchase Order (PO) from a Sales Order (SO), the PO incorrectly inherits the place_of_supply from the SO. While this reflects the customer's state on the SO, the PO should instead determine this field based on the supplier's address or GSTIN. This mismatch causes India Compliance's GST validation to throw an error (e.g., "Invalid GST Account — Row #2: Cannot charge CGST/SGST for inter-state supplies"), blocking the workflow entirely.