### PR TITLE
fix: tax template setup and GST tax breakup display issues

### DIFF
--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -35,7 +35,6 @@ from india_compliance.gst_india.utils import (
     has_gst_taxes,
     is_overseas_doc,
     join_list_with_custom_separators,
-    update_onload,
     validate_gst_category,
     validate_gstin,
 )
@@ -1664,7 +1663,6 @@ def validate_transaction(doc, method=None):
     update_taxable_values(doc)
     validate_item_wise_tax_detail(doc)
     set_gst_breakup(doc)
-    update_onload(doc, "_gst_breakup_table", doc.gst_breakup_table)
 
 
 def before_print(doc, method=None, print_settings=None):

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -1662,7 +1662,6 @@ def validate_transaction(doc, method=None):
         validate_gst_refund_accounts(doc)
     update_taxable_values(doc)
     validate_item_wise_tax_detail(doc)
-    set_gst_breakup(doc)
 
 
 def before_print(doc, method=None, print_settings=None):

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -35,6 +35,7 @@ from india_compliance.gst_india.utils import (
     has_gst_taxes,
     is_overseas_doc,
     join_list_with_custom_separators,
+    update_onload,
     validate_gst_category,
     validate_gstin,
 )
@@ -1662,6 +1663,8 @@ def validate_transaction(doc, method=None):
         validate_gst_refund_accounts(doc)
     update_taxable_values(doc)
     validate_item_wise_tax_detail(doc)
+    set_gst_breakup(doc)
+    update_onload(doc, "_gst_breakup_table", doc.gst_breakup_table)
 
 
 def before_print(doc, method=None, print_settings=None):
@@ -1678,6 +1681,7 @@ def onload(doc, method=None):
 
     set_ecommerce_supply_type(doc)
     set_gst_breakup(doc)
+    doc.set_onload("_gst_breakup_table", doc.gst_breakup_table)
 
 
 def validate_ecommerce_gstin(doc):

--- a/india_compliance/public/js/transaction.js
+++ b/india_compliance/public/js/transaction.js
@@ -19,6 +19,7 @@ for (const doctype of TRANSACTION_DOCTYPES) {
     fetch_gst_details(doctype);
     validate_overseas_gst_category(doctype);
     set_and_validate_gstin_status(doctype);
+    set_gst_tax_breakup_on_load(doctype);
 }
 
 for (const doctype of SUBCONTRACTING_DOCTYPES) {
@@ -188,6 +189,15 @@ function ignore_port_code_validation(doctype) {
     frappe.ui.form.on(doctype, {
         onload(frm) {
             frm.set_df_property("port_code", "ignore_validation", 1);
+        },
+    });
+}
+
+function set_gst_tax_breakup_on_load(doctype) {
+    frappe.ui.form.on(doctype, {
+        refresh(frm) {
+            frm.doc.gst_breakup_table = frm.doc.__onload?._gst_breakup_table;
+            frm.refresh_field("gst_breakup_table");
         },
     });
 }

--- a/india_compliance/setup_wizard.py
+++ b/india_compliance/setup_wizard.py
@@ -68,6 +68,11 @@ def configure_audit_trail(params):
 
 
 def setup_company_taxes(params):
+    if params.country != "India":
+        return
+
+    setup_tax_template(params)
+
     if not params.company_gstin:
         return
 
@@ -85,7 +90,6 @@ def setup_company_taxes(params):
 
     update_company_info(params, gstin_info.gst_category)
     create_address(gstin_info, params)
-    setup_tax_template(params)
 
 
 def update_company_info(params, gst_category=None):

--- a/india_compliance/setup_wizard.py
+++ b/india_compliance/setup_wizard.py
@@ -71,12 +71,12 @@ def setup_company_taxes(params):
     if params.country != "India":
         return
 
+    if not (params.company_name and frappe.db.exists("Company", params.company_name)):
+        return
+
     setup_tax_template(params)
 
     if not params.company_gstin:
-        return
-
-    if not (params.company_name and frappe.db.exists("Company", params.company_name)):
         return
 
     try:


### PR DESCRIPTION
closes: https://github.com/frappe/erpnext/issues/55079

- Create tax templates even if company GSTIN is not specified or validated
- Set GST Tax breakup onload and set values there