### PR TITLE
fix: enhance rounding validation for GST calculations in transactions

### DIFF
--- a/india_compliance/gst_india/overrides/test_sales_invoice.py
+++ b/india_compliance/gst_india/overrides/test_sales_invoice.py
@@ -1,7 +1,6 @@
 import frappe
 from frappe.tests import IntegrationTestCase
 from frappe.tests.utils import change_settings
-from frappe.utils import flt
 
 from india_compliance.gst_india.utils import validate_invoice_number
 from india_compliance.gst_india.utils.tests import append_item, create_transaction

--- a/india_compliance/gst_india/overrides/test_sales_invoice.py
+++ b/india_compliance/gst_india/overrides/test_sales_invoice.py
@@ -1,7 +1,10 @@
 import frappe
 from frappe.tests import IntegrationTestCase
+from frappe.tests.utils import change_settings
+from frappe.utils import flt
 
 from india_compliance.gst_india.utils import validate_invoice_number
+from india_compliance.gst_india.utils.tests import append_item, create_transaction
 
 
 class TestSalesInvoice(IntegrationTestCase):
@@ -32,3 +35,44 @@ class TestSalesInvoice(IntegrationTestCase):
                 validate_invoice_number(doc)
             except frappe.ValidationError:
                 self.fail(f"Valid name {name} throwing error")
+
+    @change_settings("GST Settings", {"enable_overseas_transactions": 1, "round_off_gst_values": 1})
+    @change_settings(
+        "Accounts Settings",
+        {"allow_multi_currency_invoices_against_single_party_account": 1},
+    )
+    def test_item_gst_amount_in_multicurrency_invoice(self):
+        """
+        In a multicurrency invoice, ERPNext rounds the doc-level tax in
+        transaction currency before converting to base currency. So the
+        doc-level `base_tax_amount_after_discount_amount` diverges from
+        per-item `rate% x base_net_amount`.
+
+        India Compliance concentrates that residual onto the last taxable
+        item so the sum of per-item gst amounts matches the doc total.
+        """
+        doc = create_transaction(
+            doctype="Sales Invoice",
+            customer="_Test Foreign Customer",
+            customer_address="_Test Foreign Customer-Billing",
+            is_export_with_gst=1,
+            currency="USD",
+            conversion_rate=95.99,
+            rate=5932.20,
+            qty=9,
+            is_out_state=True,
+            do_not_save=True,
+        )
+        append_item(doc, frappe._dict(rate=1234.56, qty=3))
+        doc.insert()
+
+        item_a = doc.items[0]
+        item_b = doc.items[1]
+
+        self.assertEqual(item_a.igst_rate, 18)
+        self.assertEqual(item_b.igst_rate, 18)
+
+        igst_row = next(t for t in doc.taxes if t.gst_tax_type == "igst")
+        self.assertEqual(
+            item_a.igst_amount + item_b.igst_amount, igst_row.base_tax_amount_after_discount_amount
+        )

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -1227,6 +1227,7 @@ class ItemGSTDetails:
             tax_map[row.name] = row
 
         for row in self.doc.get("items"):
+            row.has_gst_tax_difference = False
             key = row.name
             item_map[key] = row
 

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -1181,8 +1181,10 @@ class ItemGSTDetails:
             if tax_amount:
                 last_item_with_tax = item
 
+        self.tax_differences = tax_differences
         # Handle rounding errors
         if tax_differences and last_item_with_tax:
+            last_item_with_tax.has_gst_tax_difference = True
             for tax_type, difference in tax_differences.items():
                 amount = flt(last_item_with_tax.get(f"{tax_type}_amount") + difference, 5)
                 last_item_with_tax.set(f"{tax_type}_amount", amount)
@@ -1281,10 +1283,12 @@ class ItemGSTDetails:
 
     def validate_item_gst_details(self):
         invalid_rows = defaultdict(list)
-
         for item in self.doc.get("items"):
+            adjustments = item.get("has_gst_tax_difference")
             for tax in GST_TAX_TYPES:
                 expected_amt = self.get_item_tax_amount(item, item.get(f"{tax}_rate"), tax)
+                if adjustments:
+                    expected_amt += self.tax_differences.get(tax, 0)
 
                 diff = abs(item.get(f"{tax}_amount") - expected_amt)
 


### PR DESCRIPTION
ERPNext rounds the txn-side tax to whole units. With CR=95.99 and a 0.5 USD shift, base-side moves by ~48 INR.
This is a workaround fix.
Core fix required in erpnext.
In a multicurrency transaction, due to rounding difference is more than 1 which, we adjust the last item so that while validating the tax amount, the adjusted amount should also be taken into consideration.

Note: a fix is required in ERPNext for develop and v16 branches.