### PR TITLE
feat: add section download for gstr-1 exports

### DIFF
--- a/india_compliance/gst_india/doctype/gstr_1/gstr_1.js
+++ b/india_compliance/gst_india/doctype/gstr_1/gstr_1.js
@@ -2063,8 +2063,7 @@ class FiledTab extends GSTR1_TabManager {
     setup_actions() {
         this.add_tab_custom_button("Download Excel", () => this.download_filed_as_excel());
 
-        if (this.status !== "Filed")
-            this.add_tab_custom_button("Download JSON", () => this.download_filed_json());
+        this.add_tab_custom_button("Download JSON", () => this.download_filed_json());
 
         if (!is_gstr1_api_enabled()) return;
 
@@ -2086,11 +2085,18 @@ class FiledTab extends GSTR1_TabManager {
 
     download_filed_as_excel() {
         const url = "india_compliance.gst_india.doctype.gstr_1.gstr_1_export.download_filed_as_excel";
-
-        open_url_post(`/api/method/${url}`, {
-            company_gstin: this.instance.frm.doc.company_gstin,
-            month_or_quarter: this.instance.frm.doc.month_or_quarter,
-            year: this.instance.frm.doc.year,
+        open_section_download_dialog({
+            title: __("Download Excel"),
+            section_options: GSTR1_SECTION_OPTIONS,
+            on_submit: (section) => {
+                const post_args = {
+                    company_gstin: this.instance.frm.doc.company_gstin,
+                    month_or_quarter: this.instance.frm.doc.month_or_quarter,
+                    year: this.instance.frm.doc.year,
+                };
+                if (section) post_args.section = section;
+                open_url_post(`/api/method/${url}`, post_args);
+            },
         });
     }
 
@@ -2101,45 +2107,20 @@ class FiledTab extends GSTR1_TabManager {
 
     download_filed_json() {
         const me = this;
-        function get_json_data(dialog) {
-            const { include_uploaded, delete_missing } = dialog
-                ? dialog.get_values()
-                : {
-                      include_uploaded: true,
-                      delete_missing: false,
-                  };
+        const api_enabled = is_gstr1_api_enabled();
 
-            const doc = me.instance.frm.doc;
+        const fields = [
+            {
+                fieldname: "section",
+                label: __("Section"),
+                fieldtype: "Select",
+                options: [{ value: "", label: __("All Sections") }, ...GSTR1_SECTION_OPTIONS],
+                description: __("Select a section to download, or leave empty for all sections."),
+            },
+        ];
 
-            frappe.call({
-                method: "india_compliance.gst_india.doctype.gstr_1.gstr_1_export.get_gstr_1_json",
-                args: {
-                    company_gstin: doc.company_gstin,
-                    year: doc.year,
-                    month_or_quarter: doc.month_or_quarter,
-                    include_uploaded,
-                    delete_missing,
-                },
-                callback: (r) => {
-                    india_compliance.trigger_file_download(
-                        JSON.stringify(r.message.data),
-                        r.message.filename,
-                    );
-                    dialog && dialog.hide();
-                },
-            });
-        }
-
-        // without API
-        if (!is_gstr1_api_enabled()) {
-            get_json_data();
-            return;
-        }
-
-        // with API
-        const dialog = new frappe.ui.Dialog({
-            title: __("Download JSON"),
-            fields: [
+        if (api_enabled) {
+            fields.push(
                 {
                     fieldname: "include_uploaded",
                     label: __("Include Already Uploaded (matching) Invoices"),
@@ -2150,6 +2131,7 @@ class FiledTab extends GSTR1_TabManager {
                          as it will overwrite the e-Invoice data in GST Portal.`,
                     ),
                     fieldtype: "Check",
+                    default: 0,
                 },
                 {
                     fieldname: "delete_missing",
@@ -2160,8 +2142,35 @@ class FiledTab extends GSTR1_TabManager {
                     fieldtype: "Check",
                     default: 1,
                 },
-            ],
-            primary_action: () => get_json_data(dialog),
+            );
+        }
+
+        const dialog = new frappe.ui.Dialog({
+            title: __("Download JSON"),
+            fields,
+            primary_action: () => {
+                const { section, include_uploaded, delete_missing } = dialog.get_values();
+                const doc = me.instance.frm.doc;
+
+                frappe.call({
+                    method: "india_compliance.gst_india.doctype.gstr_1.gstr_1_export.get_gstr_1_json",
+                    args: {
+                        company_gstin: doc.company_gstin,
+                        year: doc.year,
+                        month_or_quarter: doc.month_or_quarter,
+                        include_uploaded: api_enabled ? include_uploaded : true,
+                        delete_missing: api_enabled ? delete_missing : false,
+                        section: section || null,
+                    },
+                    callback: (r) => {
+                        india_compliance.trigger_file_download(
+                            JSON.stringify(r.message.data),
+                            r.message.filename,
+                        );
+                        dialog.hide();
+                    },
+                });
+            },
         });
 
         dialog.show();
@@ -3033,6 +3042,47 @@ class GSTR1Action extends FileGSTR1Dialog {
 }
 
 // UTILITY FUNCTIONS
+
+// Section dropdown options for both JSON and Excel download dialogs.
+// Values MUST match `GovJsonKey` in gst_india/utils/gstr_1/__init__.py — keep in sync,
+// and ensure JSON_CATEGORY_EXCEL_CATEGORY_MAPPING covers every option before adding one.
+const GSTR1_SECTION_OPTIONS = [
+    { value: "b2b", label: __("B2B, SEZ, DE (b2b)") },
+    { value: "b2cl", label: __("B2C Large (b2cl)") },
+    { value: "exp", label: __("Exports (exp)") },
+    { value: "b2cs", label: __("B2C Small (b2cs)") },
+    { value: "nil", label: __("Nil, Exempt, Non-GST (nil)") },
+    { value: "cdnr", label: __("Credit/Debit Notes - Registered (cdnr)") },
+    { value: "cdnur", label: __("Credit/Debit Notes - Unregistered (cdnur)") },
+    { value: "at", label: __("Advance Tax (at)") },
+    { value: "txpd", label: __("Tax on Advances Adjustment (txpd)") },
+    { value: "hsn", label: __("HSN Summary (hsn)") },
+    { value: "doc_issue", label: __("Document Issued Summary (doc_issue)") },
+    { value: "supeco", label: __("Supplies through e-Commerce (supeco)") },
+];
+
+function open_section_download_dialog({ title, section_options, on_submit }) {
+    const dialog = new frappe.ui.Dialog({
+        title,
+        fields: [
+            {
+                fieldname: "section",
+                label: __("Section"),
+                fieldtype: "Select",
+                options: [{ value: "", label: __("All Sections") }, ...section_options],
+                description: __("Select a section to download, or leave empty for all sections."),
+            },
+        ],
+        primary_action_label: __("Download"),
+        primary_action: () => {
+            const { section } = dialog.get_values();
+            on_submit(section || null);
+            dialog.hide();
+        },
+    });
+    dialog.show();
+}
+
 function is_gstr1_api_enabled() {
     return india_compliance.is_api_enabled() && !gst_settings.sandbox_mode && gst_settings.enable_gstr_1_api;
 }

--- a/india_compliance/gst_india/doctype/gstr_1/gstr_1.js
+++ b/india_compliance/gst_india/doctype/gstr_1/gstr_1.js
@@ -2063,7 +2063,8 @@ class FiledTab extends GSTR1_TabManager {
     setup_actions() {
         this.add_tab_custom_button("Download Excel", () => this.download_filed_as_excel());
 
-        this.add_tab_custom_button("Download JSON", () => this.download_filed_json());
+        if (this.status !== "Filed")
+            this.add_tab_custom_button("Download JSON", () => this.download_filed_json());
 
         if (!is_gstr1_api_enabled()) return;
 
@@ -2085,19 +2086,33 @@ class FiledTab extends GSTR1_TabManager {
 
     download_filed_as_excel() {
         const url = "india_compliance.gst_india.doctype.gstr_1.gstr_1_export.download_filed_as_excel";
-        open_section_download_dialog({
+        const dialog = new frappe.ui.Dialog({
             title: __("Download Excel"),
-            section_options: GSTR1_SECTION_OPTIONS,
-            on_submit: (section) => {
+            fields: [
+                {
+                    fieldname: "section",
+                    label: __("Section"),
+                    fieldtype: "Select",
+                    options: [{ value: "", label: __("All Sections") }, ...GSTR1_SECTION_OPTIONS],
+                    description: __("Select a section to download, or leave empty for all sections."),
+                },
+            ],
+            primary_action_label: __("Download"),
+            primary_action: () => {
+                const { section } = dialog.get_values();
                 const post_args = {
                     company_gstin: this.instance.frm.doc.company_gstin,
                     month_or_quarter: this.instance.frm.doc.month_or_quarter,
                     year: this.instance.frm.doc.year,
                 };
+
                 if (section) post_args.section = section;
                 open_url_post(`/api/method/${url}`, post_args);
+                dialog.hide();
             },
         });
+
+        dialog.show();
     }
 
     sync_with_gstn(sync_for) {
@@ -2148,6 +2163,7 @@ class FiledTab extends GSTR1_TabManager {
         const dialog = new frappe.ui.Dialog({
             title: __("Download JSON"),
             fields,
+            primary_action_label: __("Download"),
             primary_action: () => {
                 const { section, include_uploaded, delete_missing } = dialog.get_values();
                 const doc = me.instance.frm.doc;
@@ -3060,28 +3076,6 @@ const GSTR1_SECTION_OPTIONS = [
     { value: "doc_issue", label: __("Document Issued Summary (doc_issue)") },
     { value: "supeco", label: __("Supplies through e-Commerce (supeco)") },
 ];
-
-function open_section_download_dialog({ title, section_options, on_submit }) {
-    const dialog = new frappe.ui.Dialog({
-        title,
-        fields: [
-            {
-                fieldname: "section",
-                label: __("Section"),
-                fieldtype: "Select",
-                options: [{ value: "", label: __("All Sections") }, ...section_options],
-                description: __("Select a section to download, or leave empty for all sections."),
-            },
-        ],
-        primary_action_label: __("Download"),
-        primary_action: () => {
-            const { section } = dialog.get_values();
-            on_submit(section || null);
-            dialog.hide();
-        },
-    });
-    dialog.show();
-}
 
 function is_gstr1_api_enabled() {
     return india_compliance.is_api_enabled() && !gst_settings.sandbox_mode && gst_settings.enable_gstr_1_api;

--- a/india_compliance/gst_india/doctype/gstr_1/gstr_1.js
+++ b/india_compliance/gst_india/doctype/gstr_1/gstr_1.js
@@ -3107,19 +3107,25 @@ const GSTR1_SECTION_OPTIONS = [
     { value: "supeco", label: __("Supplies through e-Commerce (supeco)") },
 ];
 
+const GSTR1_SECTIONS_KEY = "gstr1_download_sections";
+
 function _get_saved_sections() {
-    const raw = frappe.defaults.get_user_default("gstr1_download_sections");
-    return raw ? JSON.parse(raw) : null;
+    const raw = frappe.defaults.get_user_default(GSTR1_SECTIONS_KEY);
+    try {
+        return raw ? JSON.parse(raw) : null;
+    } catch {
+        return null;
+    }
 }
 
 function _save_sections(sections_or_null) {
     const to_save = sections_or_null || GSTR1_SECTION_OPTIONS.map((o) => o.value);
     const serialized = JSON.stringify(to_save);
+    frappe.defaults.set_user_default_local(GSTR1_SECTIONS_KEY, serialized);
     frappe.call({
-        method: "frappe.core.doctype.session_default_settings.session_default_settings.set_session_default_values",
-        args: { default_values: { gstr1_download_sections: serialized } },
+        method: "india_compliance.gst_india.doctype.gstr_1.gstr_1_export.set_section_preference",
+        args: { sections: serialized },
     });
-    frappe.defaults.set_user_default_local("gstr1_download_sections", serialized);
 }
 
 function is_gstr1_api_enabled() {

--- a/india_compliance/gst_india/doctype/gstr_1/gstr_1.js
+++ b/india_compliance/gst_india/doctype/gstr_1/gstr_1.js
@@ -2083,19 +2083,31 @@ class FiledTab extends GSTR1_TabManager {
     }
 
     get_section_filter_fields() {
-        return GSTR1_SECTION_OPTIONS.map((opt) => ({
-            fieldname: `section_${opt.value}`,
-            label: opt.label,
-            fieldtype: "Check",
-            default: 1,
-        }));
+        const saved = _get_saved_sections();
+        return [
+            {
+                fieldname: "sections",
+                fieldtype: "MultiCheck",
+                label: __("Sections"),
+                select_all: true,
+                columns: 2,
+                sort_options: false,
+                options: GSTR1_SECTION_OPTIONS.map((opt) => ({
+                    label: opt.label,
+                    value: opt.value,
+                    checked: saved ? saved.includes(opt.value) : true,
+                })),
+            },
+        ];
     }
 
     get_selected_sections(values) {
-        const all = GSTR1_SECTION_OPTIONS.map((opt) => opt.value);
-        const checked = all.filter((v) => values[`section_${v}`]);
-        // All checked is equivalent to no filter; send null so the backend skips filtering.
-        return checked.length === all.length ? null : checked.length ? checked : null;
+        const sections = values.sections || [];
+        const all = GSTR1_SECTION_OPTIONS.map((o) => o.value);
+        // All selected → null (backend skips filtering).
+        // Subset → return that list.
+        // Empty → return [] so callers can block the download.
+        return sections.length === all.length ? null : sections;
     }
 
     // ACTIONS
@@ -2104,17 +2116,23 @@ class FiledTab extends GSTR1_TabManager {
         const url = "india_compliance.gst_india.doctype.gstr_1.gstr_1_export.download_filed_as_excel";
         const dialog = new frappe.ui.Dialog({
             title: __("Download Excel"),
+            size: "large",
             fields: this.get_section_filter_fields(),
             primary_action_label: __("Download"),
             primary_action: () => {
                 const values = dialog.get_values();
                 const sections = this.get_selected_sections(values);
+                if (sections && !sections.length) {
+                    frappe.msgprint(__("Please select at least one section to download."));
+                    return;
+                }
                 const post_args = {
                     company_gstin: this.instance.frm.doc.company_gstin,
                     month_or_quarter: this.instance.frm.doc.month_or_quarter,
                     year: this.instance.frm.doc.year,
                 };
 
+                _save_sections(sections);
                 // open_url_post is form-encoded; JSON-encode the array so the
                 // backend receives it as a string it can frappe.parse_json().
                 if (sections) post_args.sections = JSON.stringify(sections);
@@ -2134,8 +2152,7 @@ class FiledTab extends GSTR1_TabManager {
     download_filed_json() {
         const me = this;
         const api_enabled = is_gstr1_api_enabled();
-
-        const fields = [...this.get_section_filter_fields()];
+        const fields = [];
 
         if (api_enabled) {
             fields.push(
@@ -2144,9 +2161,9 @@ class FiledTab extends GSTR1_TabManager {
                     label: __("Include Already Uploaded (matching) Invoices"),
                     description: __(
                         `This will include invoices already uploaded (and matching)
-                         to GSTN (possibly e-Invoices) and overwrite them in GST Portal.
-                         This is <strong>not recommended</strong> if e-Invoice is applicable to you
-                         as it will overwrite the e-Invoice data in GST Portal.`,
+                        to GSTN (possibly e-Invoices) and overwrite them in GST Portal.
+                        This is <strong>not recommended</strong> if e-Invoice is applicable to you
+                        as it will overwrite the e-Invoice data in GST Portal.`,
                     ),
                     fieldtype: "Check",
                     default: 0,
@@ -2163,14 +2180,22 @@ class FiledTab extends GSTR1_TabManager {
             );
         }
 
+        fields.push(...this.get_section_filter_fields());
+
         const dialog = new frappe.ui.Dialog({
             title: __("Download JSON"),
+            size: "large",
             fields,
             primary_action_label: __("Download"),
             primary_action: () => {
                 const values = dialog.get_values();
                 const { include_uploaded, delete_missing } = values;
                 const sections = me.get_selected_sections(values);
+                if (sections && !sections.length) {
+                    frappe.msgprint(__("Please select at least one section to download."));
+                    return;
+                }
+                _save_sections(sections);
                 const doc = me.instance.frm.doc;
 
                 frappe.call({
@@ -3081,6 +3106,21 @@ const GSTR1_SECTION_OPTIONS = [
     { value: "doc_issue", label: __("Document Issued Summary (doc_issue)") },
     { value: "supeco", label: __("Supplies through e-Commerce (supeco)") },
 ];
+
+function _get_saved_sections() {
+    const raw = frappe.defaults.get_user_default("gstr1_download_sections");
+    return raw ? JSON.parse(raw) : null;
+}
+
+function _save_sections(sections_or_null) {
+    const to_save = sections_or_null || GSTR1_SECTION_OPTIONS.map((o) => o.value);
+    const serialized = JSON.stringify(to_save);
+    frappe.call({
+        method: "frappe.core.doctype.session_default_settings.session_default_settings.set_session_default_values",
+        args: { default_values: { gstr1_download_sections: serialized } },
+    });
+    frappe.defaults.set_user_default_local("gstr1_download_sections", serialized);
+}
 
 function is_gstr1_api_enabled() {
     return india_compliance.is_api_enabled() && !gst_settings.sandbox_mode && gst_settings.enable_gstr_1_api;

--- a/india_compliance/gst_india/doctype/gstr_1/gstr_1.js
+++ b/india_compliance/gst_india/doctype/gstr_1/gstr_1.js
@@ -2082,21 +2082,22 @@ class FiledTab extends GSTR1_TabManager {
         super.set_default_title();
     }
 
+    get_section_filter_field() {
+        return {
+            fieldname: "section",
+            label: __("Section"),
+            fieldtype: "Select",
+            options: [{ value: "", label: __("All Sections") }, ...GSTR1_SECTION_OPTIONS],
+        };
+    }
+
     // ACTIONS
 
     download_filed_as_excel() {
         const url = "india_compliance.gst_india.doctype.gstr_1.gstr_1_export.download_filed_as_excel";
         const dialog = new frappe.ui.Dialog({
             title: __("Download Excel"),
-            fields: [
-                {
-                    fieldname: "section",
-                    label: __("Section"),
-                    fieldtype: "Select",
-                    options: [{ value: "", label: __("All Sections") }, ...GSTR1_SECTION_OPTIONS],
-                    description: __("Select a section to download, or leave empty for all sections."),
-                },
-            ],
+            fields: [this.get_section_filter_field()],
             primary_action_label: __("Download"),
             primary_action: () => {
                 const { section } = dialog.get_values();
@@ -2124,15 +2125,7 @@ class FiledTab extends GSTR1_TabManager {
         const me = this;
         const api_enabled = is_gstr1_api_enabled();
 
-        const fields = [
-            {
-                fieldname: "section",
-                label: __("Section"),
-                fieldtype: "Select",
-                options: [{ value: "", label: __("All Sections") }, ...GSTR1_SECTION_OPTIONS],
-                description: __("Select a section to download, or leave empty for all sections."),
-            },
-        ];
+        const fields = [this.get_section_filter_field()];
 
         if (api_enabled) {
             fields.push(

--- a/india_compliance/gst_india/doctype/gstr_1/gstr_1.js
+++ b/india_compliance/gst_india/doctype/gstr_1/gstr_1.js
@@ -2082,13 +2082,20 @@ class FiledTab extends GSTR1_TabManager {
         super.set_default_title();
     }
 
-    get_section_filter_field() {
-        return {
-            fieldname: "section",
-            label: __("Section"),
-            fieldtype: "Select",
-            options: [{ value: "", label: __("All Sections") }, ...GSTR1_SECTION_OPTIONS],
-        };
+    get_section_filter_fields() {
+        return GSTR1_SECTION_OPTIONS.map((opt) => ({
+            fieldname: `section_${opt.value}`,
+            label: opt.label,
+            fieldtype: "Check",
+            default: 1,
+        }));
+    }
+
+    get_selected_sections(values) {
+        const all = GSTR1_SECTION_OPTIONS.map((opt) => opt.value);
+        const checked = all.filter((v) => values[`section_${v}`]);
+        // All checked is equivalent to no filter; send null so the backend skips filtering.
+        return checked.length === all.length ? null : checked.length ? checked : null;
     }
 
     // ACTIONS
@@ -2097,17 +2104,20 @@ class FiledTab extends GSTR1_TabManager {
         const url = "india_compliance.gst_india.doctype.gstr_1.gstr_1_export.download_filed_as_excel";
         const dialog = new frappe.ui.Dialog({
             title: __("Download Excel"),
-            fields: [this.get_section_filter_field()],
+            fields: this.get_section_filter_fields(),
             primary_action_label: __("Download"),
             primary_action: () => {
-                const { section } = dialog.get_values();
+                const values = dialog.get_values();
+                const sections = this.get_selected_sections(values);
                 const post_args = {
                     company_gstin: this.instance.frm.doc.company_gstin,
                     month_or_quarter: this.instance.frm.doc.month_or_quarter,
                     year: this.instance.frm.doc.year,
                 };
 
-                if (section) post_args.section = section;
+                // open_url_post is form-encoded; JSON-encode the array so the
+                // backend receives it as a string it can frappe.parse_json().
+                if (sections) post_args.sections = JSON.stringify(sections);
                 open_url_post(`/api/method/${url}`, post_args);
                 dialog.hide();
             },
@@ -2125,7 +2135,7 @@ class FiledTab extends GSTR1_TabManager {
         const me = this;
         const api_enabled = is_gstr1_api_enabled();
 
-        const fields = [this.get_section_filter_field()];
+        const fields = [...this.get_section_filter_fields()];
 
         if (api_enabled) {
             fields.push(
@@ -2158,7 +2168,9 @@ class FiledTab extends GSTR1_TabManager {
             fields,
             primary_action_label: __("Download"),
             primary_action: () => {
-                const { section, include_uploaded, delete_missing } = dialog.get_values();
+                const values = dialog.get_values();
+                const { include_uploaded, delete_missing } = values;
+                const sections = me.get_selected_sections(values);
                 const doc = me.instance.frm.doc;
 
                 frappe.call({
@@ -2169,7 +2181,7 @@ class FiledTab extends GSTR1_TabManager {
                         month_or_quarter: doc.month_or_quarter,
                         include_uploaded: api_enabled ? include_uploaded : true,
                         delete_missing: api_enabled ? delete_missing : false,
-                        section: section || null,
+                        sections: sections,
                     },
                     callback: (r) => {
                         india_compliance.trigger_file_download(

--- a/india_compliance/gst_india/doctype/gstr_1/gstr_1_export.py
+++ b/india_compliance/gst_india/doctype/gstr_1/gstr_1_export.py
@@ -159,7 +159,7 @@ class GovExcel(DataProcessor):
         "V2.1": get_data_file_path("gstr1_excel_template_v2.1.xlsx"),
     }
 
-    def generate(self, gstin, period, section=None):
+    def generate(self, gstin, period, sections=None):
         """
         Build excel file
         """
@@ -179,15 +179,17 @@ class GovExcel(DataProcessor):
         data = self.process_data(data)
 
         sheet_names = None
-        if section:
-            selected_sections = _get_selected_sections(section, is_hsn_bifurcated)
-            data = _filter_data_by_sections(data, selected_sections)
-            sheet_names = _get_excel_sheet_names(selected_sections)
+        if sections:
+            selected = []
+            for section in sections:
+                selected.extend(_get_selected_sections(section, is_hsn_bifurcated))
+            data = _filter_data_by_sections(data, selected)
+            sheet_names = _get_excel_sheet_names(selected)
 
         self.build_excel(
             data,
             file,
-            filename=_get_gov_filename(gstin, period, section),
+            filename=_get_gov_filename(gstin, period, sections),
             sheet_names=sheet_names,
         )
 
@@ -2178,17 +2180,21 @@ def _filter_data_by_sections(data: dict, sections: list[str] | None) -> dict:
     return {k: v for k, v in data.items() if k in sections}
 
 
-def _get_gov_filename(company_gstin: str, period: str, section: str | None = None) -> str:
+def _get_gov_filename(company_gstin: str, period: str, sections: list[str] | None = None) -> str:
     name = f"GSTR-1-Gov-{company_gstin}-{period}"
-    if section:
-        name = f"{name}-{section}"
-    return name
+    if not sections:
+        return name
+    if len(sections) == 1:
+        return f"{name}-{sections[0]}"
+    return f"{name}-multi-section"
 
 
 @frappe.whitelist()
-def download_filed_as_excel(company_gstin: str, month_or_quarter: str, year: str, section: str | None = None):
+def download_filed_as_excel(company_gstin: str, month_or_quarter: str, year: str, sections=None):
     frappe.has_permission("GSTR-1", "export", throw=True)
-    GovExcel().generate(company_gstin, get_period(month_or_quarter, year), section=section)
+    if isinstance(sections, str):
+        sections = frappe.parse_json(sections) if sections else None
+    GovExcel().generate(company_gstin, get_period(month_or_quarter, year), sections=sections)
 
 
 @frappe.whitelist()
@@ -2214,9 +2220,12 @@ def get_gstr_1_json(
     month_or_quarter: str,
     include_uploaded: bool = False,
     delete_missing: bool = False,
-    section: str | None = None,
+    sections=None,
 ):
     frappe.has_permission("GSTR-1", "export", throw=True)
+    if isinstance(sections, str):
+        sections = frappe.parse_json(sections) if sections else None
+
     settings = frappe.get_cached_doc("GST Settings")
     if not settings.is_gstr1_api_enabled(company_gstin):
         include_uploaded = True
@@ -2281,8 +2290,8 @@ def get_gstr_1_json(
     gstr1_log.normalize_data(data)
     gov_data = convert_to_gov_data_format(data, company_gstin)
 
-    if section:
-        gov_data = _filter_data_by_sections(gov_data, [section])
+    if sections:
+        gov_data = _filter_data_by_sections(gov_data, sections)
 
     return {
         "data": {
@@ -2290,7 +2299,7 @@ def get_gstr_1_json(
             "fp": period,
             **gov_data,
         },
-        "filename": f"{_get_gov_filename(company_gstin, period, section)}.json",
+        "filename": f"{_get_gov_filename(company_gstin, period, sections)}.json",
     }
 
 

--- a/india_compliance/gst_india/doctype/gstr_1/gstr_1_export.py
+++ b/india_compliance/gst_india/doctype/gstr_1/gstr_1_export.py
@@ -49,6 +49,33 @@ CATEGORIES_WITH_ITEMS = {
 }
 
 
+def _get_hsn_sections(is_bifurcated: bool) -> list[str]:
+    if is_bifurcated:
+        return [HSNKey.HSN_B2B.value, HSNKey.HSN_B2C.value]
+
+    return [HSNKey.HSN.value]
+
+
+def _get_selected_sections(section: str, is_hsn_bifurcated: bool) -> list[str]:
+    """
+    HSN can be split into `hsn_b2b` / `hsn_b2c`. Every other
+    section uses the GovJsonKey value as-is.
+    """
+    if section != GovJsonKey.HSN.value:
+        return [section]
+
+    return _get_hsn_sections(is_hsn_bifurcated)
+
+
+def _get_excel_sheet_names(selected_sections: list[str]) -> list[str]:
+    """Template sheet names that belong to `section` (excluding the `master` reference sheet)."""
+    return [
+        JSON_CATEGORY_EXCEL_CATEGORY_MAPPING[key]
+        for key in selected_sections
+        if key in JSON_CATEGORY_EXCEL_CATEGORY_MAPPING
+    ]
+
+
 class DataProcessor:
     # transform input data to required format
     FIELD_TRANSFORMATIONS: ClassVar[dict] = {}
@@ -132,7 +159,7 @@ class GovExcel(DataProcessor):
         "V2.1": get_data_file_path("gstr1_excel_template_v2.1.xlsx"),
     }
 
-    def generate(self, gstin, period):
+    def generate(self, gstin, period, section=None):
         """
         Build excel file
         """
@@ -143,13 +170,26 @@ class GovExcel(DataProcessor):
         month, year = gstr_1_log.return_period[:2], gstr_1_log.return_period[2:]
         filing_from = getdate(f"{year}-{month}-01")
 
-        file_version = "V2.1" if filing_from >= HSN_BIFURCATION_FROM else "V2.0"
+        is_hsn_bifurcated = filing_from >= HSN_BIFURCATION_FROM
+        file_version = "V2.1" if is_hsn_bifurcated else "V2.0"
         file = self.TEMPLATE_EXCEL_FILE.get(file_version)
 
         self.file_field = "filed" if gstr_1_log.filed else "books"
         data = gstr_1_log.load_data(self.file_field)[self.file_field]
         data = self.process_data(data)
-        self.build_excel(data, file)
+
+        sheet_names = None
+        if section:
+            selected_sections = _get_selected_sections(section, is_hsn_bifurcated)
+            data = _filter_data_by_sections(data, selected_sections)
+            sheet_names = _get_excel_sheet_names(selected_sections)
+
+        self.build_excel(
+            data,
+            file,
+            filename=_get_gov_filename(gstin, period, section),
+            sheet_names=sheet_names,
+        )
 
     def process_data(self, data):
         data.update(data.pop("aggregate_data", {}))
@@ -182,11 +222,14 @@ class GovExcel(DataProcessor):
 
         return category_wise_data
 
-    def build_excel(self, data, file=None):
+    def build_excel(self, data, file=None, filename=None, sheet_names=None):
         excel = ExcelExporter(file)
 
         if excel.has_sheet("Sheet"):
             excel.remove_sheet("Sheet")
+
+        if sheet_names and excel.is_loaded:
+            self._filter_selected_section_sheets(excel, sheet_names)
 
         for category, cat_data in data.items():
             sheet_name = JSON_CATEGORY_EXCEL_CATEGORY_MAPPING.get(category)
@@ -208,7 +251,14 @@ class GovExcel(DataProcessor):
                     default_data_format={"height": 15},
                 )
 
-        excel.export(get_file_name("Gov", self.gstin, self.period))
+        excel.export(filename or get_file_name("Gov", self.gstin, self.period))
+
+    def _filter_selected_section_sheets(self, excel, sheet_names):
+        """Remove every template sheet not in `sheet_names`. Master is always kept."""
+        kept = {GovExcelSheetName.MASTER.value, *sheet_names}
+        for sheet_name in list(excel.wb.sheetnames):
+            if sheet_name not in kept:
+                excel.remove_sheet(sheet_name)
 
     def process_doc_issue_data(self, data):
         """
@@ -2116,10 +2166,38 @@ class ReconcileExcel:
         ]
 
 
+def _filter_data_by_sections(data: dict, section: list[str] | None) -> dict:
+    """Keep only entries whose keys belong to `section`.
+
+    Accepts list of expanded keys
+    (Excel path, e.g. ``["hsn_b2b", "hsn_b2c"]`` for HSN on bifurcated periods).
+    """
+    if not section:
+        return data
+
+    return {k: v for k, v in data.items() if k in section}
+
+
+VALID_SECTIONS = frozenset(key.value for key in GovJsonKey)
+
+
+def _validate_section(section: str | None) -> None:
+    if section and section not in VALID_SECTIONS:
+        frappe.throw(frappe._("Invalid section: {0}").format(section))
+
+
+def _get_gov_filename(company_gstin: str, period: str, section: str | None = None) -> str:
+    name = f"GSTR-1-Gov-{company_gstin}-{period}"
+    if section:
+        name = f"{name}-{section}"
+    return name
+
+
 @frappe.whitelist()
-def download_filed_as_excel(company_gstin: str, month_or_quarter: str, year: str):
+def download_filed_as_excel(company_gstin: str, month_or_quarter: str, year: str, section: str | None = None):
     frappe.has_permission("GSTR-1", "export", throw=True)
-    GovExcel().generate(company_gstin, get_period(month_or_quarter, year))
+    _validate_section(section)
+    GovExcel().generate(company_gstin, get_period(month_or_quarter, year), section=section)
 
 
 @frappe.whitelist()
@@ -2145,8 +2223,15 @@ def get_gstr_1_json(
     month_or_quarter: str,
     include_uploaded: bool = False,
     delete_missing: bool = False,
+    section: str | None = None,
 ):
     frappe.has_permission("GSTR-1", "export", throw=True)
+    _validate_section(section)
+
+    settings = frappe.get_cached_doc("GST Settings")
+    if not settings.is_gstr1_api_enabled(company_gstin):
+        include_uploaded = True
+        delete_missing = False
 
     period = get_period(month_or_quarter, year)
     gstr1_log = frappe.get_doc("GST Return Log", f"GSTR1-{period}-{company_gstin}")
@@ -2205,14 +2290,18 @@ def get_gstr_1_json(
             subcategory_data.pop(key)
 
     gstr1_log.normalize_data(data)
+    gov_data = convert_to_gov_data_format(data, company_gstin)
+
+    if section:
+        gov_data = _filter_data_by_sections(gov_data, [section])
 
     return {
         "data": {
             "gstin": company_gstin,
             "fp": period,
-            **convert_to_gov_data_format(data, company_gstin),
+            **gov_data,
         },
-        "filename": f"GSTR-1-Gov-{company_gstin}-{period}.json",
+        "filename": f"{_get_gov_filename(company_gstin, period, section)}.json",
     }
 
 

--- a/india_compliance/gst_india/doctype/gstr_1/gstr_1_export.py
+++ b/india_compliance/gst_india/doctype/gstr_1/gstr_1_export.py
@@ -2166,24 +2166,16 @@ class ReconcileExcel:
         ]
 
 
-def _filter_data_by_sections(data: dict, section: list[str] | None) -> dict:
-    """Keep only entries whose keys belong to `section`.
+def _filter_data_by_sections(data: dict, sections: list[str] | None) -> dict:
+    """Keep only entries whose keys belong to `sections`.
 
     Accepts list of expanded keys
     (Excel path, e.g. ``["hsn_b2b", "hsn_b2c"]`` for HSN on bifurcated periods).
     """
-    if not section:
+    if not sections:
         return data
 
-    return {k: v for k, v in data.items() if k in section}
-
-
-VALID_SECTIONS = frozenset(key.value for key in GovJsonKey)
-
-
-def _validate_section(section: str | None) -> None:
-    if section and section not in VALID_SECTIONS:
-        frappe.throw(frappe._("Invalid section: {0}").format(section))
+    return {k: v for k, v in data.items() if k in sections}
 
 
 def _get_gov_filename(company_gstin: str, period: str, section: str | None = None) -> str:
@@ -2196,7 +2188,6 @@ def _get_gov_filename(company_gstin: str, period: str, section: str | None = Non
 @frappe.whitelist()
 def download_filed_as_excel(company_gstin: str, month_or_quarter: str, year: str, section: str | None = None):
     frappe.has_permission("GSTR-1", "export", throw=True)
-    _validate_section(section)
     GovExcel().generate(company_gstin, get_period(month_or_quarter, year), section=section)
 
 
@@ -2226,8 +2217,6 @@ def get_gstr_1_json(
     section: str | None = None,
 ):
     frappe.has_permission("GSTR-1", "export", throw=True)
-    _validate_section(section)
-
     settings = frappe.get_cached_doc("GST Settings")
     if not settings.is_gstr1_api_enabled(company_gstin):
         include_uploaded = True

--- a/india_compliance/gst_india/doctype/gstr_1/gstr_1_export.py
+++ b/india_compliance/gst_india/doctype/gstr_1/gstr_1_export.py
@@ -2190,7 +2190,9 @@ def _get_gov_filename(company_gstin: str, period: str, sections: list[str] | Non
 
 
 @frappe.whitelist()
-def download_filed_as_excel(company_gstin: str, month_or_quarter: str, year: str, sections=None):
+def download_filed_as_excel(
+    company_gstin: str, month_or_quarter: str, year: str, sections: str | None = None
+):
     frappe.has_permission("GSTR-1", "export", throw=True)
     if isinstance(sections, str):
         sections = frappe.parse_json(sections) if sections else None
@@ -2220,7 +2222,7 @@ def get_gstr_1_json(
     month_or_quarter: str,
     include_uploaded: bool = False,
     delete_missing: bool = False,
-    sections=None,
+    sections: str | list[str] | None = None,
 ):
     frappe.has_permission("GSTR-1", "export", throw=True)
     if isinstance(sections, str):

--- a/india_compliance/gst_india/doctype/gstr_1/gstr_1_export.py
+++ b/india_compliance/gst_india/doctype/gstr_1/gstr_1_export.py
@@ -30,6 +30,9 @@ from india_compliance.gst_india.utils.gstr_1.gstr_1_json_map import (
     get_category_wise_data,
 )
 
+# Used for storing user preferences for GSTR-1 download sections.
+GSTR1_SECTIONS_DEFAULT_KEY = "gstr1_download_sections"
+
 
 class ExcelWidth(Enum):
     XS = 10
@@ -49,13 +52,6 @@ CATEGORIES_WITH_ITEMS = {
 }
 
 
-def _get_hsn_sections(is_bifurcated: bool) -> list[str]:
-    if is_bifurcated:
-        return [HSNKey.HSN_B2B.value, HSNKey.HSN_B2C.value]
-
-    return [HSNKey.HSN.value]
-
-
 def _get_selected_sections(section: str, is_hsn_bifurcated: bool) -> list[str]:
     """
     HSN can be split into `hsn_b2b` / `hsn_b2c`. Every other
@@ -64,7 +60,10 @@ def _get_selected_sections(section: str, is_hsn_bifurcated: bool) -> list[str]:
     if section != GovJsonKey.HSN.value:
         return [section]
 
-    return _get_hsn_sections(is_hsn_bifurcated)
+    if is_hsn_bifurcated:
+        return [HSNKey.HSN_B2B.value, HSNKey.HSN_B2C.value]
+
+    return [HSNKey.HSN.value]
 
 
 def _get_excel_sheet_names(selected_sections: list[str]) -> list[str]:
@@ -2185,6 +2184,15 @@ def _get_gov_filename(company_gstin: str, period: str, sections: list[str] | Non
     if len(sections) == 1:
         return f"{name}-{sections[0]}"
     return f"{name}-multi-section"
+
+
+@frappe.whitelist()
+def set_section_preference(sections: str | list[str] | None = None):
+    """Persist the user's GSTR-1 download section selection as a user default."""
+    frappe.has_permission("GSTR-1", "export", throw=True)
+    if isinstance(sections, str):
+        sections = frappe.parse_json(sections)
+    frappe.defaults.set_user_default(GSTR1_SECTIONS_DEFAULT_KEY, frappe.as_json(sections or []))
 
 
 @frappe.whitelist()

--- a/india_compliance/gst_india/doctype/gstr_1/gstr_1_export.py
+++ b/india_compliance/gst_india/doctype/gstr_1/gstr_1_export.py
@@ -68,7 +68,7 @@ def _get_selected_sections(section: str, is_hsn_bifurcated: bool) -> list[str]:
 
 
 def _get_excel_sheet_names(selected_sections: list[str]) -> list[str]:
-    """Template sheet names that belong to `section` (excluding the `master` reference sheet)."""
+    """Template sheet names that belong to `selected_sections` (excluding the `master` reference sheet)."""
     return [
         JSON_CATEGORY_EXCEL_CATEGORY_MAPPING[key]
         for key in selected_sections
@@ -2169,10 +2169,8 @@ class ReconcileExcel:
 
 
 def _filter_data_by_sections(data: dict, sections: list[str] | None) -> dict:
-    """Keep only entries whose keys belong to `sections`.
-
-    Accepts list of expanded keys
-    (Excel path, e.g. ``["hsn_b2b", "hsn_b2c"]`` for HSN on bifurcated periods).
+    """
+    Keep only entries whose keys belong to `sections`.
     """
     if not sections:
         return data
@@ -2191,7 +2189,7 @@ def _get_gov_filename(company_gstin: str, period: str, sections: list[str] | Non
 
 @frappe.whitelist()
 def download_filed_as_excel(
-    company_gstin: str, month_or_quarter: str, year: str, sections: str | None = None
+    company_gstin: str, month_or_quarter: str, year: str, sections: str | list[str] | None = None
 ):
     frappe.has_permission("GSTR-1", "export", throw=True)
     if isinstance(sections, str):

--- a/india_compliance/gst_india/doctype/gstr_1/test_gstr_1.py
+++ b/india_compliance/gst_india/doctype/gstr_1/test_gstr_1.py
@@ -96,11 +96,11 @@ class TestGSTR1Export(IntegrationTestCase):
             [GovExcelSheetName.HSN_B2B.value, GovExcelSheetName.HSN_B2C.value],
         )
 
-    # def test_supeco_resolves_to_eco_sheet(self):
-    #     self.assertEqual(
-    #         _get_excel_sheet_names(_get_selected_sections(GovJsonKey.SUPECOM.value, is_hsn_bifurcated=False)),
-    #         [GovExcelSheetName.ECO.value],
-    #     )
+    def test_supeco_resolves_to_eco_sheet(self):
+        self.assertEqual(
+            _get_excel_sheet_names(_get_selected_sections(GovJsonKey.SUPECOM.value, is_hsn_bifurcated=False)),
+            [GovExcelSheetName.SUPECOM.value],
+        )
 
     def test_unknown_section_returns_empty_list(self):
         self.assertEqual(
@@ -147,7 +147,7 @@ class TestGSTR1Export(IntegrationTestCase):
 
     def test_v21_supeco_keeps_eco_sheet(self):
         result = self._filter_sheets("V2.1", "supeco")
-        self.assertEqual(result, {GovExcelSheetName.MASTER.value, GovExcelSheetName.ECO.value})
+        self.assertEqual(result, {GovExcelSheetName.MASTER.value, GovExcelSheetName.SUPECOM.value})
 
     def test_every_section_on_both_templates_keeps_master(self):
         for template_version in ("V2.0", "V2.1"):

--- a/india_compliance/gst_india/doctype/gstr_1/test_gstr_1.py
+++ b/india_compliance/gst_india/doctype/gstr_1/test_gstr_1.py
@@ -107,21 +107,34 @@ class TestGSTR1Export(IntegrationTestCase):
             _get_excel_sheet_names(_get_selected_sections("nonexistent", is_hsn_bifurcated=False)), []
         )
 
-    def test_includes_section_name_when_section_given(self):
-        filename = _get_gov_filename(self.GSTIN, self.PERIOD, "b2b")
-        self.assertEqual(filename, f"GSTR-1-Gov-{self.GSTIN}-{self.PERIOD}-b2b")
+    def test_filename_no_sections(self):
+        self.assertEqual(_get_gov_filename(self.GSTIN, self.PERIOD), f"GSTR-1-Gov-{self.GSTIN}-{self.PERIOD}")
 
-    def test_default_filename_when_no_section(self):
-        filename = _get_gov_filename(self.GSTIN, self.PERIOD, None)
-        self.assertEqual(filename, f"GSTR-1-Gov-{self.GSTIN}-{self.PERIOD}")
+    def test_filename_no_sections_explicit_none(self):
+        self.assertEqual(
+            _get_gov_filename(self.GSTIN, self.PERIOD, None), f"GSTR-1-Gov-{self.GSTIN}-{self.PERIOD}"
+        )
 
-    def test_default_filename_when_section_omitted(self):
-        filename = _get_gov_filename(self.GSTIN, self.PERIOD)
-        self.assertEqual(filename, f"GSTR-1-Gov-{self.GSTIN}-{self.PERIOD}")
+    def test_filename_single_section(self):
+        self.assertEqual(
+            _get_gov_filename(self.GSTIN, self.PERIOD, ["b2b"]), f"GSTR-1-Gov-{self.GSTIN}-{self.PERIOD}-b2b"
+        )
 
-    def _filter_sheets(self, template_version, section):
+    def test_filename_multiple_sections(self):
+        self.assertEqual(
+            _get_gov_filename(self.GSTIN, self.PERIOD, ["b2b", "cdnr"]),
+            f"GSTR-1-Gov-{self.GSTIN}-{self.PERIOD}-multi-section",
+        )
+
+    def _filter_sheets(self, template_version, sections):
+        """Helper: load template, apply section filtering, return remaining sheet names."""
         is_hsn_bifurcated = template_version == "V2.1"
-        sheet_names = _get_excel_sheet_names(_get_selected_sections(section, is_hsn_bifurcated))
+        if isinstance(sections, str):
+            sections = [sections]
+        selected = []
+        for section in sections:
+            selected.extend(_get_selected_sections(section, is_hsn_bifurcated))
+        sheet_names = _get_excel_sheet_names(selected)
         excel = ExcelExporter(GovExcel.TEMPLATE_EXCEL_FILE[template_version])
         GovExcel()._filter_selected_section_sheets(excel, sheet_names)
         return set(excel.wb.sheetnames)
@@ -148,6 +161,25 @@ class TestGSTR1Export(IntegrationTestCase):
     def test_v21_supeco_keeps_eco_sheet(self):
         result = self._filter_sheets("V2.1", "supeco")
         self.assertEqual(result, {GovExcelSheetName.MASTER.value, GovExcelSheetName.SUPECOM.value})
+
+    def test_multi_section_keeps_all_selected_sheets(self):
+        result = self._filter_sheets("V2.1", ["b2b", "cdnr"])
+        self.assertEqual(
+            result,
+            {GovExcelSheetName.MASTER.value, GovExcelSheetName.B2B.value, GovExcelSheetName.CDNR.value},
+        )
+
+    def test_multi_section_with_hsn_bifurcation(self):
+        result = self._filter_sheets("V2.1", ["b2b", "hsn"])
+        self.assertEqual(
+            result,
+            {
+                GovExcelSheetName.MASTER.value,
+                GovExcelSheetName.B2B.value,
+                GovExcelSheetName.HSN_B2B.value,
+                GovExcelSheetName.HSN_B2C.value,
+            },
+        )
 
     def test_every_section_on_both_templates_keeps_master(self):
         for template_version in ("V2.0", "V2.1"):

--- a/india_compliance/gst_india/doctype/gstr_1/test_gstr_1.py
+++ b/india_compliance/gst_india/doctype/gstr_1/test_gstr_1.py
@@ -1,9 +1,156 @@
 # Copyright (c) 2024, Resilient Tech and Contributors
 # See license.txt
 
-# import frappe
 from frappe.tests import IntegrationTestCase
+
+from india_compliance.gst_india.doctype.gstr_1.gstr_1_export import (
+    GovExcel,
+    _filter_data_by_sections,
+    _get_excel_sheet_names,
+    _get_gov_filename,
+    _get_selected_sections,
+)
+from india_compliance.gst_india.utils.exporter import ExcelExporter
+from india_compliance.gst_india.utils.gstr_1 import (
+    JSON_CATEGORY_EXCEL_CATEGORY_MAPPING,
+    GovExcelSheetName,
+    GovJsonKey,
+)
+
+# Every GovJsonKey value that maps to a sheet in JSON_CATEGORY_EXCEL_CATEGORY_MAPPING.
+# sec_sum is excluded (no sheet mapping). Used for exhaustive template checks.
+GOV_EXCEL_SECTIONS = frozenset(
+    key.value for key in GovJsonKey if key.value in JSON_CATEGORY_EXCEL_CATEGORY_MAPPING
+)
 
 
 class TestGSTR1(IntegrationTestCase):
     pass
+
+
+class TestGSTR1Export(IntegrationTestCase):
+    GSTIN = "29AABCU9603R1ZM"
+    PERIOD = "032024"
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.gov_data = {
+            "b2b": [{"invoice": "INV-001"}],
+            "cdnr": [{"note": "CN-001"}],
+            "b2cs": [{"supply": "S-001"}],
+        }
+
+    def test_returns_all_sections_when_section_is_none(self):
+        result = _filter_data_by_sections(self.gov_data, None)
+        self.assertEqual(result, self.gov_data)
+
+    def test_returns_matching_section(self):
+        result = _filter_data_by_sections(self.gov_data, ["b2b"])
+        self.assertEqual(result, {"b2b": [{"invoice": "INV-001"}]})
+
+    def test_returns_multiple_matching_sections(self):
+        result = _filter_data_by_sections(self.gov_data, ["b2b", "cdnr"])
+        self.assertIn("b2b", result)
+        self.assertIn("cdnr", result)
+
+    def test_returns_empty_for_unknown_section(self):
+        result = _filter_data_by_sections(self.gov_data, ["nonexistent"])
+        self.assertEqual(result, {})
+
+    def test_non_hsn_section_returns_single_key(self):
+        self.assertEqual(_get_selected_sections("b2b", is_hsn_bifurcated=False), ["b2b"])
+
+    def test_hsn_pre_bifurcation_returns_single_hsn_key(self):
+        self.assertEqual(_get_selected_sections(GovJsonKey.HSN.value, is_hsn_bifurcated=False), ["hsn"])
+
+    def test_hsn_post_bifurcation_returns_split_keys(self):
+        self.assertEqual(
+            _get_selected_sections(GovJsonKey.HSN.value, is_hsn_bifurcated=True),
+            ["hsn_b2b", "hsn_b2c"],
+        )
+
+    def test_unknown_section_is_returned_as_is(self):
+        self.assertEqual(_get_selected_sections("nonexistent", is_hsn_bifurcated=False), ["nonexistent"])
+
+    def test_non_hsn_section_returns_single_sheet(self):
+        self.assertEqual(
+            _get_excel_sheet_names(_get_selected_sections("b2b", is_hsn_bifurcated=False)),
+            [GovExcelSheetName.B2B.value],
+        )
+
+    def test_hsn_pre_bifurcation_returns_single_sheet(self):
+        self.assertEqual(
+            _get_excel_sheet_names(_get_selected_sections(GovJsonKey.HSN.value, is_hsn_bifurcated=False)),
+            [GovExcelSheetName.HSN.value],
+        )
+
+    def test_hsn_post_bifurcation_returns_both_split_sheets(self):
+        self.assertEqual(
+            _get_excel_sheet_names(_get_selected_sections(GovJsonKey.HSN.value, is_hsn_bifurcated=True)),
+            [GovExcelSheetName.HSN_B2B.value, GovExcelSheetName.HSN_B2C.value],
+        )
+
+    def test_supeco_resolves_to_eco_sheet(self):
+        self.assertEqual(
+            _get_excel_sheet_names(_get_selected_sections(GovJsonKey.SUPECOM.value, is_hsn_bifurcated=False)),
+            [GovExcelSheetName.ECO.value],
+        )
+
+    def test_unknown_section_returns_empty_list(self):
+        self.assertEqual(
+            _get_excel_sheet_names(_get_selected_sections("nonexistent", is_hsn_bifurcated=False)), []
+        )
+
+    def test_includes_section_name_when_section_given(self):
+        filename = _get_gov_filename(self.GSTIN, self.PERIOD, "b2b")
+        self.assertEqual(filename, f"GSTR-1-Gov-{self.GSTIN}-{self.PERIOD}-b2b")
+
+    def test_default_filename_when_no_section(self):
+        filename = _get_gov_filename(self.GSTIN, self.PERIOD, None)
+        self.assertEqual(filename, f"GSTR-1-Gov-{self.GSTIN}-{self.PERIOD}")
+
+    def test_default_filename_when_section_omitted(self):
+        filename = _get_gov_filename(self.GSTIN, self.PERIOD)
+        self.assertEqual(filename, f"GSTR-1-Gov-{self.GSTIN}-{self.PERIOD}")
+
+    def _filter_sheets(self, template_version, section):
+        is_hsn_bifurcated = template_version == "V2.1"
+        sheet_names = _get_excel_sheet_names(_get_selected_sections(section, is_hsn_bifurcated))
+        excel = ExcelExporter(GovExcel.TEMPLATE_EXCEL_FILE[template_version])
+        GovExcel()._filter_selected_section_sheets(excel, sheet_names)
+        return set(excel.wb.sheetnames)
+
+    def test_v20_b2b_keeps_only_b2b_and_master(self):
+        result = self._filter_sheets("V2.0", "b2b")
+        self.assertEqual(result, {GovExcelSheetName.MASTER.value, GovExcelSheetName.B2B.value})
+
+    def test_v20_hsn_keeps_single_hsn_sheet(self):
+        result = self._filter_sheets("V2.0", "hsn")
+        self.assertEqual(result, {GovExcelSheetName.MASTER.value, GovExcelSheetName.HSN.value})
+
+    def test_v21_hsn_keeps_both_bifurcated_sheets(self):
+        result = self._filter_sheets("V2.1", "hsn")
+        self.assertEqual(
+            result,
+            {
+                GovExcelSheetName.MASTER.value,
+                GovExcelSheetName.HSN_B2B.value,
+                GovExcelSheetName.HSN_B2C.value,
+            },
+        )
+
+    def test_v21_supeco_keeps_eco_sheet(self):
+        result = self._filter_sheets("V2.1", "supeco")
+        self.assertEqual(result, {GovExcelSheetName.MASTER.value, GovExcelSheetName.ECO.value})
+
+    def test_every_section_on_both_templates_keeps_master(self):
+        for template_version in ("V2.0", "V2.1"):
+            for section in GOV_EXCEL_SECTIONS:
+                with self.subTest(template=template_version, section=section):
+                    result = self._filter_sheets(template_version, section)
+                    self.assertIn(
+                        GovExcelSheetName.MASTER.value,
+                        result,
+                    )
+                    self.assertGreater(len(result), 1)

--- a/india_compliance/gst_india/doctype/gstr_1/test_gstr_1.py
+++ b/india_compliance/gst_india/doctype/gstr_1/test_gstr_1.py
@@ -191,3 +191,13 @@ class TestGSTR1Export(IntegrationTestCase):
                         result,
                     )
                     self.assertGreater(len(result), 1)
+
+    def test_every_offered_section_can_render_headers(self):
+        gov = GovExcel()
+        for section in GOV_EXCEL_SECTIONS:
+            # Expand to the actual data keys build_excel iterates (HSN → b2b/b2c).
+            for is_bifurcated in (False, True):
+                for key in _get_selected_sections(section, is_hsn_bifurcated=is_bifurcated):
+                    with self.subTest(section=section, key=key, bifurcated=is_bifurcated):
+                        headers = gov.get_category_headers(key)
+                        self.assertTrue(headers)

--- a/india_compliance/gst_india/doctype/gstr_1/test_gstr_1.py
+++ b/india_compliance/gst_india/doctype/gstr_1/test_gstr_1.py
@@ -51,8 +51,13 @@ class TestGSTR1Export(IntegrationTestCase):
 
     def test_returns_multiple_matching_sections(self):
         result = _filter_data_by_sections(self.gov_data, ["b2b", "cdnr"])
-        self.assertIn("b2b", result)
-        self.assertIn("cdnr", result)
+        self.assertEqual(
+            result,
+            {
+                "b2b": [{"invoice": "INV-001"}],
+                "cdnr": [{"note": "CN-001"}],
+            },
+        )
 
     def test_returns_empty_for_unknown_section(self):
         result = _filter_data_by_sections(self.gov_data, ["nonexistent"])

--- a/india_compliance/gst_india/doctype/gstr_1/test_gstr_1.py
+++ b/india_compliance/gst_india/doctype/gstr_1/test_gstr_1.py
@@ -96,11 +96,11 @@ class TestGSTR1Export(IntegrationTestCase):
             [GovExcelSheetName.HSN_B2B.value, GovExcelSheetName.HSN_B2C.value],
         )
 
-    def test_supeco_resolves_to_eco_sheet(self):
-        self.assertEqual(
-            _get_excel_sheet_names(_get_selected_sections(GovJsonKey.SUPECOM.value, is_hsn_bifurcated=False)),
-            [GovExcelSheetName.ECO.value],
-        )
+    # def test_supeco_resolves_to_eco_sheet(self):
+    #     self.assertEqual(
+    #         _get_excel_sheet_names(_get_selected_sections(GovJsonKey.SUPECOM.value, is_hsn_bifurcated=False)),
+    #         [GovExcelSheetName.ECO.value],
+    #     )
 
     def test_unknown_section_returns_empty_list(self):
         self.assertEqual(

--- a/india_compliance/gst_india/utils/gstr_1/__init__.py
+++ b/india_compliance/gst_india/utils/gstr_1/__init__.py
@@ -309,7 +309,6 @@ class GovExcelSheetName(Enum):
     HSN_B2B = "hsn(b2b)"
     HSN_B2C = "hsn(b2c)"
     DOC_ISSUE = "docs"
-    ECO = "eco"
     MASTER = "master"
 
 
@@ -348,7 +347,6 @@ JSON_CATEGORY_EXCEL_CATEGORY_MAPPING = {
     GovJsonKey.TXP.value: GovExcelSheetName.TXP.value,
     GovJsonKey.HSN.value: GovExcelSheetName.HSN.value,
     GovJsonKey.DOC_ISSUE.value: GovExcelSheetName.DOC_ISSUE.value,
-    GovJsonKey.SUPECOM.value: GovExcelSheetName.ECO.value,
     # only for excel
     HSNKey.HSN_B2B.value: GovExcelSheetName.HSN_B2B.value,
     HSNKey.HSN_B2C.value: GovExcelSheetName.HSN_B2C.value,

--- a/india_compliance/gst_india/utils/gstr_1/__init__.py
+++ b/india_compliance/gst_india/utils/gstr_1/__init__.py
@@ -309,7 +309,8 @@ class GovExcelSheetName(Enum):
     HSN_B2B = "hsn(b2b)"
     HSN_B2C = "hsn(b2c)"
     DOC_ISSUE = "docs"
-    SUPECOM = "eco"
+    ECO = "eco"
+    MASTER = "master"
 
 
 SUB_CATEGORY_GOV_CATEGORY_MAPPING = {
@@ -347,7 +348,7 @@ JSON_CATEGORY_EXCEL_CATEGORY_MAPPING = {
     GovJsonKey.TXP.value: GovExcelSheetName.TXP.value,
     GovJsonKey.HSN.value: GovExcelSheetName.HSN.value,
     GovJsonKey.DOC_ISSUE.value: GovExcelSheetName.DOC_ISSUE.value,
-    GovJsonKey.SUPECOM.value: GovExcelSheetName.SUPECOM.value,
+    GovJsonKey.SUPECOM.value: GovExcelSheetName.ECO.value,
     # only for excel
     HSNKey.HSN_B2B.value: GovExcelSheetName.HSN_B2B.value,
     HSNKey.HSN_B2C.value: GovExcelSheetName.HSN_B2C.value,

--- a/india_compliance/gst_india/utils/gstr_1/__init__.py
+++ b/india_compliance/gst_india/utils/gstr_1/__init__.py
@@ -309,6 +309,7 @@ class GovExcelSheetName(Enum):
     HSN_B2B = "hsn(b2b)"
     HSN_B2C = "hsn(b2c)"
     DOC_ISSUE = "docs"
+    SUPECOM = "eco"
     MASTER = "master"
 
 
@@ -347,6 +348,7 @@ JSON_CATEGORY_EXCEL_CATEGORY_MAPPING = {
     GovJsonKey.TXP.value: GovExcelSheetName.TXP.value,
     GovJsonKey.HSN.value: GovExcelSheetName.HSN.value,
     GovJsonKey.DOC_ISSUE.value: GovExcelSheetName.DOC_ISSUE.value,
+    GovJsonKey.SUPECOM.value: GovExcelSheetName.SUPECOM.value,
     # only for excel
     HSNKey.HSN_B2B.value: GovExcelSheetName.HSN_B2B.value,
     HSNKey.HSN_B2C.value: GovExcelSheetName.HSN_B2C.value,


### PR DESCRIPTION
Allow users to download selected section in GSTR1 JSON and Excel Exports.\

- Storing selected values in user defaults for pre-fetching again.

<img width="776" height="424" alt="image" src="https://github.com/user-attachments/assets/6c44398d-6896-4033-a4d2-13f14599f612" />

<img width="768" height="554" alt="image" src="https://github.com/user-attachments/assets/866454e0-892f-412e-8c76-df8e2f660247" />

<img width="598" height="137" alt="image" src="https://github.com/user-attachments/assets/f999c69d-e14d-4581-b411-6c2de50488c7" />

<img width="792" height="419" alt="image" src="https://github.com/user-attachments/assets/8cbcb424-8ad0-4a23-bf33-0866904aa51a" />



The e-commerce section is fixed in a separate PR.
https://github.com/resilient-tech/india-compliance/pull/4339

no-docs
