### PR TITLE
feat: add close e-Waybill functionality and update related UI and tests

### DIFF
--- a/india_compliance/gst_india/api_classes/nic/e_waybill.py
+++ b/india_compliance/gst_india/api_classes/nic/e_waybill.py
@@ -119,6 +119,9 @@ class EWaybillAPI(BaseAPI):
     def extend_validity(self, data):
         return self.post("EXTENDVALIDITY", json=data)
 
+    def close_e_waybill(self, data):
+        return self.post("CLSEWB", json=data)
+
     def update_distance(self, result):
         if (
             (alert := result.get("alert"))

--- a/india_compliance/gst_india/client_scripts/e_waybill_actions.js
+++ b/india_compliance/gst_india/client_scripts/e_waybill_actions.js
@@ -114,11 +114,13 @@ function setup_e_waybill_actions(doctype) {
                     "e-Waybill",
                 );
 
-                frm.add_custom_button(
-                    __("Close e-Waybill"),
-                    () => show_close_e_waybill_dialog(frm),
-                    "e-Waybill",
-                );
+                if (is_e_waybill_closure_enabled()) {
+                    frm.add_custom_button(
+                        __("Close e-Waybill"),
+                        () => show_close_e_waybill_dialog(frm),
+                        "e-Waybill",
+                    );
+                }
             }
 
             if (
@@ -733,6 +735,14 @@ function show_close_e_waybill_dialog(frm) {
         ],
         primary_action_label: __("Close"),
         primary_action(values) {
+            // NIC rejects a closure date earlier than the e-Waybill date;
+            // pre-empt that round-trip with a clear message.
+            const ewb_date = (frm.doc.__onload?.e_waybill_info?.created_on || "").split(" ")[0];
+            if (ewb_date && values.closure_date < ewb_date) {
+                frappe.msgprint(__("Closure Date cannot be earlier than the e-Waybill date."));
+                return;
+            }
+
             frappe.call({
                 method: "india_compliance.gst_india.utils.e_waybill.close_e_waybill",
                 args: {
@@ -1223,6 +1233,11 @@ function is_e_waybill_valid(frm) {
         (!e_waybill_info.valid_upto ||
             frappe.datetime.convert_to_user_tz(e_waybill_info.valid_upto, false).diff() > 0)
     );
+}
+
+function is_e_waybill_closure_enabled() {
+    // Closure (CLSEWB) API is live in sandbox now; in production from 2026-06-15.
+    return gst_settings.sandbox_mode || frappe.datetime.get_today() >= "2026-06-15";
 }
 
 async function has_e_waybill_threshold_met(frm) {

--- a/india_compliance/gst_india/client_scripts/e_waybill_actions.js
+++ b/india_compliance/gst_india/client_scripts/e_waybill_actions.js
@@ -719,7 +719,6 @@ function show_close_e_waybill_dialog(frm) {
                 default: frm.doc.ewaybill,
             },
             {
-                // closure date is set to today by the backend; only remarks are collected
                 label: "Remarks",
                 fieldname: "remarks",
                 fieldtype: "Data",
@@ -1286,7 +1285,6 @@ function can_extend_e_waybill_now(valid_upto) {
 function has_extend_validity_expired(frm) {
     const e_waybill_info = frm.doc.__onload?.e_waybill_info;
 
-    // a closed e-Waybill can no longer be extended
     if (e_waybill_info?.is_closed) return true;
 
     const valid_upto = e_waybill_info?.valid_upto;

--- a/india_compliance/gst_india/client_scripts/e_waybill_actions.js
+++ b/india_compliance/gst_india/client_scripts/e_waybill_actions.js
@@ -114,7 +114,7 @@ function setup_e_waybill_actions(doctype) {
                     "e-Waybill",
                 );
 
-                if (is_e_waybill_closure_enabled()) {
+                if (is_e_waybill_changes_applicable()) {
                     frm.add_custom_button(
                         __("Close e-Waybill"),
                         () => show_close_e_waybill_dialog(frm),
@@ -719,23 +719,15 @@ function show_close_e_waybill_dialog(frm) {
                 default: frm.doc.ewaybill,
             },
             {
+                // closure date is set to today by the backend; only remarks are collected
                 label: "Remarks",
                 fieldname: "remarks",
                 fieldtype: "Data",
                 reqd: 1,
-                length: 50,
             },
         ],
         primary_action_label: __("Close"),
         primary_action(values) {
-            // NIC rejects a closure date earlier than the e-Waybill date;
-            // pre-empt that round-trip with a clear message.
-            const ewb_date = (frm.doc.__onload?.e_waybill_info?.created_on || "").split(" ")[0];
-            if (ewb_date && values.closure_date < ewb_date) {
-                frappe.msgprint(__("Closure Date cannot be earlier than the e-Waybill date."));
-                return;
-            }
-
             frappe.call({
                 method: "india_compliance.gst_india.utils.e_waybill.close_e_waybill",
                 args: {
@@ -1228,8 +1220,8 @@ function is_e_waybill_valid(frm) {
     );
 }
 
-function is_e_waybill_closure_enabled() {
-    // Closure (CLSEWB) API is live in sandbox now; in production from 2026-06-15.
+function is_e_waybill_changes_applicable() {
+    // e-Waybill changes are live in sandbox now; in production from 2026-06-15.
     return gst_settings.sandbox_mode || frappe.datetime.get_today() >= "2026-06-15";
 }
 

--- a/india_compliance/gst_india/client_scripts/e_waybill_actions.js
+++ b/india_compliance/gst_india/client_scripts/e_waybill_actions.js
@@ -1221,8 +1221,8 @@ function is_e_waybill_valid(frm) {
 }
 
 function is_e_waybill_changes_applicable() {
-    // e-Waybill changes are live in sandbox now; in production from 2026-06-15.
-    return gst_settings.sandbox_mode || frappe.datetime.get_today() >= "2026-06-15";
+    // keep in sync with E_WAYBILL_CHANGES_APPLICABLE_DATE (constants/e_waybill.py)
+    return gst_settings.sandbox_mode || frappe.datetime.get_today() >= "2026-08-01";
 }
 
 async function has_e_waybill_threshold_met(frm) {

--- a/india_compliance/gst_india/client_scripts/e_waybill_actions.js
+++ b/india_compliance/gst_india/client_scripts/e_waybill_actions.js
@@ -113,6 +113,12 @@ function setup_e_waybill_actions(doctype) {
                     () => show_update_transporter_dialog(frm),
                     "e-Waybill",
                 );
+
+                frm.add_custom_button(
+                    __("Close e-Waybill"),
+                    () => show_close_e_waybill_dialog(frm),
+                    "e-Waybill",
+                );
             }
 
             if (
@@ -699,6 +705,52 @@ function show_cancel_e_waybill_dialog(frm, callback) {
     d.show();
 }
 
+function show_close_e_waybill_dialog(frm) {
+    const d = new frappe.ui.Dialog({
+        title: __("Close e-Waybill"),
+        fields: [
+            {
+                label: "e-Waybill",
+                fieldname: "ewaybill",
+                fieldtype: "Data",
+                read_only: 1,
+                default: frm.doc.ewaybill,
+            },
+            {
+                label: "Closure Date",
+                fieldname: "closure_date",
+                fieldtype: "Date",
+                reqd: 1,
+                default: frappe.datetime.get_today(),
+            },
+            {
+                label: "Remarks",
+                fieldname: "remarks",
+                fieldtype: "Data",
+                reqd: 1,
+                length: 50,
+            },
+        ],
+        primary_action_label: __("Close"),
+        primary_action(values) {
+            frappe.call({
+                method: "india_compliance.gst_india.utils.e_waybill.close_e_waybill",
+                args: {
+                    doctype: frm.doctype,
+                    docname: frm.doc.name,
+                    values,
+                },
+                callback: () => {
+                    d.hide();
+                    frm.refresh();
+                },
+            });
+        },
+    });
+
+    d.show();
+}
+
 function show_mark_e_waybill_as_cancelled_dialog(frm) {
     const fields = get_cancel_e_waybill_dialog_fields(frm);
     fields.push({
@@ -1166,6 +1218,8 @@ function is_e_waybill_valid(frm) {
     const e_waybill_info = frm.doc.__onload && frm.doc.__onload.e_waybill_info;
     return (
         e_waybill_info &&
+        // a closed e-Waybill can no longer be modified
+        !e_waybill_info.is_closed &&
         (!e_waybill_info.valid_upto ||
             frappe.datetime.convert_to_user_tz(e_waybill_info.valid_upto, false).diff() > 0)
     );

--- a/india_compliance/gst_india/client_scripts/e_waybill_actions.js
+++ b/india_compliance/gst_india/client_scripts/e_waybill_actions.js
@@ -719,13 +719,6 @@ function show_close_e_waybill_dialog(frm) {
                 default: frm.doc.ewaybill,
             },
             {
-                label: "Closure Date",
-                fieldname: "closure_date",
-                fieldtype: "Date",
-                reqd: 1,
-                default: frappe.datetime.get_today(),
-            },
-            {
                 label: "Remarks",
                 fieldname: "remarks",
                 fieldtype: "Data",
@@ -1299,7 +1292,12 @@ function can_extend_e_waybill_now(valid_upto) {
 }
 
 function has_extend_validity_expired(frm) {
-    const valid_upto = frm.doc.__onload?.e_waybill_info?.valid_upto;
+    const e_waybill_info = frm.doc.__onload?.e_waybill_info;
+
+    // a closed e-Waybill can no longer be extended
+    if (e_waybill_info?.is_closed) return true;
+
+    const valid_upto = e_waybill_info?.valid_upto;
     const extend_before = get_hours(valid_upto, 8);
     const now = frappe.datetime.now_datetime();
 

--- a/india_compliance/gst_india/constants/custom_fields.py
+++ b/india_compliance/gst_india/constants/custom_fields.py
@@ -1765,7 +1765,7 @@ e_waybill_status_field = {
     "label": "e-Waybill Status",
     "fieldtype": "Select",
     "insert_after": "ewaybill",
-    "options": "\nPending\nGenerated\nManually Generated\nAuto-Retry\nCancelled\nManually Cancelled\nFailed\nNot Applicable",
+    "options": "\nPending\nGenerated\nManually Generated\nAuto-Retry\nCancelled\nManually Cancelled\nClosed\nFailed\nNot Applicable",
     "print_hide": 1,
     "no_copy": 1,
     "translatable": 1,

--- a/india_compliance/gst_india/constants/e_waybill.py
+++ b/india_compliance/gst_india/constants/e_waybill.py
@@ -1,6 +1,10 @@
 # Just for reference
 # DATETIME_FORMAT = "%d/%m/%Y %I:%M:%S %p"
 
+from frappe.utils import getdate
+
+E_WAYBILL_CLOSURE_AVAILABLE_FROM = getdate("2026-06-15")
+
 selling_address = {
     "bill_from": "company_address",
     "bill_to": "customer_address",

--- a/india_compliance/gst_india/constants/e_waybill.py
+++ b/india_compliance/gst_india/constants/e_waybill.py
@@ -3,7 +3,7 @@
 
 from frappe.utils import getdate
 
-E_WAYBILL_CLOSURE_AVAILABLE_FROM = getdate("2026-06-15")
+E_WAYBILL_CHANGES_APPLICABLE_DATE = getdate("2026-06-15")
 
 selling_address = {
     "bill_from": "company_address",

--- a/india_compliance/gst_india/constants/e_waybill.py
+++ b/india_compliance/gst_india/constants/e_waybill.py
@@ -3,7 +3,8 @@
 
 from frappe.utils import getdate
 
-E_WAYBILL_CHANGES_APPLICABLE_DATE = getdate("2026-06-15")
+# Date from which NIC e-Waybill API changes apply in production (already live in sandbox)
+E_WAYBILL_CHANGES_APPLICABLE_DATE = getdate("2026-08-01")
 
 selling_address = {
     "bill_from": "company_address",

--- a/india_compliance/gst_india/data/test_e_waybill.json
+++ b/india_compliance/gst_india/data/test_e_waybill.json
@@ -413,6 +413,26 @@
             "success": true
         }
     },
+    "close_e_waybill": {
+        "request_data": {
+            "ewbNo": "301002999920",
+            "closureDate": "04/10/2022",
+            "remarks": "Goods delivered"
+        },
+        "params": "action=CLSEWB",
+        "values": {
+            "closure_date": "2022-10-04",
+            "remarks": "Goods delivered"
+        },
+        "response_data": {
+            "message": "E-Way Bill is closed successfully",
+            "result": {
+                "ewbClosureDate": "04/10/2022 04:14:00 PM",
+                "ewayBillNo": "301002999920"
+            },
+            "success": true
+        }
+    },
     "get_e_waybill": {
         "kwargs": {
             "company_address": "_Test Indian Registered Company-Billing"

--- a/india_compliance/gst_india/data/test_e_waybill.json
+++ b/india_compliance/gst_india/data/test_e_waybill.json
@@ -491,7 +491,6 @@
         },
         "params": "action=CLSEWB",
         "values": {
-            "closure_date": "2022-10-04",
             "remarks": "Goods delivered"
         },
         "response_data": {

--- a/india_compliance/gst_india/data/test_e_waybill.json
+++ b/india_compliance/gst_india/data/test_e_waybill.json
@@ -139,6 +139,76 @@
             "success": true
         }
     },
+    "goods_item_for_closure": {
+        "kwargs": {
+            "vehicle_no": "GJ07DL9009",
+            "is_in_state": 1,
+            "company_address": "_Test Indian Registered Company-Billing"
+        },
+        "request_data": {
+            "otherValue": 0.0,
+            "cessNonAdvolValue": 0,
+            "actFromStateCode": 24,
+            "actToStateCode": 24,
+            "cessValue": 0,
+            "cgstValue": 9.0,
+            "docDate": "05/10/2022",
+            "docNo": "test_invoice_no",
+            "docType": "INV",
+            "fromAddr1": "Test Address - 1",
+            "fromGstin": "05AAACG2115R1ZN",
+            "fromPincode": 380015,
+            "fromPlace": "Test City",
+            "fromStateCode": 24,
+            "fromTrdName": "_Test Indian Registered Company",
+            "igstValue": 0,
+            "itemList": [
+                {
+                    "cessNonAdvol": 0,
+                    "cessRate": 0,
+                    "cgstRate": 9.0,
+                    "hsnCode": "61149090",
+                    "igstRate": 0,
+                    "itemNo": 1,
+                    "productDesc": "Test Trading Goods 1",
+                    "qtyUnit": "NOS",
+                    "quantity": 1.0,
+                    "sgstRate": 9.0,
+                    "taxableAmount": 100.0
+                }
+            ],
+            "mainHsnCode": "61149090",
+            "sgstValue": 9.0,
+            "subSupplyType": 1,
+            "supplyType": "O",
+            "toAddr1": "Test Address - 3",
+            "toGstin": "05AAACG2140A1ZL",
+            "toPincode": 380015,
+            "toPlace": "Test City",
+            "toStateCode": 24,
+            "toTrdName": "_Test Registered Customer",
+            "totInvValue": 118.0,
+            "totalValue": 100.0,
+            "transDistance": 10,
+            "transMode": 1,
+            "transactionType": 1,
+            "transporterName": "Test Common Supplier",
+            "userGstin": "05AAACG2115R1ZN",
+            "vehicleNo": "GJ07DL9009",
+            "vehicleType": "R"
+        },
+        "params": "action=GENEWAYBILL",
+        "response_data": {
+            "message": "E-Way Bill is generated successfully",
+            "result": {
+                "alert": "",
+                "ewayBillDate": "05/10/2022 12:39:00 PM",
+                "ewayBillNo": 351002999999,
+                "validUpto": "06/10/2022 11:59:00 PM"
+            },
+            "success": true
+        }
+    },
     "update_transporter": {
         "params": "action=UPDATETRANSPORTER",
         "values": {
@@ -415,7 +485,7 @@
     },
     "close_e_waybill": {
         "request_data": {
-            "ewbNo": "301002999920",
+            "ewbNo": "351002999999",
             "closureDate": "04/10/2022",
             "remarks": "Goods delivered"
         },
@@ -428,7 +498,7 @@
             "message": "E-Way Bill is closed successfully",
             "result": {
                 "ewbClosureDate": "04/10/2022 04:14:00 PM",
-                "ewayBillNo": "301002999920"
+                "ewayBillNo": "351002999999"
             },
             "success": true
         }

--- a/india_compliance/gst_india/doctype/e_waybill_log/e_waybill_log.json
+++ b/india_compliance/gst_india/doctype/e_waybill_log/e_waybill_log.json
@@ -20,6 +20,11 @@
   "column_break_2",
   "cancel_reason_code",
   "cancel_remark",
+  "closure_details_section",
+  "is_closed",
+  "closed_on",
+  "column_break_closure",
+  "closure_remark",
   "extension_details_section",
   "extension_scheduled",
   "extension_data",
@@ -76,6 +81,36 @@
    "fieldname": "cancel_remark",
    "fieldtype": "Data",
    "label": "Cancel Remark",
+   "read_only": 1
+  },
+  {
+   "depends_on": "eval: doc.is_closed == 1",
+   "fieldname": "closure_details_section",
+   "fieldtype": "Section Break",
+   "label": "Closure Details"
+  },
+  {
+   "default": "0",
+   "fieldname": "is_closed",
+   "fieldtype": "Check",
+   "in_standard_filter": 1,
+   "label": "Is Closed",
+   "read_only": 1
+  },
+  {
+   "fieldname": "closed_on",
+   "fieldtype": "Datetime",
+   "label": "Closed On",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_closure",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "closure_remark",
+   "fieldtype": "Data",
+   "label": "Closure Remark",
    "read_only": 1
   },
   {
@@ -179,7 +214,7 @@
    "link_fieldname": "ewaybill"
   }
  ],
- "modified": "2025-02-26 11:48:34.983047",
+ "modified": "2026-05-29 15:07:17.805008",
  "modified_by": "Administrator",
  "module": "GST India",
  "name": "e-Waybill Log",
@@ -229,6 +264,7 @@
    "share": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -1349,6 +1349,7 @@ class EWaybillData(GSTTransactionData):
     def get_data_for_closure(self, values):
         self.validate_if_e_waybill_is_set()
         self.validate_if_e_waybill_is_not_closed()
+        self.check_e_waybill_validity()
 
         return {
             "ewbNo": self.doc.ewaybill,

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -14,6 +14,7 @@ from frappe.utils import (
     get_datetime_str,
     get_fullname,
     get_link_to_form,
+    getdate,
     random_string,
 )
 from frappe.utils.file_manager import save_file
@@ -38,6 +39,7 @@ from india_compliance.gst_india.constants.e_waybill import (
     BUYING_DOCTYPES,
     CANCEL_REASON_CODES,
     CONSIGNMENT_STATUS,
+    E_WAYBILL_CLOSURE_AVAILABLE_FROM,
     EXTEND_VALIDITY_REASON_CODES,
     ITEM_LIMIT,
     PERMITTED_DOCTYPES,
@@ -428,10 +430,38 @@ def log_and_process_e_waybill_cancellation(doc, values, result):
     doc.db_set(data)
 
 
+def is_e_waybill_closure_enabled(settings=None, throw=False):
+    """e-Waybill Closure (CLSEWB) is live in sandbox now; in production only from
+    E_WAYBILL_CLOSURE_AVAILABLE_FROM (NIC rollout date)."""
+    if not settings:
+        settings = frappe.get_cached_doc("GST Settings")
+
+    available = settings.sandbox_mode or getdate() >= E_WAYBILL_CLOSURE_AVAILABLE_FROM
+
+    if available:
+        return True
+
+    if throw:
+        frappe.throw(
+            _("e-Waybill Closure API will be available from {0}.").format(
+                frappe.bold(format_date(E_WAYBILL_CLOSURE_AVAILABLE_FROM))
+            )
+        )
+
+    return False
+
+
 # nosemgrep: frappe-semgrep-rules.rules.security.missing-argument-type-hint
 @frappe.whitelist()
 def close_e_waybill(*, doctype: str, docname: str, values: str | dict | frappe._dict):
     """Permission check not required as load_doc checks permissions."""
+    if not is_e_waybill_closure_enabled():
+        frappe.throw(
+            _("e-Waybill Closure API will be available from {0}.").format(
+                frappe.bold(format_date(E_WAYBILL_CLOSURE_AVAILABLE_FROM))
+            )
+        )
+
     doc = load_doc(doctype, docname, "submit")
     values = frappe.parse_json(values)
     _close_e_waybill(doc, values)

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -477,16 +477,12 @@ def log_and_process_e_waybill_closure(doc, values, result):
         {
             "name": doc.ewaybill,
             "is_closed": 1,
-            # closure changes the remote state; invalidate cached data so the
-            # next fetch_e_waybill_data refreshes the data/PDF instead of
-            # serving the pre-closure copy.
             "is_latest_data": 0,
             "closure_remark": values.remarks,
             "closed_on": parse_datetime(result.ewbClosureDate, day_first=True),
         },
     )
 
-    # Unlike cancellation, closure keeps the e-Waybill number; only status changes.
     if doc.doctype == "Sales Invoice":
         doc.db_set("e_waybill_status", result.get("e_waybill_status") or "Closed")
 

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -430,6 +430,48 @@ def log_and_process_e_waybill_cancellation(doc, values, result):
 
 # nosemgrep: frappe-semgrep-rules.rules.security.missing-argument-type-hint
 @frappe.whitelist()
+def close_e_waybill(*, doctype: str, docname: str, values: str | dict | frappe._dict):
+    """Permission check not required as load_doc checks permissions."""
+    doc = load_doc(doctype, docname, "submit")
+    values = frappe.parse_json(values)
+    _close_e_waybill(doc, values)
+
+    return send_updated_doc(doc)
+
+
+def _close_e_waybill(doc, values):
+    closure_data = EWaybillData(doc).get_data_for_closure(values)
+
+    # Closure is an e-Waybill-only operation (no e-Invoice/IRN branch).
+    result = EWaybillAPI.create(doc).close_e_waybill(closure_data)
+
+    log_and_process_e_waybill_closure(doc, values, result)
+
+    frappe.msgprint(
+        _("e-Waybill closed successfully"),
+        indicator="green",
+        alert=True,
+    )
+
+
+def log_and_process_e_waybill_closure(doc, values, result):
+    log_and_process_e_waybill(
+        doc,
+        {
+            "name": doc.ewaybill,
+            "is_closed": 1,
+            "closure_remark": values.remarks,
+            "closed_on": parse_datetime(result.ewbClosureDate, day_first=True),
+        },
+    )
+
+    # Unlike cancellation, closure keeps the e-Waybill number; only status changes.
+    if doc.doctype == "Sales Invoice":
+        doc.db_set("e_waybill_status", result.get("e_waybill_status") or "Closed")
+
+
+# nosemgrep: frappe-semgrep-rules.rules.security.missing-argument-type-hint
+@frappe.whitelist()
 def update_vehicle_info(*, doctype: str, docname: str, values: str | dict | frappe._dict):
     """Permission check not required as load_doc checks permissions."""
     doc = load_doc(doctype, docname, "submit")
@@ -1158,6 +1200,7 @@ def get_e_waybill_info(doc):
             "valid_upto",
             "is_generated_in_sandbox_mode",
             "extension_scheduled",
+            "is_closed",
         ),
         as_dict=True,
     )
@@ -1278,6 +1321,18 @@ class EWaybillData(GSTTransactionData):
             "ewbNo": self.doc.ewaybill,
             "cancelRsnCode": CANCEL_REASON_CODES[values.reason],
             "cancelRmrk": values.remark if values.remark else values.reason,
+        }
+
+    def get_data_for_closure(self, values):
+        self.validate_if_e_waybill_is_set()
+        # TODO: Add validations
+        # Closure Date cannot be earlier than EwayBill Date
+        # You cannot close the e-Waybill as there is no PART-B/Vehicle entry
+
+        return {
+            "ewbNo": self.doc.ewaybill,
+            "closureDate": format_date(values.closure_date, "dd/mm/yyyy"),
+            "remarks": values.remarks,
         }
 
     def get_update_vehicle_data(self, values):

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -455,12 +455,7 @@ def is_e_waybill_closure_enabled(settings=None, throw=False):
 @frappe.whitelist()
 def close_e_waybill(*, doctype: str, docname: str, values: str | dict | frappe._dict):
     """Permission check not required as load_doc checks permissions."""
-    if not is_e_waybill_closure_enabled():
-        frappe.throw(
-            _("e-Waybill Closure API will be available from {0}.").format(
-                frappe.bold(format_date(E_WAYBILL_CLOSURE_AVAILABLE_FROM))
-            )
-        )
+    is_e_waybill_closure_enabled(throw=True)
 
     doc = load_doc(doctype, docname, "submit")
     values = frappe.parse_json(values)
@@ -1355,18 +1350,20 @@ class EWaybillData(GSTTransactionData):
 
     def get_data_for_closure(self, values):
         self.validate_if_e_waybill_is_set()
-        # TODO: Add validations
-        # Closure Date cannot be earlier than EwayBill Date
-        # You cannot close the e-Waybill as there is no PART-B/Vehicle entry
+        self.validate_if_e_waybill_is_not_closed()
+        # The following are validated by NIC (surfaced via ERRORS_MAP), so no
+        # local pre-check: closureDate >= e-Waybill date, and Part-B must exist
+        # Eroor will be raised from API no validation needed.
 
         return {
             "ewbNo": self.doc.ewaybill,
-            "closureDate": format_date(values.closure_date, "dd/mm/yyyy"),
+            "closureDate": format_date(getdate(), "dd/mm/yyyy"),
             "remarks": values.remarks,
         }
 
     def get_update_vehicle_data(self, values):
         self.validate_if_e_waybill_is_set()
+        self.validate_if_e_waybill_is_not_closed()
         self.check_e_waybill_validity()
         self.validate_mode_of_transport()
         self.set_transporter_details()
@@ -1386,6 +1383,7 @@ class EWaybillData(GSTTransactionData):
 
     def get_update_transporter_data(self, values):
         self.validate_if_e_waybill_is_set()
+        self.validate_if_e_waybill_is_not_closed()
         self.check_e_waybill_validity()
 
         return {
@@ -1395,6 +1393,7 @@ class EWaybillData(GSTTransactionData):
 
     def get_extend_validity_data(self, values):
         self.validate_if_e_waybill_is_set()
+        self.validate_if_e_waybill_is_not_closed()
         self.validate_if_e_waybill_can_be_extend()
         self.validate_mode_of_transport()
         self.validate_transit_type(values)
@@ -1525,6 +1524,11 @@ class EWaybillData(GSTTransactionData):
     def validate_if_e_waybill_is_set(self):
         if not self.doc.ewaybill:
             frappe.throw(_("No e-Waybill found for this document"))
+
+    def validate_if_e_waybill_is_not_closed(self):
+        # this works because we do run_onload in load_doc above
+        if self.doc.get_onload().get("e_waybill_info", {}).get("is_closed"):
+            frappe.throw(_("e-Waybill {0} is already closed").format(frappe.bold(self.doc.ewaybill)))
 
     def check_e_waybill_validity(self):
         # this works because we do run_onload in load_doc above

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -39,7 +39,7 @@ from india_compliance.gst_india.constants.e_waybill import (
     BUYING_DOCTYPES,
     CANCEL_REASON_CODES,
     CONSIGNMENT_STATUS,
-    E_WAYBILL_CLOSURE_AVAILABLE_FROM,
+    E_WAYBILL_CHANGES_APPLICABLE_DATE,
     EXTEND_VALIDITY_REASON_CODES,
     ITEM_LIMIT,
     PERMITTED_DOCTYPES,
@@ -430,32 +430,24 @@ def log_and_process_e_waybill_cancellation(doc, values, result):
     doc.db_set(data)
 
 
-def is_e_waybill_closure_enabled(settings=None, throw=False):
-    """e-Waybill Closure (CLSEWB) is live in sandbox now; in production only from
-    E_WAYBILL_CLOSURE_AVAILABLE_FROM (NIC rollout date)."""
+def is_e_waybill_changes_applicable(settings=None):
+    # changes deployed in sandbox mode and will be deployed in production on 15th June 2026.
     if not settings:
         settings = frappe.get_cached_doc("GST Settings")
 
-    available = settings.sandbox_mode or getdate() >= E_WAYBILL_CLOSURE_AVAILABLE_FROM
-
-    if available:
-        return True
-
-    if throw:
-        frappe.throw(
-            _("e-Waybill Closure API will be available from {0}.").format(
-                frappe.bold(format_date(E_WAYBILL_CLOSURE_AVAILABLE_FROM))
-            )
-        )
-
-    return False
+    return settings.sandbox_mode or getdate() >= E_WAYBILL_CHANGES_APPLICABLE_DATE
 
 
 # nosemgrep: frappe-semgrep-rules.rules.security.missing-argument-type-hint
 @frappe.whitelist()
 def close_e_waybill(*, doctype: str, docname: str, values: str | dict | frappe._dict):
     """Permission check not required as load_doc checks permissions."""
-    is_e_waybill_closure_enabled(throw=True)
+    if not is_e_waybill_changes_applicable():
+        frappe.throw(
+            _("e-Waybill Closure API will be available from {0}.").format(
+                frappe.bold(format_date(E_WAYBILL_CHANGES_APPLICABLE_DATE))
+            )
+        )
 
     doc = load_doc(doctype, docname, "submit")
     values = frappe.parse_json(values)
@@ -485,6 +477,10 @@ def log_and_process_e_waybill_closure(doc, values, result):
         {
             "name": doc.ewaybill,
             "is_closed": 1,
+            # closure changes the remote state; invalidate cached data so the
+            # next fetch_e_waybill_data refreshes the data/PDF instead of
+            # serving the pre-closure copy.
+            "is_latest_data": 0,
             "closure_remark": values.remarks,
             "closed_on": parse_datetime(result.ewbClosureDate, day_first=True),
         },
@@ -771,6 +767,7 @@ def validate_data_before_schedule(doc, values):
     e_waybill_data = EWaybillData(doc)
 
     e_waybill_data.validate_if_e_waybill_is_set()
+    e_waybill_data.validate_if_e_waybill_is_not_closed()
     e_waybill_data.validate_mode_of_transport()
     e_waybill_data.validate_transit_type(values)
     e_waybill_data.validate_remaining_distance(values)
@@ -1351,9 +1348,6 @@ class EWaybillData(GSTTransactionData):
     def get_data_for_closure(self, values):
         self.validate_if_e_waybill_is_set()
         self.validate_if_e_waybill_is_not_closed()
-        # The following are validated by NIC (surfaced via ERRORS_MAP), so no
-        # local pre-check: closureDate >= e-Waybill date, and Part-B must exist
-        # Eroor will be raised from API no validation needed.
 
         return {
             "ewbNo": self.doc.ewaybill,

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -431,7 +431,7 @@ def log_and_process_e_waybill_cancellation(doc, values, result):
 
 
 def is_e_waybill_changes_applicable(settings=None):
-    # changes deployed in sandbox mode and will be deployed in production on 15th June 2026.
+    # changes are live in sandbox and apply in production from E_WAYBILL_CHANGES_APPLICABLE_DATE
     if not settings:
         settings = frappe.get_cached_doc("GST Settings")
 
@@ -718,6 +718,7 @@ def get_e_waybills_to_extend():
         frappe.qb.from_(e_waybill)
         .where(
             e_waybill.is_cancelled.eq(0)
+            & e_waybill.is_closed.eq(0)
             & e_waybill.extension_scheduled.eq(1)
             & e_waybill.valid_upto.between(
                 get_datetime_str(add_days(get_datetime(), -1)),
@@ -1352,7 +1353,7 @@ class EWaybillData(GSTTransactionData):
         return {
             "ewbNo": self.doc.ewaybill,
             "closureDate": format_date(getdate(), "dd/mm/yyyy"),
-            "remarks": values.remarks,
+            "remarks": self.sanitize_value(values.remarks, regex=3),
         }
 
     def get_update_vehicle_data(self, values):

--- a/india_compliance/gst_india/utils/test_e_waybill.py
+++ b/india_compliance/gst_india/utils/test_e_waybill.py
@@ -436,7 +436,9 @@ class TestEWaybill(IntegrationTestCase):
     def test_close_e_waybill_blocked_before_rollout_in_production(self):
         """In production, close_e_waybill fails fast before the NIC rollout date
         (before the doc is loaded or any API call is made)."""
-        with time_machine.travel(get_datetime("2026-06-13"), tick=False):
+        before_rollout = add_to_date(E_WAYBILL_CHANGES_APPLICABLE_DATE, days=-1, as_datetime=True)
+
+        with time_machine.travel(before_rollout, tick=False):
             self.assertRaisesRegex(
                 frappe.exceptions.ValidationError,
                 re.compile(r"Closure API will be available from"),

--- a/india_compliance/gst_india/utils/test_e_waybill.py
+++ b/india_compliance/gst_india/utils/test_e_waybill.py
@@ -326,6 +326,7 @@ class TestEWaybill(IntegrationTestCase):
         )
 
     @responses.activate
+    @change_settings("GST Settings", {"sandbox_mode": 1})
     def test_close_e_waybill(self):
         """Test whitelisted method `close_e_waybill` (NIC v1.03 CLSEWB).
 
@@ -1754,7 +1755,6 @@ def update_dates_for_test_data(test_data):
         if "docDate" in response_request:
             response_request.update({"docDate": today_date})
 
-        # closure date is system-set to today (get_data_for_closure uses getdate())
         if "closureDate" in response_request:
             response_request.update({"closureDate": today_date})
 

--- a/india_compliance/gst_india/utils/test_e_waybill.py
+++ b/india_compliance/gst_india/utils/test_e_waybill.py
@@ -16,6 +16,7 @@ from responses import matchers
 
 from india_compliance.gst_india.api_classes.base import BASE_URL
 from india_compliance.gst_india.constants import SERVICE_HSN_PREFIX
+from india_compliance.gst_india.constants.e_waybill import E_WAYBILL_CLOSURE_AVAILABLE_FROM
 from india_compliance.gst_india.overrides.sales_invoice import (
     is_e_waybill_applicable,
 )
@@ -36,6 +37,7 @@ from india_compliance.gst_india.utils.e_waybill import (
     generate_e_waybill,
     get_e_waybills_to_extend,
     get_source_destination_address,
+    is_e_waybill_closure_enabled,
     schedule_ewaybill_for_extension,
     update_transporter,
     update_vehicle_info,
@@ -375,6 +377,75 @@ class TestEWaybill(IntegrationTestCase):
             e_waybill_close_data.get("request_data"),
             EWaybillData(doc).get_data_for_closure(frappe._dict(e_waybill_close_data.get("values"))),
         )
+
+    @responses.activate
+    def test_e_waybill_modification_blocked_after_closure(self):
+        """A closed e-Waybill must be rejected by the shared backend validation
+        path — so a direct RPC cannot re-close it or modify it (vehicle /
+        transporter / extend), even though the UI already hides those actions."""
+        si = self.create_sales_invoice_for("goods_item_with_ewaybill")
+        self._generate_e_waybill(si.name)
+
+        e_waybill_close_data = self.e_waybill_test_data.get("close_e_waybill")
+        self._mock_e_waybill_response(
+            data=e_waybill_close_data.get("response_data"),
+            match_list=[
+                matchers.query_string_matcher(e_waybill_close_data.get("params")),
+                matchers.json_params_matcher(e_waybill_close_data.get("request_data")),
+            ],
+        )
+        close_e_waybill(doctype=si.doctype, docname=si.name, values=e_waybill_close_data.get("values"))
+
+        # Reload so onload e_waybill_info reflects is_closed = 1
+        doc = load_doc("Sales Invoice", si.name, "submit")
+        e_waybill_data = EWaybillData(doc)
+
+        # Every modify path builds its payload through the shared closed-state guard
+        for builder in (
+            "get_data_for_closure",
+            "get_update_vehicle_data",
+            "get_update_transporter_data",
+            "get_extend_validity_data",
+        ):
+            self.assertRaisesRegex(
+                frappe.exceptions.ValidationError,
+                re.compile(r"already closed"),
+                getattr(e_waybill_data, builder),
+                frappe._dict(),
+            )
+
+    @change_settings("GST Settings", {"sandbox_mode": 0})
+    def test_e_waybill_closure_availability_gate(self):
+        """Closure (CLSEWB) is gated: sandbox now, production only from the NIC
+        rollout date (E_WAYBILL_CLOSURE_AVAILABLE_FROM)."""
+        settings = frappe.get_cached_doc("GST Settings")
+
+        # Production, before rollout -> disabled; the whitelisted entrypoint
+        # fails fast (before loading the doc or calling the API).
+        before = add_to_date(E_WAYBILL_CLOSURE_AVAILABLE_FROM, days=-1, as_datetime=True)
+        with time_machine.travel(before, tick=False):
+            self.assertFalse(is_e_waybill_closure_enabled(settings))
+            self.assertRaisesRegex(
+                frappe.exceptions.ValidationError,
+                re.compile(r"Closure API will be available from"),
+                close_e_waybill,
+                doctype="Sales Invoice",
+                docname="NON-EXISTENT",
+                values={},
+            )
+
+        # Production, on/after rollout -> enabled
+        after = add_to_date(E_WAYBILL_CLOSURE_AVAILABLE_FROM, days=1, as_datetime=True)
+        with time_machine.travel(after, tick=False):
+            self.assertTrue(is_e_waybill_closure_enabled(settings))
+
+    @change_settings("GST Settings", {"sandbox_mode": 1})
+    def test_e_waybill_closure_enabled_in_sandbox(self):
+        """Sandbox mode enables closure even before the rollout date."""
+        settings = frappe.get_cached_doc("GST Settings")
+        before = add_to_date(E_WAYBILL_CLOSURE_AVAILABLE_FROM, days=-1, as_datetime=True)
+        with time_machine.travel(before, tick=False):
+            self.assertTrue(is_e_waybill_closure_enabled(settings))
 
     @change_settings(
         "GST Settings",

--- a/india_compliance/gst_india/utils/test_e_waybill.py
+++ b/india_compliance/gst_india/utils/test_e_waybill.py
@@ -421,6 +421,24 @@ class TestEWaybill(IntegrationTestCase):
             frappe._dict(),
         )
 
+    @responses.activate
+    def test_close_e_waybill_blocked_after_validity_expiry(self):
+        """An expired e-Waybill cannot be closed."""
+        si = self.create_sales_invoice_for("goods_item_with_ewaybill")
+        self._generate_e_waybill(si.name)
+
+        doc = load_doc("Sales Invoice", si.name, "submit")
+        doc.get_onload().get("e_waybill_info", {})["valid_upto"] = add_to_date(
+            get_datetime(), days=-1, as_datetime=True
+        )
+
+        self.assertRaisesRegex(
+            frappe.exceptions.ValidationError,
+            re.compile(r"validity is over"),
+            EWaybillData(doc).get_data_for_closure,
+            frappe._dict(remarks="Goods delivered"),
+        )
+
     def test_e_waybill_changes_applicable_gate(self):
         before = add_to_date(E_WAYBILL_CHANGES_APPLICABLE_DATE, days=-1, as_datetime=True)
         after = add_to_date(E_WAYBILL_CHANGES_APPLICABLE_DATE, days=1, as_datetime=True)

--- a/india_compliance/gst_india/utils/test_e_waybill.py
+++ b/india_compliance/gst_india/utils/test_e_waybill.py
@@ -31,6 +31,7 @@ from india_compliance.gst_india.utils.e_waybill import (
     _generate_e_waybill,
     _get_e_waybill_threshold,
     cancel_e_waybill,
+    close_e_waybill,
     fetch_e_waybill_data,
     generate_e_waybill,
     get_e_waybills_to_extend,
@@ -319,6 +320,60 @@ class TestEWaybill(IntegrationTestCase):
         self.assertDictEqual(
             e_waybill_cancel_data.get("request_data"),
             EWaybillData(doc).get_data_for_cancellation(frappe._dict(e_waybill_cancel_data.get("values"))),
+        )
+
+    @responses.activate
+    def test_close_e_waybill(self):
+        """Test whitelisted method `close_e_waybill` (NIC v1.03 CLSEWB).
+
+        Closure keeps the e-Waybill number intact (unlike cancellation) and
+        records the closure on the e-Waybill Log + sets status to Closed.
+        """
+        si = self.create_sales_invoice_for("goods_item_with_ewaybill")
+        self._generate_e_waybill(si.name)
+
+        e_waybill_close_data = self.e_waybill_test_data.get("close_e_waybill")
+
+        # Mock response for CLSEWB
+        self._mock_e_waybill_response(
+            data=e_waybill_close_data.get("response_data"),
+            match_list=[
+                matchers.query_string_matcher(e_waybill_close_data.get("params")),
+                matchers.json_params_matcher(e_waybill_close_data.get("request_data")),
+            ],
+        )
+
+        close_e_waybill(
+            doctype=si.doctype,
+            docname=si.name,
+            values=e_waybill_close_data.get("values"),
+        )
+
+        # e-Waybill Log marked closed
+        self.assertTrue(
+            frappe.get_doc(
+                "e-Waybill Log",
+                {"reference_name": si.name, "is_closed": 1},
+            )
+        )
+
+        # closure must NOT clear the e-Waybill number, and status becomes Closed
+        si.reload()
+        self.assertEqual(si.ewaybill, e_waybill_close_data.get("request_data").get("ewbNo"))
+        self.assertEqual(si.e_waybill_status, "Closed")
+
+    @responses.activate
+    def test_get_e_waybill_close_data(self):
+        """Check if e-waybill closure request data is generated correctly"""
+        si = self.create_sales_invoice_for("goods_item_with_ewaybill")
+        self._generate_e_waybill(si.name)
+
+        doc = load_doc("Sales Invoice", si.name, "submit")
+        e_waybill_close_data = self.e_waybill_test_data.get("close_e_waybill")
+
+        self.assertDictEqual(
+            e_waybill_close_data.get("request_data"),
+            EWaybillData(doc).get_data_for_closure(frappe._dict(e_waybill_close_data.get("values"))),
         )
 
     @change_settings(
@@ -1598,6 +1653,8 @@ def update_dates_for_test_data(test_data):
             if k == "vehUpdateDate":
                 response_result.update({k: current_datetime})
             if k == "cancelDate":
+                response_result.update({k: current_datetime})
+            if k == "ewbClosureDate":
                 response_result.update({k: current_datetime})
             if k == "docDate":
                 response_result.update({k: today_date})

--- a/india_compliance/gst_india/utils/test_e_waybill.py
+++ b/india_compliance/gst_india/utils/test_e_waybill.py
@@ -16,7 +16,7 @@ from responses import matchers
 
 from india_compliance.gst_india.api_classes.base import BASE_URL
 from india_compliance.gst_india.constants import SERVICE_HSN_PREFIX
-from india_compliance.gst_india.constants.e_waybill import E_WAYBILL_CLOSURE_AVAILABLE_FROM
+from india_compliance.gst_india.constants.e_waybill import E_WAYBILL_CHANGES_APPLICABLE_DATE
 from india_compliance.gst_india.overrides.sales_invoice import (
     is_e_waybill_applicable,
 )
@@ -37,10 +37,11 @@ from india_compliance.gst_india.utils.e_waybill import (
     generate_e_waybill,
     get_e_waybills_to_extend,
     get_source_destination_address,
-    is_e_waybill_closure_enabled,
+    is_e_waybill_changes_applicable,
     schedule_ewaybill_for_extension,
     update_transporter,
     update_vehicle_info,
+    validate_data_before_schedule,
 )
 from india_compliance.gst_india.utils.tests import (
     SUBCONTRACTING_TEST_FINISHED_ITEM_TG,
@@ -330,9 +331,10 @@ class TestEWaybill(IntegrationTestCase):
 
         Closure keeps the e-Waybill number intact (unlike cancellation) and
         records the closure on the e-Waybill Log + sets status to Closed.
+
         """
-        si = self.create_sales_invoice_for("goods_item_with_ewaybill")
-        self._generate_e_waybill(si.name)
+        si = self.create_sales_invoice_for("goods_item_for_closure")
+        self._generate_e_waybill(si.name, test_data=self.e_waybill_test_data.goods_item_for_closure)
 
         e_waybill_close_data = self.e_waybill_test_data.get("close_e_waybill")
 
@@ -351,11 +353,12 @@ class TestEWaybill(IntegrationTestCase):
             values=e_waybill_close_data.get("values"),
         )
 
-        # e-Waybill Log marked closed
+        # e-Waybill Log marked closed, and cached data invalidated so a later
+        # fetch refreshes instead of serving the pre-closure copy
         self.assertTrue(
             frappe.get_doc(
                 "e-Waybill Log",
-                {"reference_name": si.name, "is_closed": 1},
+                {"reference_name": si.name, "is_closed": 1, "is_latest_data": 0},
             )
         )
 
@@ -367,10 +370,13 @@ class TestEWaybill(IntegrationTestCase):
     @responses.activate
     def test_get_e_waybill_close_data(self):
         """Check if e-waybill closure request data is generated correctly"""
-        si = self.create_sales_invoice_for("goods_item_with_ewaybill")
-        self._generate_e_waybill(si.name)
+        si = self.create_sales_invoice_for("goods_item_for_closure")
+        self._generate_e_waybill(si.name, test_data=self.e_waybill_test_data.goods_item_for_closure)
 
         doc = load_doc("Sales Invoice", si.name, "submit")
+        # this bill is open; pin the precondition so the test is independent of
+        # whether an earlier test closed the same (shared) e-Waybill number
+        doc.get_onload().get("e_waybill_info", {})["is_closed"] = 0
         e_waybill_close_data = self.e_waybill_test_data.get("close_e_waybill")
 
         self.assertDictEqual(
@@ -386,18 +392,10 @@ class TestEWaybill(IntegrationTestCase):
         si = self.create_sales_invoice_for("goods_item_with_ewaybill")
         self._generate_e_waybill(si.name)
 
-        e_waybill_close_data = self.e_waybill_test_data.get("close_e_waybill")
-        self._mock_e_waybill_response(
-            data=e_waybill_close_data.get("response_data"),
-            match_list=[
-                matchers.query_string_matcher(e_waybill_close_data.get("params")),
-                matchers.json_params_matcher(e_waybill_close_data.get("request_data")),
-            ],
-        )
-        close_e_waybill(doctype=si.doctype, docname=si.name, values=e_waybill_close_data.get("values"))
-
-        # Reload so onload e_waybill_info reflects is_closed = 1
         doc = load_doc("Sales Invoice", si.name, "submit")
+
+        # mark as closed via the onload flag the validation path reads
+        doc.get_onload().get("e_waybill_info", {})["is_closed"] = 1
         e_waybill_data = EWaybillData(doc)
 
         # Every modify path builds its payload through the shared closed-state guard
@@ -414,17 +412,31 @@ class TestEWaybill(IntegrationTestCase):
                 frappe._dict(),
             )
 
-    @change_settings("GST Settings", {"sandbox_mode": 0})
-    def test_e_waybill_closure_availability_gate(self):
-        """Closure (CLSEWB) is gated: sandbox now, production only from the NIC
-        rollout date (E_WAYBILL_CLOSURE_AVAILABLE_FROM)."""
-        settings = frappe.get_cached_doc("GST Settings")
+        # the schedule-extension path validates separately and must also be blocked
+        self.assertRaisesRegex(
+            frappe.exceptions.ValidationError,
+            re.compile(r"already closed"),
+            validate_data_before_schedule,
+            doc,
+            frappe._dict(),
+        )
 
-        # Production, before rollout -> disabled; the whitelisted entrypoint
-        # fails fast (before loading the doc or calling the API).
-        before = add_to_date(E_WAYBILL_CLOSURE_AVAILABLE_FROM, days=-1, as_datetime=True)
+    def test_e_waybill_changes_applicable_gate(self):
+        before = add_to_date(E_WAYBILL_CHANGES_APPLICABLE_DATE, days=-1, as_datetime=True)
+        after = add_to_date(E_WAYBILL_CHANGES_APPLICABLE_DATE, days=1, as_datetime=True)
+
         with time_machine.travel(before, tick=False):
-            self.assertFalse(is_e_waybill_closure_enabled(settings))
+            self.assertFalse(is_e_waybill_changes_applicable(frappe._dict(sandbox_mode=0)))
+            self.assertTrue(is_e_waybill_changes_applicable(frappe._dict(sandbox_mode=1)))
+
+        with time_machine.travel(after, tick=False):
+            self.assertTrue(is_e_waybill_changes_applicable(frappe._dict(sandbox_mode=0)))
+
+    @change_settings("GST Settings", {"sandbox_mode": 0})
+    def test_close_e_waybill_blocked_before_rollout_in_production(self):
+        """In production, close_e_waybill fails fast before the NIC rollout date
+        (before the doc is loaded or any API call is made)."""
+        with time_machine.travel(get_datetime("2026-06-13"), tick=False):
             self.assertRaisesRegex(
                 frappe.exceptions.ValidationError,
                 re.compile(r"Closure API will be available from"),
@@ -433,19 +445,6 @@ class TestEWaybill(IntegrationTestCase):
                 docname="NON-EXISTENT",
                 values={},
             )
-
-        # Production, on/after rollout -> enabled
-        after = add_to_date(E_WAYBILL_CLOSURE_AVAILABLE_FROM, days=1, as_datetime=True)
-        with time_machine.travel(after, tick=False):
-            self.assertTrue(is_e_waybill_closure_enabled(settings))
-
-    @change_settings("GST Settings", {"sandbox_mode": 1})
-    def test_e_waybill_closure_enabled_in_sandbox(self):
-        """Sandbox mode enables closure even before the rollout date."""
-        settings = frappe.get_cached_doc("GST Settings")
-        before = add_to_date(E_WAYBILL_CLOSURE_AVAILABLE_FROM, days=-1, as_datetime=True)
-        with time_machine.travel(before, tick=False):
-            self.assertTrue(is_e_waybill_closure_enabled(settings))
 
     @change_settings(
         "GST Settings",
@@ -1734,6 +1733,10 @@ def update_dates_for_test_data(test_data):
 
         if "docDate" in response_request:
             response_request.update({"docDate": today_date})
+
+        # closure date is system-set to today (get_data_for_closure uses getdate())
+        if "closureDate" in response_request:
+            response_request.update({"closureDate": today_date})
 
         if key == "get_e_waybill":
             for v in response_result.get("VehiclListDetails"):

--- a/india_compliance/patches.txt
+++ b/india_compliance/patches.txt
@@ -5,7 +5,7 @@ execute:from frappe.installer import add_module_defs; add_module_defs("india_com
 
 [post_model_sync]
 india_compliance.patches.v14.set_default_for_overridden_accounts_setting
-execute:from india_compliance.gst_india.setup import create_custom_fields; create_custom_fields() #72
+execute:from india_compliance.gst_india.setup import create_custom_fields; create_custom_fields() #73
 execute:from india_compliance.gst_india.setup import create_property_setters; create_property_setters() #11
 execute:from india_compliance.income_tax_india.setup import create_custom_fields; create_custom_fields() #7
 india_compliance.patches.post_install.remove_old_fields #2


### PR DESCRIPTION
Closes: #4336 

- Closed e-waybill can be cancelled.
- Only an active e-waybill can be closed.
- Expired e-waybill cannot be closed.
- A closed e-waybill allows transport and vehicle update, but currently we are disallowing it for consistency.
- Part B is mandatory for closure.
- It is voluntary.

https://docs.ewaybillgst.gov.in/apidocs/version1.03/closure-eway-bill.html#overview

no-docs