### PR TITLE
fix: simplify ignore_gst_validations and validate_items functions

### DIFF
--- a/india_compliance/gst_india/overrides/purchase_receipt.py
+++ b/india_compliance/gst_india/overrides/purchase_receipt.py
@@ -25,7 +25,7 @@ def get_dashboard_data(data):
 
 
 def onload(doc, method=None):
-    if ignore_gst_validations(doc, throw=False):
+    if ignore_gst_validations(doc):
         return
 
     if (

--- a/india_compliance/gst_india/overrides/test_transaction.py
+++ b/india_compliance/gst_india/overrides/test_transaction.py
@@ -33,8 +33,6 @@ from india_compliance.gst_india.constants import GST_TAX_TYPES, SALES_DOCTYPES
 from india_compliance.gst_india.overrides.transaction import (
     DOCTYPES_WITH_GST_DETAIL,
     ItemGSTDetails,
-    after_mapping,
-    reset_gst_details_on_cross_mapping,
     validate_gst_refund_accounts,
 )
 from india_compliance.gst_india.utils.tests import (

--- a/india_compliance/gst_india/overrides/test_transaction.py
+++ b/india_compliance/gst_india/overrides/test_transaction.py
@@ -14,7 +14,12 @@ from erpnext.controllers.accounts_controller import (
 )
 from erpnext.controllers.sales_and_purchase_return import make_return_doc
 from erpnext.controllers.taxes_and_totals import get_regional_round_off_accounts
-from erpnext.selling.doctype.sales_order.sales_order import make_purchase_order
+from erpnext.selling.doctype.sales_order.sales_order import (
+    make_purchase_order,
+)
+from erpnext.selling.doctype.sales_order.sales_order import (
+    make_sales_invoice as make_sales_invoice_from_so,
+)
 from erpnext.stock.doctype.delivery_note.delivery_note import make_sales_invoice
 from erpnext.stock.doctype.purchase_receipt.purchase_receipt import (
     update_regional_gl_entries,
@@ -28,6 +33,8 @@ from india_compliance.gst_india.constants import GST_TAX_TYPES, SALES_DOCTYPES
 from india_compliance.gst_india.overrides.transaction import (
     DOCTYPES_WITH_GST_DETAIL,
     ItemGSTDetails,
+    after_mapping,
+    reset_gst_details_on_cross_mapping,
     validate_gst_refund_accounts,
 )
 from india_compliance.gst_india.utils.tests import (
@@ -1664,3 +1671,45 @@ class TestPlaceOfSupply(FrappeTestCase):
         # Customer is in Karnataka (29). place_of_supply on the DN must reflect
         # that, not the PR's "24-Gujarat".
         self.assertEqual(dn.place_of_supply, "29-Karnataka")
+
+    @change_settings("GST Settings", {"enable_overseas_transactions": 1})
+    def test_make_sales_invoice_from_sales_order_with_non_gst_items(self):
+        """
+        make_sales_invoice_from_so must not raise when a Sales Order for a SEZ
+        customer contains items where some have a Non-GST item_tax_template and
+        one has no template.
+        Issue in mapping because gst_treatment was not set.
+        """
+        no_template_item = "_Test Item No Tax Template"
+        if not frappe.db.exists("Item", no_template_item):
+            frappe.get_doc(
+                {
+                    "doctype": "Item",
+                    "item_code": no_template_item,
+                    "item_name": no_template_item,
+                    "item_group": "Products",
+                    "stock_uom": "Nos",
+                    "is_stock_item": 0,
+                    "gst_hsn_code": "61149090",
+                }
+            ).insert()
+
+        # SEZ billing address forces "Zero-Rated" on all SO items so the order
+        # can be submitted despite having mixed-template items.
+        so = create_transaction(
+            doctype="Sales Order",
+            item_code="_Test Non GST Item",  # has "Non-GST - _TIRC" template
+            do_not_save=True,
+        )
+        so.customer_address = "_Test Registered Customer-Billing-1"  # SEZ, gst_category="SEZ"
+        so.gst_category = "SEZ"
+        append_item(
+            so, frappe._dict(item_code=no_template_item, rate=100, item_tax_template="Non-GST - _TIRC")
+        )  # non-gst tax template to replicate the mix
+        so.insert()
+        so.submit()
+
+        si = make_sales_invoice_from_so(so.name)
+
+        self.assertIsNotNone(si)
+        self.assertEqual(si.doctype, "Sales Invoice")

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -548,7 +548,7 @@ class GSTAccounts:
         frappe.throw(message, title=title or _("Invalid GST Account"))
 
 
-def validate_items(doc, throw):
+def validate_items(doc):
     """Validate Items for a GST Compliant Invoice"""
 
     if not doc.get("items"):
@@ -577,8 +577,6 @@ def validate_items(doc, throw):
             items_with_duplicate_taxes.append(bold(item_key))
 
     if non_gst_items and has_gst_items:
-        if not throw:
-            return False
         frappe.throw(
             _(
                 "Items not covered under GST cannot be clubbed with items for which GST"
@@ -592,16 +590,12 @@ def validate_items(doc, throw):
         return
 
     if items_with_duplicate_taxes:
-        if not throw:
-            return False
         frappe.throw(
             _(
                 "Cannot use different Item Tax Templates in different rows for following items:<br> {0}"
             ).format("<br>".join(items_with_duplicate_taxes)),
             title=_("Inconsistent Item Tax Templates"),
         )
-
-    return True
 
 
 def validate_place_of_supply(doc):
@@ -1743,7 +1737,7 @@ def validate_company_address_field(doc):
 
 
 def before_validate_transaction(doc, method=None):
-    if ignore_gst_validations(doc, throw=False):
+    if ignore_gst_validations(doc):
         return False
 
     if not doc.place_of_supply:
@@ -1791,6 +1785,7 @@ def validate_transaction(doc, method=None):
         _update_place_of_supply_and_taxes(doc)
 
     set_gst_tax_type(doc)
+    validate_items(doc)
 
     if doc.place_of_supply:
         validate_place_of_supply(doc)
@@ -1849,7 +1844,7 @@ def validate_transaction(doc, method=None):
 
 
 def before_print(doc, method=None, print_settings=None):
-    if ignore_gst_validations(doc, throw=False) or not doc.place_of_supply or not doc.company_gstin:
+    if ignore_gst_validations(doc) or not doc.place_of_supply or not doc.company_gstin:
         return
 
     set_ecommerce_supply_type(doc)
@@ -1857,7 +1852,7 @@ def before_print(doc, method=None, print_settings=None):
 
 
 def onload(doc, method=None):
-    if ignore_gst_validations(doc, throw=False) or not doc.place_of_supply or not doc.company_gstin:
+    if ignore_gst_validations(doc) or not doc.place_of_supply or not doc.company_gstin:
         return
 
     set_ecommerce_supply_type(doc)
@@ -1895,14 +1890,8 @@ def after_mapping(target_doc, method=None, source_doc=None):
         target_doc.set(fieldname, source_doc.get(fieldname))
 
 
-def ignore_gst_validations(doc, throw=True):
-    if (
-        not is_indian_registered_company(doc)
-        or doc.get("is_opening") == "Yes"
-        # Also returning if item with multiple taxes
-        or validate_items(doc, throw) is False
-    ):
-        return True
+def ignore_gst_validations(doc):
+    return not is_indian_registered_company(doc) or doc.get("is_opening") == "Yes"
 
 
 def reset_gst_details_on_cross_mapping(target_doc, source_doc):
@@ -1910,13 +1899,14 @@ def reset_gst_details_on_cross_mapping(target_doc, source_doc):
     When mapping between sales and purchase doctypes (e.g. Purchase Order
     from Sales Order), reset GST details.
     """
-    if ignore_gst_validations(target_doc):
-        return
 
     is_source_sales = source_doc.doctype in SALES_DOCTYPES
     is_target_sales = target_doc.doctype in SALES_DOCTYPES
 
     if is_source_sales == is_target_sales:
+        return
+
+    if ignore_gst_validations(target_doc):
         return
 
     # Re-fetch address-based fields (gst_category, party_gstin) from the
@@ -1969,6 +1959,8 @@ def before_update_after_submit(doc, method=None):
 
     if ignore_gst_validations(doc):
         return
+
+    validate_items(doc)
 
     if is_sales_transaction := doc.doctype in SALES_DOCTYPES:
         validate_hsn_codes(doc)


### PR DESCRIPTION
Issue: While mapping, with a 2 non-gst item one with a default tax template as non-GST and other with no default tax template an error is raised because, on mapping, gst treatment for one item is fetched, but for the other it is empty, causing the error.


Fix:

- Correct order in `reset_gst_details_on_cross_mapping`
- Validate item should not be part of ignore_gst_validations.

```
Traceback (most recent call last):
  File "/usr/lib/python3.11/contextlib.py", line 81, in inner
    return func(*args, **kwds)
           ^^^^^^^^^^^^^^^^^^^
  File "/home/lj/frappe-bench15/apps/india_compliance/india_compliance/gst_india/overrides/test_transaction.py", line 1820, in test_make_sales_invoice_from_sales_order_with_non_gst_items
    si = make_sales_invoice_from_so(so.name)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/lj/frappe-bench15/apps/frappe/frappe/utils/typing_validations.py", line 32, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/lj/frappe-bench15/apps/erpnext/erpnext/selling/doctype/sales_order/sales_order.py", line 1198, in make_sales_invoice
    doclist = get_mapped_doc(
              ^^^^^^^^^^^^^^^
  File "/home/lj/frappe-bench15/apps/frappe/frappe/model/mapper.py", line 150, in get_mapped_doc
    target_doc.run_method("after_mapping", source_doc)
  File "/home/lj/frappe-bench15/apps/frappe/frappe/model/document.py", line 1014, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/lj/frappe-bench15/apps/frappe/frappe/model/document.py", line 1374, in composer
    return composed(self, method, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/lj/frappe-bench15/apps/frappe/frappe/model/document.py", line 1358, in runner
    add_to_return_value(self, f(self, method, *args, **kwargs))
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/lj/frappe-bench15/apps/india_compliance/india_compliance/gst_india/overrides/transaction.py", line 1887, in after_mapping
    reset_gst_details_on_cross_mapping(target_doc, source_doc)
  File "/home/lj/frappe-bench15/apps/india_compliance/india_compliance/gst_india/overrides/transaction.py", line 1913, in reset_gst_details_on_cross_mapping
    if ignore_gst_validations(target_doc):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/lj/frappe-bench15/apps/india_compliance/india_compliance/gst_india/overrides/transaction.py", line 1903, in ignore_gst_validations
    or validate_items(doc, throw) is False
       ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/lj/frappe-bench15/apps/india_compliance/india_compliance/gst_india/overrides/transaction.py", line 582, in validate_items
    frappe.throw(
  File "/home/lj/frappe-bench15/apps/frappe/frappe/__init__.py", line 615, in throw
    msgprint(
  File "/home/lj/frappe-bench15/apps/frappe/frappe/__init__.py", line 580, in msgprint
    _raise_exception()
  File "/home/lj/frappe-bench15/apps/frappe/frappe/__init__.py", line 531, in _raise_exception
    raise exc
frappe.exceptions.ValidationError: Items not covered under GST cannot be clubbed with items for which GST is applicable. Please create another document for items in the following row numbers:1
```

Frappe Support Issue: https://support.frappe.io/desk/hd-ticket/69910
Manual backport: https://github.com/resilient-tech/india-compliance/pull/4350