### PR TITLE
test: update get_materials_from_supplier calls to use frappe.flags.args for subcontracting details

### DIFF
--- a/india_compliance/gst_india/overrides/test_subcontracting_transaction.py
+++ b/india_compliance/gst_india/overrides/test_subcontracting_transaction.py
@@ -345,7 +345,12 @@ class TestSubcontractingTransaction(IntegrationTestCase):
         sco = make_sco()
         se = make_stock_transfer_entry(sco_no=sco.name, rm_items=get_rm_items(sco.supplied_items))
 
-        return_se = get_materials_from_supplier(sco.name, [d.name for d in sco.supplied_items])
+        frappe.flags.args = frappe._dict(
+            subcontract_order=sco.name,
+            rm_details=[d.name for d in sco.supplied_items],
+            order_doctype=sco.doctype,
+        )
+        return_se = get_materials_from_supplier(sco.name)
         return_se.save()
 
         scr = make_subcontracting_receipt(sco.name)
@@ -481,7 +486,12 @@ class TestAddressMappingAfterMapping(IntegrationTestCase):
             bill_to_address=sco.supplier_address,
         )
 
-        return_se = get_materials_from_supplier(sco.name, [d.name for d in sco.supplied_items])
+        frappe.flags.args = frappe._dict(
+            subcontract_order=sco.name,
+            rm_details=[d.name for d in sco.supplied_items],
+            order_doctype=sco.doctype,
+        )
+        return_se = get_materials_from_supplier(sco.name)
 
         self.assertEqual(return_se.purpose, "Material Transfer")
         self.assertTrue(return_se.is_return)

--- a/india_compliance/gst_india/overrides/test_subcontracting_transaction.py
+++ b/india_compliance/gst_india/overrides/test_subcontracting_transaction.py
@@ -350,7 +350,10 @@ class TestSubcontractingTransaction(IntegrationTestCase):
             rm_details=[d.name for d in sco.supplied_items],
             order_doctype=sco.doctype,
         )
-        return_se = get_materials_from_supplier(sco.name)
+        try:
+            return_se = get_materials_from_supplier(sco.name)
+        finally:
+            frappe.flags.args = None
         return_se.save()
 
         scr = make_subcontracting_receipt(sco.name)
@@ -491,7 +494,10 @@ class TestAddressMappingAfterMapping(IntegrationTestCase):
             rm_details=[d.name for d in sco.supplied_items],
             order_doctype=sco.doctype,
         )
-        return_se = get_materials_from_supplier(sco.name)
+        try:
+            return_se = get_materials_from_supplier(sco.name)
+        finally:
+            frappe.flags.args = None
 
         self.assertEqual(return_se.purpose, "Material Transfer")
         self.assertTrue(return_se.is_return)


### PR DESCRIPTION
Related PR: https://github.com/frappe/erpnext/pull/55537