### PR TITLE
fix: set correct gst treatment in case of import purchase transactions

### DIFF
--- a/india_compliance/gst_india/overrides/test_transaction.py
+++ b/india_compliance/gst_india/overrides/test_transaction.py
@@ -792,6 +792,31 @@ class TestTransaction(IntegrationTestCase):
         if self.doctype == "Purchase Invoice":
             self.assertEqual(doc.itc_classification, "Import Of Service")
 
+    @change_settings("GST Settings", {"enable_overseas_transactions": 1})
+    def test_import_purchase_transaction_with_non_gst_charge_is_taxable(self):
+        if self.is_sales_doctype:
+            return
+
+        doc = create_transaction(
+            **self.transaction_details,
+            supplier="_Test Foreign Supplier",
+            item_code="_Test Trading Goods 1",
+            do_not_save=True,
+        )
+        doc.append(
+            "taxes",
+            {
+                "charge_type": "Actual",
+                "account_head": "Expenses Included In Valuation - _TIRC",
+                "description": "Freight",
+                "tax_amount": 100,
+                "cost_center": "Main - _TIRC",
+            },
+        )
+        doc.save()
+
+        self.assertEqual(doc.items[0].gst_treatment, "Taxable")
+
     def test_regular_purchase_without_gst_taxes_is_nil_rated(self):
         if self.is_sales_doctype:
             return

--- a/india_compliance/gst_india/overrides/test_transaction.py
+++ b/india_compliance/gst_india/overrides/test_transaction.py
@@ -777,8 +777,8 @@ class TestTransaction(IntegrationTestCase):
         self.assertDocumentEqual({"taxable_value": 62.51, "cgst_amount": 5.63}, doc.items[0])
 
     @change_settings("GST Settings", {"enable_overseas_transactions": 1})
-    def test_import_service_purchase_invoice_is_taxable(self):
-        if self.doctype != "Purchase Invoice":
+    def test_import_service_purchase_transaction_are_taxable(self):
+        if self.is_sales_doctype:
             return
 
         doc = create_transaction(
@@ -788,8 +788,9 @@ class TestTransaction(IntegrationTestCase):
             do_not_submit=True,
         )
 
-        self.assertEqual(doc.itc_classification, "Import Of Service")
         self.assertEqual(doc.items[0].gst_treatment, "Taxable")
+        if self.doctype == "Purchase Invoice":
+            self.assertEqual(doc.itc_classification, "Import Of Service")
 
     def test_regular_purchase_without_gst_taxes_is_nil_rated(self):
         if self.is_sales_doctype:

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -33,6 +33,8 @@ from india_compliance.gst_india.utils import (
     get_place_of_supply,
     get_place_of_supply_options,
     has_gst_taxes,
+    is_import_of_goods,
+    is_import_of_services,
     is_overseas_doc,
     join_list_with_custom_separators,
     validate_gst_category,
@@ -1378,10 +1380,7 @@ class ItemGSTTreatment:
             self.set_for_overseas()
             return
 
-        if self.doc.get("itc_classification") in (
-            "Import Of Goods",
-            "Import Of Service",
-        ):
+        if not is_sales_transaction and (is_import_of_goods(self.doc) or is_import_of_services(self.doc)):
             # NOTE: Import transactions are treated as "Taxable" since the supply is taxable
             # under GST even when no GST is charged directly (e.g. Import Of Goods settled
             # via BOE) But there is one more possibliity of classifying import transactions

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -33,8 +33,7 @@ from india_compliance.gst_india.utils import (
     get_place_of_supply,
     get_place_of_supply_options,
     has_gst_taxes,
-    is_import_of_goods,
-    is_import_of_services,
+    is_import_transaction,
     is_overseas_doc,
     join_list_with_custom_separators,
     validate_gst_category,
@@ -1380,7 +1379,7 @@ class ItemGSTTreatment:
             self.set_for_overseas()
             return
 
-        if not is_sales_transaction and (is_import_of_goods(self.doc) or is_import_of_services(self.doc)):
+        if is_import_transaction(self.doc):
             # NOTE: Import transactions are treated as "Taxable" since the supply is taxable
             # under GST even when no GST is charged directly (e.g. Import Of Goods settled
             # via BOE) But there is one more possibliity of classifying import transactions
@@ -1702,10 +1701,7 @@ def validate_item_tax_template(doc):
     if not doc.items or not doc.taxes:
         return
 
-    is_import_transaction = doc.get("itc_classification") in (
-        "Import Of Goods",
-        "Import Of Service",
-    )
+    is_import = is_import_transaction(doc)
     non_taxable_items_with_tax = []
     taxable_items_with_no_tax = []
 
@@ -1722,7 +1718,7 @@ def validate_item_tax_template(doc):
             non_taxable_items_with_tax.append(item.idx)
 
         if not is_gst_applied and item.gst_treatment in TAXABLE_GST_TREATMENTS:
-            if is_import_transaction:
+            if is_import:
                 continue
             taxable_items_with_no_tax.append(item.idx)
 

--- a/india_compliance/gst_india/utils/__init__.py
+++ b/india_compliance/gst_india/utils/__init__.py
@@ -8,6 +8,7 @@ import frappe
 from dateutil import parser
 from erpnext.accounts.party import get_default_contact
 from erpnext.accounts.utils import get_fiscal_year
+from erpnext.stock.get_item_details import purchase_doctypes
 from frappe import _
 from frappe.contacts.doctype.contact.contact import get_contact_details
 from frappe.desk.form.load import get_docinfo, run_onload
@@ -375,7 +376,7 @@ def is_foreign_transaction(gst_category, place_of_supply):
 
 
 def is_import_of_goods(doc):
-    return doc.gst_category in IMPORT_GST_CATEGORIES and are_goods_supplied(doc)
+    return doc.get("gst_category") in IMPORT_GST_CATEGORIES and are_goods_supplied(doc)
 
 
 def is_import_of_services(doc):
@@ -387,7 +388,11 @@ def is_import_of_services(doc):
     would be collected and discharged by the SEZ Unit / SEZ Developer i.e., under Forward
     Charge Mechanism.
     """
-    return doc.gst_category == "Overseas" and not are_goods_supplied(doc)
+    return doc.get("gst_category") == "Overseas" and not are_goods_supplied(doc)
+
+
+def is_import_transaction(doc):
+    return doc.doctype in purchase_doctypes and (is_import_of_goods(doc) or is_import_of_services(doc))
 
 
 def get_hsn_settings():


### PR DESCRIPTION
Issue: Correct GST treatment for Purchase Import Transactions was not set because the itc_classification field is not available in other transactions.
