### PR TITLE
fix: sum rounded total for correct e-waybill total

### DIFF
--- a/india_compliance/gst_india/overrides/test_transaction_data.py
+++ b/india_compliance/gst_india/overrides/test_transaction_data.py
@@ -317,6 +317,25 @@ class TestTransactionData(IntegrationTestCase):
         self.assertEqual(item_sum, gst_data.transaction_details["total"])
         self.assertEqual(gst_data.transaction_details["total"], 15826.26)
 
+    @change_settings("System Settings", {"currency_precision": 3})
+    def test_grouped_items_total_matches_transaction_total(self):
+        doc = create_sales_invoice(do_not_save=True)
+        doc.items[0].rate = 3112.5
+        doc.items[0].qty = 2
+        append_item(doc, frappe._dict(rate=3112.5, qty=2))
+        _append_taxes(doc, ["CGST", "SGST"], included_in_print_rate=1)
+        doc.group_same_items = True
+        doc.save()
+
+        gst_data = GSTTransactionData(doc)
+        gst_data.set_transaction_details()
+        items = gst_data.get_all_item_details()
+
+        item_sum = sum(it["taxable_amount"] + it["non_taxable_amount"] for it in items)
+        self.assertEqual(len(items), 1)  # grouped into 1 row
+        self.assertEqual(item_sum, gst_data.transaction_details["total"])
+        self.assertEqual(gst_data.transaction_details["total"], 10550.84)
+
     def test_validate_unique_hsn_and_uom(self):
         doc = create_sales_invoice(do_not_submit=True)
 

--- a/india_compliance/gst_india/overrides/test_transaction_data.py
+++ b/india_compliance/gst_india/overrides/test_transaction_data.py
@@ -1,7 +1,7 @@
 import re
 
 import frappe
-from frappe.tests import IntegrationTestCase
+from frappe.tests import IntegrationTestCase, change_settings
 from frappe.utils import add_to_date, getdate
 from frappe.utils.data import format_date
 
@@ -291,6 +291,31 @@ class TestTransactionData(IntegrationTestCase):
                 }
             ],
         )
+
+    @change_settings("System Settings", {"currency_precision": 3})
+    def test_transaction_total_equals_sum_of_rounded_item_values(self):
+        """transaction_details.total must equal Σ rounded(item.taxable_value).
+
+        3 items at rate=3112.5, qty=2, GST 18% included in rate:
+          taxable_value per item = 6225 / 1.18 = 5275.4237...
+          Σ round(5275.4237) = 5275.42 * 3 = 15826.26  ← correct (portal expects this)
+          round(Σ 5275.4237) = round(15826.271) = 15826.27  ← old total
+        """
+        doc = create_sales_invoice(do_not_save=True)
+        doc.items[0].rate = 3112.5
+        doc.items[0].qty = 2
+        for _ in range(2):
+            append_item(doc, frappe._dict(rate=3112.5, qty=2))
+        _append_taxes(doc, ["CGST", "SGST"], included_in_print_rate=1)
+        doc.save()
+
+        gst_data = GSTTransactionData(doc)
+        gst_data.set_transaction_details()
+        items = gst_data.get_all_item_details()
+
+        item_sum = sum(it["taxable_amount"] + it["non_taxable_amount"] for it in items)
+        self.assertEqual(item_sum, gst_data.transaction_details["total"])
+        self.assertEqual(gst_data.transaction_details["total"], 15826.26)
 
     def test_validate_unique_hsn_and_uom(self):
         doc = create_sales_invoice(do_not_submit=True)

--- a/india_compliance/gst_india/utils/transaction_data.py
+++ b/india_compliance/gst_india/utils/transaction_data.py
@@ -324,7 +324,7 @@ class GSTTransactionData:
                 idx += 1
 
             item.qty += row.qty
-            item.taxable_value += row.taxable_value
+            item.taxable_value += self.rounded(row.taxable_value)
 
             for tax in GST_TAX_TYPES:
                 item[f"{tax}_amount"] += row.get(f"{tax}_amount", 0)

--- a/india_compliance/gst_india/utils/transaction_data.py
+++ b/india_compliance/gst_india/utils/transaction_data.py
@@ -75,10 +75,11 @@ class GSTTransactionData:
         self.transaction_details.update({key: 0 for key in tax_total_keys})
 
         for row in self.doc.items:
-            total += row.taxable_value
+            taxable_value = self.rounded(row.taxable_value)
+            total += taxable_value
 
             if row.gst_treatment in TAXABLE_GST_TREATMENTS:
-                total_taxable_value += row.taxable_value
+                total_taxable_value += taxable_value
 
             if self.is_purchase_rcm:
                 continue


### PR DESCRIPTION
Issue: The sum of item-wise taxable value is not equal to the total taxable value.
The issue occurs only for the e-Waybill JSON upload.
<img width="1868" height="111" alt="image" src="https://github.com/user-attachments/assets/68a2e43f-6f8b-4203-b228-acb53de896e2" />


Frappe Support Issue: https://support.frappe.io/helpdesk/tickets/67983