### PR TITLE
fix: update permission check for Journal Entry access in GSTR1 class

### DIFF
--- a/india_compliance/gst_india/doctype/gstr_1/gstr_1.js
+++ b/india_compliance/gst_india/doctype/gstr_1/gstr_1.js
@@ -774,7 +774,7 @@ class GSTR1 {
     }
 
     async show_rcm_journal_entry() {
-        if (!frappe.perm.has_perm("Journal Entry")) return;
+        if (!frappe.boot.user.can_read.includes("Journal Entry")) return;
 
         const { month_or_quarter, year, company, filing_preference } = this.frm.doc;
         const { message: je_details } = await frappe.call({
@@ -804,7 +804,7 @@ class GSTR1 {
     };
 
     async show_rounding_diff_journal_entry() {
-        if (!frappe.perm.has_perm("Journal Entry")) return;
+        if (!frappe.boot.user.can_read.includes("Journal Entry")) return;
 
         const rounding_difference = this.data.books?.rounding_difference?.[0];
         if (!rounding_difference || Object.values(rounding_difference).every((v) => !v)) return;


### PR DESCRIPTION
The GSTR1 class gates show_rcm_journal_entry and show_rounding_diff_journal_entry behind frappe.perm.has_perm("Journal Entry"). This call requires the Journal Entry doctype meta to be loaded client-side — which is not the case here — causing it to consistently resolve to read: 0 and skipping the journal entry display regardless of the user's actual permissions.

frappe/frappe#34658 is not the correct approach to fix this — see [frappe/frappe#34658 (comment)](https://github.com/frappe/frappe/pull/34658#issuecomment-2627368578).

Instead, use frappe.boot.user.can_read.includes("Journal Entry") directly at the call site. Boot data is always available, needs no meta, and is the correct lightweight check for this pattern.

Companion to frappe/frappe#39644