### PR TITLE
fix: update transporter name handling to allow up to 100 characters

### DIFF
--- a/india_compliance/gst_india/overrides/test_transaction_data.py
+++ b/india_compliance/gst_india/overrides/test_transaction_data.py
@@ -226,6 +226,16 @@ class TestTransactionData(IntegrationTestCase):
             },
         )
 
+    def test_set_transporter_details_with_long_name(self):
+        """Transporter name exceeding 100 chars should be truncated; invalid chars stripped"""
+        long_name = "A" * 105 + '"\\'  # 107 chars with invalid chars
+        doc = create_sales_invoice(vehicle_no="GJ07DL9009", transporter_name=long_name, do_not_submit=True)
+
+        gst_transaction_data = GSTTransactionData(doc)
+        gst_transaction_data.set_transporter_details()
+
+        self.assertEqual(gst_transaction_data.transaction_details["transporter_name"], "A" * 100)
+
     def test_get_all_item_details(self):
         """Assertion for all Item Details fetched from transaction docs"""
         doc = create_sales_invoice(do_not_submit=True)

--- a/india_compliance/gst_india/utils/transaction_data.py
+++ b/india_compliance/gst_india/utils/transaction_data.py
@@ -215,7 +215,7 @@ class GSTTransactionData:
                     "lr_date": (format_date(self.doc.lr_date, self.DATE_FORMAT) if self.doc.lr_no else ""),
                     "gst_transporter_id": self.doc.gst_transporter_id or "",
                     "transporter_name": (
-                        self.sanitize_value(self.doc.transporter_name, regex=3, max_length=25)
+                        self.sanitize_value(self.doc.transporter_name, regex=3, max_length=100)
                         if self.doc.transporter_name
                         else ""
                     ),


### PR DESCRIPTION
Transporter Name field is allowed up to 100 characters.

e-invoice
```
"transporterName": {
"type": "string",
"maxLength": 100,
"description": "Name of the transporter"
},
```

e-waybill
```
"TransName": {
				"type": "string",
				"minLength": 3,
				"maxLength": 100,
				"pattern": "^([^\\\"])*$",
				"description": "Name of the transporter"
			},
```

Frappe Support Issue: https://support.frappe.io/helpdesk/tickets/70486?view=VIEW-HD+Ticket-771