### PR TITLE
fix: skip gst rounding for multicurrency transactions

### DIFF
--- a/india_compliance/gst_india/overrides/test_transaction.py
+++ b/india_compliance/gst_india/overrides/test_transaction.py
@@ -19,13 +19,14 @@ from erpnext.stock.doctype.purchase_receipt.purchase_receipt import (
 )
 from frappe.model.mapper import get_mapped_doc
 from frappe.tests import IntegrationTestCase, change_settings
-from frappe.utils import add_days, getdate, today
+from frappe.utils import add_days, flt, getdate, today
 from parameterized import parameterized_class
 
 from india_compliance.gst_india.constants import GST_TAX_TYPES, SALES_DOCTYPES
 from india_compliance.gst_india.overrides.transaction import (
     DOCTYPES_WITH_GST_DETAIL,
     ItemGSTDetails,
+    _is_multicurrency_doc,
     validate_gst_refund_accounts,
     validate_item_tax_template,
 )
@@ -1220,6 +1221,20 @@ class TestQuotationTransaction(IntegrationTestCase):
         self.assertEqual(doc.gst_category, "Unregistered")
 
 
+def _create_currency_exchange(from_currency, to_currency, exchange_rate):
+    frappe.get_doc(
+        {
+            "doctype": "Currency Exchange",
+            "from_currency": from_currency,
+            "to_currency": to_currency,
+            "date": today(),
+            "exchange_rate": exchange_rate,
+            "for_buying": 1,
+            "for_selling": 1,
+        }
+    ).insert(ignore_permissions=True)
+
+
 def get_lead(first_name):
     if name := frappe.db.exists("Lead", {"first_name": first_name}):
         return name
@@ -1239,6 +1254,84 @@ class TestSpecificTransactions(IntegrationTestCase):
     @classmethod
     def tearDown(cls):
         frappe.db.rollback()
+
+    @change_settings(
+        "GST Settings",
+        {"enable_overseas_transactions": 1, "round_off_gst_values": 1},
+    )
+    @change_settings(
+        "Accounts Settings",
+        {"allow_multi_currency_invoices_against_single_party_account": 1},
+    )
+    def test_multicurrency_invoice_skips_gst_round_off(self):
+        """
+        With round_off_gst_values enabled, ERPNext whole-rounds the txn-currency
+        GST. On a multicurrency doc that 0.5-foreign-unit shift is amplified by
+        conversion_rate on the base (INR) side, exceeding ERPNext's 0.5 INR
+        per-item-tax tolerance -> "Item Wise Tax Details do not match with Taxes
+        and Charges".
+        """
+        _create_currency_exchange("USD", "INR", 95.99)
+
+        doc = create_transaction(
+            doctype="Sales Invoice",
+            customer="_Test Foreign Customer",
+            party_name="_Test Foreign Customer",
+            currency="USD",  # conversion_rate intentionally NOT passed
+            is_export_with_gst=1,
+            is_out_state=1,  # IGST 18%
+            qty=9,
+            rate=5932.20,
+            do_not_submit=True,
+        )
+
+        self.assertEqual(flt(doc.conversion_rate), 95.99)
+
+        igst_row = next(row for row in doc.taxes if row.gst_tax_type == "igst")
+
+        self.assertNotEqual(igst_row.tax_amount, flt(round(igst_row.tax_amount, 0)))
+
+        # The IGST tax row was NOT added to the round-off accounts for this doc.
+        self.assertNotIn(
+            igst_row.account_head,
+            get_regional_round_off_accounts(doc.company, [], doc),
+        )
+
+    @change_settings("GST Settings", {"round_off_gst_values": 1})
+    def test_single_currency_invoice_still_rounds_off_gst(self):
+        """
+        Negative control: a single-currency (INR) doc must STILL whole-round GST
+        when round_off_gst_values is enabled. The multicurrency skip must not
+        leak into the default single-currency behavior.
+        """
+        doc = create_transaction(
+            doctype="Sales Invoice",
+            is_in_state=1,  # CGST + SGST 9% each
+            qty=9,
+            rate=5932.20,
+            do_not_submit=True,
+        )
+
+        self.assertEqual(flt(doc.conversion_rate), 1)
+
+        cgst_row = next(row for row in doc.taxes if row.gst_tax_type == "cgst")
+
+        self.assertEqual(cgst_row.tax_amount, flt(round(cgst_row.tax_amount, 0)))
+
+        self.assertIn(
+            cgst_row.account_head,
+            get_regional_round_off_accounts(doc.company, [], doc),
+        )
+
+    def test_is_multicurrency_doc(self):
+        self.assertTrue(_is_multicurrency_doc(frappe._dict(conversion_rate=95.99)))
+        self.assertTrue(_is_multicurrency_doc({"conversion_rate": 80}))
+        self.assertTrue(_is_multicurrency_doc('{"conversion_rate": 95.99}'))
+
+        self.assertFalse(_is_multicurrency_doc(frappe._dict(conversion_rate=1)))
+        self.assertFalse(_is_multicurrency_doc({"conversion_rate": 0}))
+        self.assertFalse(_is_multicurrency_doc({}))
+        self.assertFalse(_is_multicurrency_doc('{"conversion_rate": 1}'))
 
     def test_copy_e_waybill_fields_from_dn_to_si(self):
         "Make sure e-Waybill fields are copied from Delivery Note to Sales Invoice"

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -711,11 +711,15 @@ def validate_overseas_gst_category(doc):
         frappe.throw(_("Cannot set GST Category to SEZ / Overseas in POS Invoice"))
 
 
-def get_regional_round_off_accounts(company, account_list):
+def get_regional_round_off_accounts(company, account_list, doc=None):
     country = frappe.get_cached_value("Company", company, "country")
     if country != "India" or not frappe.get_cached_value(
         "GST Settings", "GST Settings", "round_off_gst_values"
     ):
+        return account_list
+
+    # skip gst rounding for multicurrency transactions
+    if doc and _is_multicurrency_doc(doc):
         return account_list
 
     if isinstance(account_list, str):
@@ -724,6 +728,14 @@ def get_regional_round_off_accounts(company, account_list):
     account_list.extend(get_all_gst_accounts(company))
 
     return account_list
+
+
+def _is_multicurrency_doc(doc):
+    if isinstance(doc, str):
+        doc = json.loads(doc)
+
+    conversion_rate = flt(doc.get("conversion_rate"))
+    return bool(conversion_rate and conversion_rate != 1)
 
 
 def update_party_details(party_details, doctype, company):

--- a/india_compliance/gst_india/utils/taxes_controller.py
+++ b/india_compliance/gst_india/utils/taxes_controller.py
@@ -154,7 +154,7 @@ class CustomTaxController:
     def update_tax_amount(self):
         total_taxes = 0
         total_taxable_value = self.calculate_total_taxable_value()
-        round_off_accounts = fetch_round_off_accounts(self.doc.company, [])
+        round_off_accounts = fetch_round_off_accounts(self.doc.company, [], self.doc)
 
         for tax in self.doc.taxes:
             if tax.charge_type == "Actual":

--- a/india_compliance/public/js/taxes_controller.js
+++ b/india_compliance/public/js/taxes_controller.js
@@ -21,6 +21,7 @@ india_compliance.taxes_controller = class TaxesController {
             args: {
                 company: this.frm.doc.company,
                 account_list: [],
+                doc: this.frm.doc,
             },
             callback(r) {
                 if (r.message) {


### PR DESCRIPTION
Issue: In multicurrency transactions, a whole-unit txn-side rounding shift (max 0.5 of the foreign currency) is amplified by conversion_rate on the base side. With CR=95.99 and a 0.5 USD shift, that's ~48 INR drift between the doc-level base tax and the per-item error-diffused breakup. This exceeds ERPNext's 0.5 INR tolerance and throws "Item Wise Tax Details do not match with Taxes and Charges". Even without round_off_gst_values, residuals can exceed IC's downstream validate_item_gst_details 1 INR threshold under certain configurations.



depends on: https://github.com/frappe/erpnext/pull/55758