### PR TITLE
fix: add error handling for SUPECO section in GSTR-1 API

### DIFF
--- a/india_compliance/gst_india/api_classes/taxpayer_returns.py
+++ b/india_compliance/gst_india/api_classes/taxpayer_returns.py
@@ -21,6 +21,7 @@ class ReturnsAPI(TaxpayerBaseAPI):
         "RET2B1016": "no_docs_found",
         "RT-3BAS1009": "no_docs_found",
         "RET11417": "no_docs_found",  # GSTR-1 Exports
+        "RETWEB_04": "no_docs_found",  # GSTR-1 SUPECO
         "RET2B1018": "requested_before_cutoff_date",
         "RTN_24": "queued",
         "RET11402": "authorization_failed",  # API Authorization Failed for 2A

--- a/india_compliance/gst_india/doctype/gstr_1/test_gstr_1.py
+++ b/india_compliance/gst_india/doctype/gstr_1/test_gstr_1.py
@@ -1,8 +1,10 @@
 # Copyright (c) 2024, Resilient Tech and Contributors
 # See license.txt
 
+import frappe
 from frappe.tests import IntegrationTestCase
 
+from india_compliance.gst_india.api_classes.taxpayer_returns import GSTR1API
 from india_compliance.gst_india.doctype.gstr_1.gstr_1_export import (
     GovExcel,
     _filter_data_by_sections,
@@ -26,6 +28,43 @@ GOV_EXCEL_SECTIONS = frozenset(
 
 class TestGSTR1(IntegrationTestCase):
     pass
+
+
+class TestGSTR1APIErrorHandling(IntegrationTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.api = GSTR1API.__new__(GSTR1API)
+        cls.api.company_gstin = "01AABCE2207R1Z5"
+
+    def test_no_invoices_found_is_ignored(self):
+        # SUPECO section with no data returns RETWEB_04 with status_cd 0
+        response = frappe._dict(
+            {
+                "error": {
+                    "error_cd": "RETWEB_04",
+                    "message": "No invoices found!!",
+                },
+                "status_cd": 0,
+            }
+        )
+
+        self.api.handle_error_response(response)
+        self.assertEqual(response.error_type, "no_docs_found")
+
+    def test_unknown_error_code_raises(self):
+        response = frappe._dict(
+            {
+                "error": {
+                    "error_cd": "RETWEB_99",
+                    "message": "Some other error",
+                },
+                "status_cd": 0,
+            }
+        )
+
+        self.assertRaises(frappe.ValidationError, self.api.handle_error_response, response)
 
 
 class TestGSTR1Export(IntegrationTestCase):


### PR DESCRIPTION
Closes: #4385 