### PR TITLE
fix: correct date handling for manual dates in manual e-waybill

### DIFF
--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -343,6 +343,9 @@ def log_and_process_e_waybill_generation(doc, result, *, with_irn=False):
 
     doc.db_set(data)
 
+    # dates are entered by the user in ISO format for manual generation
+    day_first = not with_irn and status != "Manually Generated"
+
     sandbox_mode, fetch = frappe.get_cached_value(
         "GST Settings", "GST Settings", ["sandbox_mode", "fetch_e_waybill_data"]
     )
@@ -352,11 +355,11 @@ def log_and_process_e_waybill_generation(doc, result, *, with_irn=False):
             "e_waybill_number": e_waybill_number,
             "created_on": parse_datetime(
                 result.get("ewayBillDate" if not with_irn else "EwbDt"),
-                day_first=not with_irn,
+                day_first=day_first,
             ),
             "valid_upto": parse_datetime(
                 result.get("validUpto" if not with_irn else "EwbValidTill"),
-                day_first=not with_irn,
+                day_first=day_first,
             ),
             "reference_doctype": doc.doctype,
             "reference_name": doc.name,
@@ -415,7 +418,10 @@ def log_and_process_e_waybill_cancellation(doc, values, result):
             "cancelled_on": (
                 get_datetime()  # Fallback to handle already cancelled e-Waybill
                 if result.error_code == "312"
-                else parse_datetime(result.cancelDate, day_first=True)
+                else parse_datetime(
+                    result.cancelDate,
+                    day_first=result.get("e_waybill_status") != "Manually Cancelled",
+                )
             ),
         },
     )

--- a/india_compliance/gst_india/utils/test_e_invoice.py
+++ b/india_compliance/gst_india/utils/test_e_invoice.py
@@ -19,6 +19,7 @@ from india_compliance.gst_india.utils.e_invoice import (
     cancel_e_invoice,
     generate_e_invoice,
     mark_e_invoice_as_cancelled,
+    mark_e_invoice_as_generated,
     validate_e_invoice_applicability,
     validate_if_e_invoice_can_be_cancelled,
 )
@@ -843,7 +844,14 @@ class TestEInvoice(IntegrationTestCase):
         si.reload()
         si.cancel()
 
-        values = frappe._dict({"reason": "Others", "remark": "Manually deleted from GSTR-1"})
+        cancelled_on = get_datetime("2026-06-05 11:00:00")
+        values = frappe._dict(
+            {
+                "reason": "Others",
+                "remark": "Manually deleted from GSTR-1",
+                "cancelled_on": str(cancelled_on),
+            }
+        )
 
         mark_e_invoice_as_cancelled("Sales Invoice", si.name, values)
         cancelled_doc = frappe.get_doc("Sales Invoice", si.name)
@@ -854,6 +862,42 @@ class TestEInvoice(IntegrationTestCase):
         )
 
         self.assertTrue(frappe.get_cached_value("e-Invoice Log", si.irn, "is_cancelled"), 1)
+        self.assertEqual(
+            frappe.get_cached_value("e-Invoice Log", si.irn, "cancelled_on"),
+            cancelled_on,
+        )
+
+    def test_mark_e_invoice_as_generated(self):
+        """Dates entered by the user should be stored as-is"""
+        test_data = self.e_invoice_test_data.get("goods_item_with_ewaybill")
+
+        si = create_sales_invoice(
+            **test_data.get("kwargs"),
+            qty=1000,
+            is_in_state=True,
+        )
+
+        # day and month both <= 12 to catch incorrect day-first parsing
+        ack_dt = get_datetime("2026-06-05 13:17:16")
+        irn = "manual" + frappe.generate_hash(length=58)
+
+        mark_e_invoice_as_generated(
+            si.doctype,
+            si.name,
+            values={
+                "irn": irn,
+                "ack_no": "172512345678901",
+                "ack_dt": str(ack_dt),
+            },
+        )
+
+        e_invoice_log = frappe.get_doc("e-Invoice Log", irn)
+        self.assertEqual(e_invoice_log.acknowledged_on, ack_dt)
+        self.assertEqual(e_invoice_log.acknowledgement_number, "172512345678901")
+        self.assertEqual(
+            frappe.db.get_value("Sales Invoice", si.name, "einvoice_status"),
+            "Manually Generated",
+        )
 
     @change_settings("GST Settings", {"nil_exempt_e_invoice_treatment": "Generate with Other Charges"})
     def test_validate_e_invoice_applicability(self):

--- a/india_compliance/gst_india/utils/test_e_waybill.py
+++ b/india_compliance/gst_india/utils/test_e_waybill.py
@@ -35,6 +35,8 @@ from india_compliance.gst_india.utils.e_waybill import (
     generate_e_waybill,
     get_e_waybills_to_extend,
     get_source_destination_address,
+    mark_e_waybill_as_cancelled,
+    mark_e_waybill_as_generated,
     schedule_ewaybill_for_extension,
     update_transporter,
     update_vehicle_info,
@@ -285,6 +287,63 @@ class TestEWaybill(IntegrationTestCase):
                 {"reference_name": si.name, "is_cancelled": 1},
             )
         )
+
+    def test_mark_e_waybill_as_generated(self):
+        """Dates entered by the user should be stored as-is (system timezone, no day-first parsing)"""
+        si = self.create_sales_invoice_for("goods_item_with_ewaybill")
+
+        # day and month both <= 12 to catch incorrect day-first parsing
+        e_waybill_date = get_datetime("2026-06-05 13:17:16")
+        valid_upto = get_datetime("2026-06-07 13:17:16")
+
+        mark_e_waybill_as_generated(
+            si.doctype,
+            si.name,
+            values={
+                "ewaybill": "351002721232",
+                "e_waybill_date": str(e_waybill_date),
+                "valid_upto": str(valid_upto),
+            },
+        )
+
+        e_waybill_log = frappe.get_doc("e-Waybill Log", "351002721232")
+        self.assertEqual(e_waybill_log.created_on, e_waybill_date)
+        self.assertEqual(e_waybill_log.valid_upto, valid_upto)
+        self.assertEqual(
+            frappe.db.get_value("Sales Invoice", si.name, "e_waybill_status"),
+            "Manually Generated",
+        )
+
+    def test_mark_e_waybill_as_cancelled(self):
+        """Cancel date entered by the user should be stored as-is"""
+        si = self.create_sales_invoice_for("goods_item_with_ewaybill")
+
+        e_waybill_date = get_datetime("2026-06-05 13:17:16")
+        cancelled_on = get_datetime("2026-06-05 11:00:00")
+
+        mark_e_waybill_as_generated(
+            si.doctype,
+            si.name,
+            values={
+                "ewaybill": "351002721233",
+                "e_waybill_date": str(e_waybill_date),
+                "valid_upto": str(get_datetime("2026-06-07 13:17:16")),
+            },
+        )
+
+        mark_e_waybill_as_cancelled(
+            si.doctype,
+            si.name,
+            values={
+                "reason": "Data Entry Mistake",
+                "remark": "Manually Cancelled",
+                "cancelled_on": str(cancelled_on),
+            },
+        )
+
+        e_waybill_log = frappe.get_doc("e-Waybill Log", "351002721233")
+        self.assertEqual(e_waybill_log.is_cancelled, 1)
+        self.assertEqual(e_waybill_log.cancelled_on, cancelled_on)
 
     @responses.activate
     def test_get_e_waybill_cancel_data(self):


### PR DESCRIPTION
Issue: incorrect dates in the e-Waybill log for manual generation/cancellation, since user-entered ISO dates were parsed as day-first (e.g. 2026-06-05 stored as 2026-05-06)