### PR TITLE
fix: always execute workflow action; filter jobs

### DIFF
--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -61,10 +61,15 @@ jobs:
   changes:
     name: Detect backend changes
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       backend: ${{ steps.filter.outputs.backend }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: dorny/paths-filter@v4
         id: filter
         with:
@@ -81,7 +86,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     needs: changes
-    if: ${{ github.event_name == 'workflow_dispatch' || needs.changes.outputs.backend == 'true' }}
+    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.backend == 'true' }}
 
     strategy:
       fail-fast: false

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -13,12 +13,6 @@ on:
       codecov_token:
 
   pull_request:
-    paths-ignore:
-      - "**.css"
-      - "**.js"
-      - "**.md"
-      - "**.html"
-      - "**.csv"
 
   push:
     branches:
@@ -31,12 +25,6 @@ on:
         version-16-hotfix,
         version-16,
       ]
-    paths-ignore:
-      - "**.css"
-      - "**.js"
-      - "**.md"
-      - "**.html"
-      - "**.csv"
 
   workflow_dispatch:
     inputs:
@@ -70,9 +58,30 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Detect backend changes
+    runs-on: ubuntu-latest
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            backend:
+              - '**'
+              - '!**.css'
+              - '!**.js'
+              - '!**.md'
+              - '!**.html'
+              - '!**.csv'
+
   tests:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    needs: changes
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.changes.outputs.backend == 'true' }}
 
     strategy:
       fail-fast: false
@@ -166,8 +175,8 @@ jobs:
 
   coverage:
     name: Coverage Wrap Up
-    if: github.event_name == 'push'
-    needs: tests
+    if: ${{ github.event_name == 'push' && needs.changes.outputs.backend == 'true' }}
+    needs: [changes, tests]
     runs-on: ubuntu-latest
     steps:
       - name: Clone


### PR DESCRIPTION
Issue

- Github actions are required
- With filter they are only selectively executed
- With new filters action always completes but runs jobs selectively
- This ensure auto-merge