### PR TITLE
fix: add fuzzy match rule without date and corresponding test case

### DIFF
--- a/india_compliance/gst_india/doctype/purchase_reconciliation_tool/__init__.py
+++ b/india_compliance/gst_india/doctype/purchase_reconciliation_tool/__init__.py
@@ -40,7 +40,7 @@ class Fields(Enum):
 class Rule(Enum):
     EXACT_MATCH = "Exact Match"
     FUZZY_MATCH = "Fuzzy Match"
-    FUZZY_MATCH_WITHOUT_DATE = "Fuzzy Match Without Date"
+    SAME_BILL_NO = "Same Bill No"  # cleaned bill_no equal, ignores bill date
     MISMATCH = "Mismatch"
     ROUNDING_DIFFERENCE = "Rounding Difference"  # <= 1 hardcoded
 
@@ -63,7 +63,7 @@ class MatchStatus(Enum):
 #     {"Suggested Match": ["E", "E", "F", "E", "E", 1, 1, 1, 1, 2]},
 #     {"Mismatch": ["E", "E", "E", "N", "N", "N", "N", "N", "N", "N"]},
 #     {"Mismatch": ["E", "E", "F", "N", "N", "N", "N", "N", "N", "N"]},
-#     {"Mismatch": ["E", "E", "FD", "N", "N", "N", "N", "N", "N", "N"]},  # FD = fuzzy bill_no, ignores date
+#     {"Mismatch": ["E", "E", "S", "N", "N", "N", "N", "N", "N", "N"]},  # S = same cleaned bill_no, ignores date
 #     {"Residual Match": ["E", "E", "N", "E", "E", 1, 1, 1, 1, 2]},
 # ]
 
@@ -71,6 +71,7 @@ class MatchStatus(Enum):
 #     {"Mismatch": ["E", "N", "E", "E", "E", 1, 1, 1, 1, 2]},
 #     {"Mismatch": ["E", "N", "F", "E", "E", 1, 1, 1, 1, 2]},
 #     {"Mismatch": ["E", "N", "F", "N", "N", "N", "N", "N", "N", "N"]},
+#     {"Mismatch": ["E", "N", "S", "N", "N", "N", "N", "N", "N", "N"]},  # S = same cleaned bill_no, ignores date
 #     {"Residual Match": ["E", "N", "N", "E", "E", 1, 1, 1, 1, 2]},
 # ]
 
@@ -176,7 +177,7 @@ GSTIN_RULES = (
         "rule": {
             Fields.FISCAL_YEAR: Rule.EXACT_MATCH,
             Fields.SUPPLIER_GSTIN: Rule.EXACT_MATCH,
-            Fields.BILL_NO: Rule.FUZZY_MATCH_WITHOUT_DATE,
+            Fields.BILL_NO: Rule.SAME_BILL_NO,
         },
     },
     {
@@ -241,6 +242,15 @@ PAN_RULES = (
             # Fields.SGST: Rule.MISMATCH,
             # Fields.IGST: Rule.MISMATCH,
             # Fields.CESS: Rule.MISMATCH,
+        },
+    },
+    {
+        "match_status": MatchStatus.MISMATCH,
+        "rule": {
+            Fields.FISCAL_YEAR: Rule.EXACT_MATCH,
+            # Fields.SUPPLIER_GSTIN: Rule.MISMATCH,
+            Fields.COMPANY_GSTIN: Rule.EXACT_MATCH,
+            Fields.BILL_NO: Rule.SAME_BILL_NO,
         },
     },
     {
@@ -856,12 +866,12 @@ class Reconciler(BaseReconciliation):
             return purchase[field] == inward_supply[field]
         elif rule == Rule.FUZZY_MATCH:
             return self.fuzzy_match(purchase, inward_supply)
-        elif rule == Rule.FUZZY_MATCH_WITHOUT_DATE:
-            return self.fuzzy_match(purchase, inward_supply, check_date=False)
+        elif rule == Rule.SAME_BILL_NO:
+            return self.same_bill_no(purchase, inward_supply)
         elif rule == Rule.ROUNDING_DIFFERENCE:
             return self.get_amount_difference(purchase, inward_supply, field) <= 1
 
-    def fuzzy_match(self, purchase, inward_supply, check_date=True):
+    def fuzzy_match(self, purchase, inward_supply):
         """
         Returns true if the (cleaned) bill_no approximately match.
         - For a fuzzy match, month of invoice and inward supply should be same.
@@ -871,20 +881,38 @@ class Reconciler(BaseReconciliation):
         if not purchase.bill_no or not inward_supply.bill_no:
             return False
 
-        if check_date and abs((purchase.bill_date - inward_supply.bill_date).days) > 10:
+        if abs((purchase.bill_date - inward_supply.bill_date).days) > 10:
             return False
 
-        if not purchase._bill_no:
-            purchase._bill_no = BaseUtil.get_cleaner_bill_no(purchase.bill_no, purchase.fy)
-
-        if not inward_supply._bill_no:
-            inward_supply._bill_no = BaseUtil.get_cleaner_bill_no(inward_supply.bill_no, inward_supply.fy)
+        self.set_cleaned_bill_no(purchase, inward_supply)
 
         partial_ratio = fuzz.partial_ratio(purchase._bill_no, inward_supply._bill_no)
         if float(partial_ratio) == 100:
             return True
 
         return float(process.extractOne(purchase._bill_no, [inward_supply._bill_no])[1]) >= 90.0
+
+    def same_bill_no(self, purchase, inward_supply):
+        """
+        Returns true if the cleaned bill numbers are identical, regardless of
+        bill date. A bill number is unique per supplier per fiscal year, so an
+        exact (not fuzzy) match is the same invoice. Exact comparison avoids
+        matching different invoices whose numbers are prefixes (e.g. INV-1 / INV-100).
+        """
+        if not purchase.bill_no or not inward_supply.bill_no:
+            return False
+
+        self.set_cleaned_bill_no(purchase, inward_supply)
+
+        return purchase._bill_no == inward_supply._bill_no
+
+    @staticmethod
+    def set_cleaned_bill_no(purchase, inward_supply):
+        if not purchase._bill_no:
+            purchase._bill_no = BaseUtil.get_cleaner_bill_no(purchase.bill_no, purchase.fy)
+
+        if not inward_supply._bill_no:
+            inward_supply._bill_no = BaseUtil.get_cleaner_bill_no(inward_supply.bill_no, inward_supply.fy)
 
     def get_amount_difference(self, purchase, inward_supply, field):
         if field == "cess":

--- a/india_compliance/gst_india/doctype/purchase_reconciliation_tool/__init__.py
+++ b/india_compliance/gst_india/doctype/purchase_reconciliation_tool/__init__.py
@@ -40,6 +40,7 @@ class Fields(Enum):
 class Rule(Enum):
     EXACT_MATCH = "Exact Match"
     FUZZY_MATCH = "Fuzzy Match"
+    FUZZY_MATCH_WITHOUT_DATE = "Fuzzy Match Without Date"
     MISMATCH = "Mismatch"
     ROUNDING_DIFFERENCE = "Rounding Difference"  # <= 1 hardcoded
 
@@ -62,6 +63,7 @@ class MatchStatus(Enum):
 #     {"Suggested Match": ["E", "E", "F", "E", "E", 1, 1, 1, 1, 2]},
 #     {"Mismatch": ["E", "E", "E", "N", "N", "N", "N", "N", "N", "N"]},
 #     {"Mismatch": ["E", "E", "F", "N", "N", "N", "N", "N", "N", "N"]},
+#     {"Mismatch": ["E", "E", "FD", "N", "N", "N", "N", "N", "N", "N"]},  # FD = fuzzy bill_no, ignores date
 #     {"Residual Match": ["E", "E", "N", "E", "E", 1, 1, 1, 1, 2]},
 # ]
 
@@ -167,6 +169,14 @@ GSTIN_RULES = (
             # Fields.SGST: Rule.MISMATCH,
             # Fields.IGST: Rule.MISMATCH,
             # Fields.CESS: Rule.MISMATCH,
+        },
+    },
+    {
+        "match_status": MatchStatus.MISMATCH,
+        "rule": {
+            Fields.FISCAL_YEAR: Rule.EXACT_MATCH,
+            Fields.SUPPLIER_GSTIN: Rule.EXACT_MATCH,
+            Fields.BILL_NO: Rule.FUZZY_MATCH_WITHOUT_DATE,
         },
     },
     {
@@ -846,10 +856,12 @@ class Reconciler(BaseReconciliation):
             return purchase[field] == inward_supply[field]
         elif rule == Rule.FUZZY_MATCH:
             return self.fuzzy_match(purchase, inward_supply)
+        elif rule == Rule.FUZZY_MATCH_WITHOUT_DATE:
+            return self.fuzzy_match(purchase, inward_supply, check_date=False)
         elif rule == Rule.ROUNDING_DIFFERENCE:
             return self.get_amount_difference(purchase, inward_supply, field) <= 1
 
-    def fuzzy_match(self, purchase, inward_supply):
+    def fuzzy_match(self, purchase, inward_supply, check_date=True):
         """
         Returns true if the (cleaned) bill_no approximately match.
         - For a fuzzy match, month of invoice and inward supply should be same.
@@ -859,7 +871,7 @@ class Reconciler(BaseReconciliation):
         if not purchase.bill_no or not inward_supply.bill_no:
             return False
 
-        if abs((purchase.bill_date - inward_supply.bill_date).days) > 10:
+        if check_date and abs((purchase.bill_date - inward_supply.bill_date).days) > 10:
             return False
 
         if not purchase._bill_no:

--- a/india_compliance/gst_india/doctype/purchase_reconciliation_tool/test_purchase_reconciliation_tool.py
+++ b/india_compliance/gst_india/doctype/purchase_reconciliation_tool/test_purchase_reconciliation_tool.py
@@ -385,11 +385,51 @@ class TestPurchaseReconciliationTool(IntegrationTestCase):
         )
         data = prt.reconcile_and_generate_data()
 
+        rows = {r.purchase_invoice_name: r for r in data if r.purchase_invoice_name}
+
+        # each invoice matched to its own bill number, not cross-matched
+        self.assertEqual(rows[pi_a.name].inward_supply_name, is_a.name)
+        self.assertEqual(rows[pi_b.name].inward_supply_name, is_b.name)
+        # same bill number with a > 10 day date gap is flagged as Mismatch
+        self.assertEqual(rows[pi_a.name].match_status, "Mismatch")
+        self.assertEqual(rows[pi_b.name].match_status, "Mismatch")
+
+    def test_prefix_bill_no_not_matched_across_date_gap(self):
+        """
+        Different invoices whose bill numbers are prefixes of each other
+        (INV-1 vs INV-100) must not be matched, even with the same amount,
+        when the bill dates are more than 10 days apart.
+        """
+        pinv = create_purchase_invoice(
+            bill_no="INV/1/23-24",
+            bill_date="2023-09-01",
+            posting_date="2023-09-01",
+        )
+        gst_is = create_gst_inward_supply(
+            bill_no="INV/100/23-24",
+            bill_date="2023-09-25",  # > 10 days apart
+            return_period_2b="092023",
+        )
+
+        prt = frappe.get_doc("Purchase Reconciliation Tool")
+        prt.update(
+            {
+                "company_gstin": "24AAQCA8719H1ZC",
+                "purchase_period": "Custom",
+                "purchase_from_date": "2023-09-01",
+                "purchase_to_date": "2023-09-30",
+                "inward_supply_period": "Custom",
+                "inward_supply_from_date": "2023-09-01",
+                "inward_supply_to_date": "2023-09-30",
+                "gst_return": "GSTR 2B",
+            }
+        )
+        data = prt.reconcile_and_generate_data()
+
         matched = {r.purchase_invoice_name: r.inward_supply_name for r in data if r.purchase_invoice_name}
 
-        self.assertNotEqual(matched.get(pi_b.name), is_a.name)
-        self.assertEqual(matched.get(pi_a.name), is_a.name)
-        self.assertEqual(matched.get(pi_b.name), is_b.name)
+        self.assertIsNone(matched.get(pinv.name))
+        self.assertIn(gst_is.name, {r.inward_supply_name for r in data if not r.purchase_invoice_name})
 
     def test_get_invoice_details_with_none_inward_supply_name(self):
         """

--- a/india_compliance/gst_india/doctype/purchase_reconciliation_tool/test_purchase_reconciliation_tool.py
+++ b/india_compliance/gst_india/doctype/purchase_reconciliation_tool/test_purchase_reconciliation_tool.py
@@ -339,6 +339,62 @@ class TestPurchaseReconciliationTool(IntegrationTestCase):
             status="Not Filed",
         )
 
+    def test_same_bill_no_takes_preference_over_amount_match(self):
+        """
+        Two invoices of the same supplier with the same GST amount. Each bill
+        number is recorded in a slightly different format in 2A vs ERP, and the
+        same invoice's bill date differs by more than 10 days.
+
+        Without bill-number preference, the amount-only residual rule cross
+        matches QKI/053612 (ERP) with QKI 055190 (2A). Each invoice must
+        instead be matched to its own bill number.
+        """
+        pi_a = create_purchase_invoice(
+            bill_no="QKI/055190/23-24",
+            bill_date="2023-09-01",
+            posting_date="2023-09-01",
+        )
+        pi_b = create_purchase_invoice(
+            bill_no="QKI/053612/23-24",
+            bill_date="2023-09-20",
+            posting_date="2023-09-20",
+        )
+        is_a = create_gst_inward_supply(
+            bill_no="QKI 055190 2023-24",
+            bill_date="2023-09-22",  # within 10 days of pi_b (the wrong cross-match)
+            return_period_2b="092023",
+        )
+        is_b = create_gst_inward_supply(
+            bill_no="QKI 053612 2023-24",
+            bill_date="2023-08-05",  # > 10 days from both purchases
+            return_period_2b="082023",
+        )
+
+        prt = frappe.get_doc("Purchase Reconciliation Tool")
+        prt.update(
+            {
+                "company_gstin": "24AAQCA8719H1ZC",
+                "purchase_period": "Custom",
+                "purchase_from_date": "2023-09-01",
+                "purchase_to_date": "2023-09-30",
+                "inward_supply_period": "Custom",
+                "inward_supply_from_date": "2023-08-01",
+                "inward_supply_to_date": "2023-09-30",
+                "gst_return": "GSTR 2B",
+            }
+        )
+        data = prt.reconcile_and_generate_data()
+
+        matched = {
+            r.purchase_invoice_name: r.inward_supply_name
+            for r in data
+            if r.purchase_invoice_name
+        }
+
+        self.assertNotEqual(matched.get(pi_b.name), is_a.name)
+        self.assertEqual(matched.get(pi_a.name), is_a.name)
+        self.assertEqual(matched.get(pi_b.name), is_b.name)
+
     def test_get_invoice_details_with_none_inward_supply_name(self):
         """
         get_invoice_details with inward_supply_name=None must not raise FrappeTypeError.

--- a/india_compliance/gst_india/doctype/purchase_reconciliation_tool/test_purchase_reconciliation_tool.py
+++ b/india_compliance/gst_india/doctype/purchase_reconciliation_tool/test_purchase_reconciliation_tool.py
@@ -385,11 +385,7 @@ class TestPurchaseReconciliationTool(IntegrationTestCase):
         )
         data = prt.reconcile_and_generate_data()
 
-        matched = {
-            r.purchase_invoice_name: r.inward_supply_name
-            for r in data
-            if r.purchase_invoice_name
-        }
+        matched = {r.purchase_invoice_name: r.inward_supply_name for r in data if r.purchase_invoice_name}
 
         self.assertNotEqual(matched.get(pi_b.name), is_a.name)
         self.assertEqual(matched.get(pi_a.name), is_a.name)


### PR DESCRIPTION
Issue: When a supplier had two invoices with the same GST amount and their bill numbers were stored in a slightly different format in GSTR-2A vs ERP, the tool could cross-match them — e.g. showing QKI/055190 (2A) as a "Suggested Match" to QKI/053612 (ERP), while the genuine same-number invoices were left as Missing in PI / Missing in 2A/2B.

Root cause: fuzzy_match applied the 10-day bill-date check before comparing the (normalized) bill numbers. For the same invoice booked with a >10 day date gap, every bill-number rule was skipped, so the pair fell through to the amount-only Residual Match rule, which paired invoices purely by tax amount and was then promoted to "Suggested Match".

Fix: Give the bill number preference over an amount-only match. Added a FUZZY_MATCH_WITHOUT_DATE rule (bill no matches, date ignored) to GSTIN_RULES, placed after the date-constrained bill rules and before the residual rule. Matching priority is now: bill + date → bill no → date + amount.


Frappe Support Issue: https://support.frappe.io/helpdesk/tickets/67857?view=VIEW-HD+Ticket-771