### PR TITLE
fix: auto selection of template in case of duplicate tax categories conditions

### DIFF
--- a/india_compliance/gst_india/client_scripts/tax_category.js
+++ b/india_compliance/gst_india/client_scripts/tax_category.js
@@ -1,0 +1,20 @@
+frappe.ui.form.on("Tax Category", {
+    refresh: set_field_states,
+    gst_state(frm) {
+        if (frm.doc.gst_state && frm.doc.is_india_compliance_default) {
+            frm.set_value("is_india_compliance_default", 0);
+        }
+        set_field_states(frm);
+    },
+    is_india_compliance_default(frm) {
+        if (frm.doc.is_india_compliance_default && frm.doc.gst_state) {
+            frm.set_value("gst_state", "");
+        }
+        set_field_states(frm);
+    },
+});
+
+function set_field_states(frm) {
+    frm.set_df_property("is_india_compliance_default", "read_only", Boolean(frm.doc.gst_state));
+    frm.set_df_property("gst_state", "read_only", Boolean(frm.doc.is_india_compliance_default));
+}

--- a/india_compliance/gst_india/constants/custom_fields.py
+++ b/india_compliance/gst_india/constants/custom_fields.py
@@ -1240,10 +1240,22 @@ CUSTOM_FIELDS = {
     ],
     "Tax Category": [
         {
+            "fieldname": "is_india_compliance_default",
+            "label": "India Compliance Default",
+            "fieldtype": "Check",
+            "insert_after": "disabled",
+            "print_hide": 1,
+            "no_copy": 1,
+            "description": (
+                "When enabled, this Tax Category is used for automatic GST tax template"
+                " selection for the given Inter State / Reverse Charge combination."
+            ),
+        },
+        {
             "fieldname": "is_inter_state",
             "label": "Is Inter State",
             "fieldtype": "Check",
-            "insert_after": "disabled",
+            "insert_after": "is_india_compliance_default",
             "print_hide": 1,
         },
         {

--- a/india_compliance/gst_india/data/tax_defaults.json
+++ b/india_compliance/gst_india/data/tax_defaults.json
@@ -3,24 +3,28 @@
         {
             "title": "In-State",
             "is_inter_state": 0,
-            "gst_state": ""
+            "gst_state": "",
+            "is_india_compliance_default": 1
         },
         {
             "title": "Out-State",
             "is_inter_state": 1,
-            "gst_state": ""
+            "gst_state": "",
+            "is_india_compliance_default": 1
         },
         {
             "title": "Reverse Charge In-State",
             "is_inter_state": 0,
             "is_reverse_charge": 1,
-            "gst_state": ""
+            "gst_state": "",
+            "is_india_compliance_default": 1
         },
         {
             "title": "Reverse Charge Out-State",
             "is_inter_state": 1,
             "is_reverse_charge": 1,
-            "gst_state": ""
+            "gst_state": "",
+            "is_india_compliance_default": 1
         },
         {
             "title": "Registered Composition",

--- a/india_compliance/gst_india/overrides/tax_category.py
+++ b/india_compliance/gst_india/overrides/tax_category.py
@@ -3,9 +3,30 @@ from frappe import _
 
 
 def validate(doc, method=None):
-    if doc.get("gst_state") and frappe.db.get_value(
+    if doc.get("is_india_compliance_default") and doc.get("gst_state"):
+        frappe.throw(_("India Compliance Default Tax Category cannot have a Source State"))
+
+    if doc.get("is_india_compliance_default"):
+        if frappe.db.exists(
+            "Tax Category",
+            {
+                "name": ["!=", doc.name],
+                "is_india_compliance_default": 1,
+                "is_inter_state": doc.is_inter_state,
+                "is_reverse_charge": doc.is_reverse_charge,
+            },
+        ):
+            frappe.throw(
+                _(
+                    "An India Compliance Default Tax Category already exists for this"
+                    " Inter State / Reverse Charge combination"
+                )
+            )
+
+    elif doc.get("gst_state") and frappe.db.exists(
         "Tax Category",
         {
+            "name": ["!=", doc.name],
             "gst_state": doc.gst_state,
             "is_inter_state": doc.is_inter_state,
             "is_reverse_charge": doc.is_reverse_charge,

--- a/india_compliance/gst_india/overrides/tax_category.py
+++ b/india_compliance/gst_india/overrides/tax_category.py
@@ -14,6 +14,7 @@ def validate(doc, method=None):
                 "is_india_compliance_default": 1,
                 "is_inter_state": doc.is_inter_state,
                 "is_reverse_charge": doc.is_reverse_charge,
+                "gst_state": ["is", "not set"],
             },
         )
         if existing:

--- a/india_compliance/gst_india/overrides/tax_category.py
+++ b/india_compliance/gst_india/overrides/tax_category.py
@@ -7,7 +7,7 @@ def validate(doc, method=None):
         frappe.throw(_("India Compliance Default Tax Category cannot have a Source State"))
 
     if doc.get("is_india_compliance_default"):
-        if frappe.db.exists(
+        existing = frappe.db.get_value(
             "Tax Category",
             {
                 "name": ["!=", doc.name],
@@ -15,12 +15,13 @@ def validate(doc, method=None):
                 "is_inter_state": doc.is_inter_state,
                 "is_reverse_charge": doc.is_reverse_charge,
             },
-        ):
+        )
+        if existing:
             frappe.throw(
                 _(
-                    "An India Compliance Default Tax Category already exists for this"
+                    "An India Compliance Default Tax Category {0} already exists for this"
                     " Inter State / Reverse Charge combination"
-                )
+                ).format(frappe.bold(frappe.utils.get_link_to_form("Tax Category", existing)))
             )
 
     elif doc.get("gst_state") and frappe.db.exists(

--- a/india_compliance/gst_india/overrides/test_company.py
+++ b/india_compliance/gst_india/overrides/test_company.py
@@ -34,6 +34,11 @@ class TestCompanyFixtures(IntegrationTestCase):
         # Check for tax category creations.
         self.assertTrue(frappe.db.exists("Tax Category", "Reverse Charge In-State"))
 
+        for row in get_tax_defaults()["tax_categories"]:
+            expected = bool(row.get("is_india_compliance_default"))
+            actual = bool(frappe.db.get_value("Tax Category", row["title"], "is_india_compliance_default"))
+            self.assertEqual(actual, expected)
+
     def test_get_tax_defaults(self):
         gst_rate = 12
         default_taxes = get_tax_defaults(gst_rate)

--- a/india_compliance/gst_india/overrides/test_tax_category.py
+++ b/india_compliance/gst_india/overrides/test_tax_category.py
@@ -83,6 +83,8 @@ class TestTaxCategoryAutoSelection(IntegrationTestCase):
             "_Test Gujarat In-State", is_inter_state=0, is_reverse_charge=0, gst_state=SOURCE_STATE
         )
         template = self._create_linked_template("_Test Gujarat In-State Template", category.name)
+        self.addCleanup(frappe.delete_doc, "Tax Category", category.name, force=True)
+        self.addCleanup(frappe.delete_doc, SALES_TEMPLATE, template, force=True)
 
         gst_details = self._sales_gst_details()
         self.assertEqual(gst_details.get("taxes_and_charges"), template)
@@ -97,9 +99,11 @@ class TestTaxCategoryAutoSelection(IntegrationTestCase):
         self.assertEqual(gst_details.get("taxes_and_charges"), DEFAULT_IN_STATE_TEMPLATE)
 
     def test_state_specific_category_without_template_falls_back_to_default(self):
-        self._create_tax_category(
+        category = self._create_tax_category(
             "_Test Gujarat No Template", is_inter_state=0, is_reverse_charge=0, gst_state=SOURCE_STATE
         )
+        # Remove this company-state category so it can't collide with the preferred-over-default test.
+        self.addCleanup(frappe.delete_doc, "Tax Category", category.name, force=True)
 
         gst_details = self._sales_gst_details()
         self.assertEqual(gst_details.get("taxes_and_charges"), DEFAULT_IN_STATE_TEMPLATE)

--- a/india_compliance/gst_india/overrides/test_tax_category.py
+++ b/india_compliance/gst_india/overrides/test_tax_category.py
@@ -21,20 +21,6 @@ GUJARAT_SUPPLIER_ADDRESS = "_Test Registered Supplier-Billing"
 
 
 class TestTaxCategoryAutoSelection(IntegrationTestCase):
-    @classmethod
-    def setUpClass(cls):
-        frappe.db.savepoint("before_test_tax_category")
-
-    @classmethod
-    def tearDownClass(cls):
-        frappe.db.rollback(save_point="before_test_tax_category")
-
-    def setUp(self):
-        frappe.db.savepoint("before_each_tax_category")
-
-    def tearDown(self):
-        frappe.db.rollback(save_point="before_each_tax_category")
-
     # ---------- helpers ----------
 
     def _create_tax_category(self, title, **flags):

--- a/india_compliance/gst_india/overrides/test_tax_category.py
+++ b/india_compliance/gst_india/overrides/test_tax_category.py
@@ -1,0 +1,196 @@
+import frappe
+from frappe.exceptions import ValidationError
+from frappe.tests import IntegrationTestCase
+
+from india_compliance.gst_india.overrides.company import get_tax_defaults
+from india_compliance.gst_india.overrides.transaction import get_gst_details
+from india_compliance.gst_india.utils.tests import create_transaction
+
+COMPANY = "_Test Indian Registered Company"
+COMPANY_ABBR = "_TIRC"
+COMPANY_GSTIN = "24AAQCA8719H1ZC"
+SALES_TEMPLATE = "Sales Taxes and Charges Template"
+PURCHASE_TEMPLATE = "Purchase Taxes and Charges Template"
+DEFAULT_IN_STATE_TEMPLATE = f"Output GST In-state - {COMPANY_ABBR}"
+# Company source state (GSTIN 24AAQCA8719H1ZC -> Gujarat)
+SOURCE_STATE = "Gujarat"
+# Gujarat address -> intra-state supply; Karnataka -> inter-state.
+GUJARAT_CUSTOMER_ADDRESS = "_Test Registered Customer-Billing"
+KARNATAKA_CUSTOMER_ADDRESS = "_Test Registered Customer-Billing-3"
+GUJARAT_SUPPLIER_ADDRESS = "_Test Registered Supplier-Billing"
+
+
+class TestTaxCategoryAutoSelection(IntegrationTestCase):
+    @classmethod
+    def setUpClass(cls):
+        frappe.db.savepoint("before_test_tax_category")
+
+    @classmethod
+    def tearDownClass(cls):
+        frappe.db.rollback(save_point="before_test_tax_category")
+
+    def setUp(self):
+        frappe.db.savepoint("before_each_tax_category")
+
+    def tearDown(self):
+        frappe.db.rollback(save_point="before_each_tax_category")
+
+    # ---------- helpers ----------
+
+    def _create_tax_category(self, title, **flags):
+        return frappe.get_doc({"doctype": "Tax Category", "title": title, **flags}).insert()
+
+    def _create_linked_template(self, title, tax_category):
+        """Clone the default In-State template, point it at a different Tax Category."""
+        template = frappe.copy_doc(frappe.get_doc(SALES_TEMPLATE, DEFAULT_IN_STATE_TEMPLATE))
+        template.title = title
+        template.tax_category = tax_category
+        template.is_default = 0
+        template.insert()
+        return template.name
+
+    def _gst_details(self, doctype="Sales Invoice", **party):
+        party.setdefault("company_gstin", COMPANY_GSTIN)
+        return get_gst_details(frappe._dict(party), doctype, COMPANY)
+
+    def _sales_gst_details(self, **party):
+        party.setdefault("customer", "_Test Registered Customer")
+        party.setdefault("customer_address", GUJARAT_CUSTOMER_ADDRESS)
+        return self._gst_details("Sales Invoice", **party)
+
+    def test_shipped_tax_categories_match_default_flag(self):
+        for row in get_tax_defaults()["tax_categories"]:
+            expected = bool(row.get("is_india_compliance_default"))
+            actual = bool(frappe.db.get_value("Tax Category", row["title"], "is_india_compliance_default"))
+            self.assertEqual(actual, expected, msg=f"{row['title']} default flag mismatch")
+
+    def test_default_scenarios_are_unique(self):
+        seen = set()
+        for row in get_tax_defaults()["tax_categories"]:
+            if not row.get("is_india_compliance_default"):
+                continue
+
+            scenario = (row.get("is_inter_state", 0), row.get("is_reverse_charge", 0))
+            self.assertNotIn(scenario, seen, msg=f"Duplicate default scenario {scenario}")
+            seen.add(scenario)
+
+    # ---------- a user category must not hijack selection ----------
+
+    def test_user_tax_category_does_not_hijack_selection(self):
+        category = self._create_tax_category("_Test Custom In-State", is_inter_state=0, is_reverse_charge=0)
+        self._create_linked_template("_Test Custom In-State Template", category.name)
+
+        gst_details = self._sales_gst_details()
+        self.assertEqual(gst_details.get("taxes_and_charges"), DEFAULT_IN_STATE_TEMPLATE)
+
+    def test_transaction_uses_default_template_despite_user_category(self):
+        category = self._create_tax_category("_Test Custom In-State 2", is_inter_state=0, is_reverse_charge=0)
+        self._create_linked_template("_Test Custom In-State Template 2", category.name)
+
+        doc = create_transaction(doctype="Sales Invoice", is_in_state=True, do_not_submit=True)
+        self.assertEqual(doc.taxes_and_charges, DEFAULT_IN_STATE_TEMPLATE)
+
+    # ---------- state-specific override precedence ----------
+
+    def test_state_specific_tax_category_is_preferred_over_default(self):
+        category = self._create_tax_category(
+            "_Test Gujarat In-State", is_inter_state=0, is_reverse_charge=0, gst_state=SOURCE_STATE
+        )
+        template = self._create_linked_template("_Test Gujarat In-State Template", category.name)
+
+        gst_details = self._sales_gst_details()
+        self.assertEqual(gst_details.get("taxes_and_charges"), template)
+
+    def test_state_specific_category_for_other_state_is_ignored(self):
+        category = self._create_tax_category(
+            "_Test Karnataka In-State", is_inter_state=0, is_reverse_charge=0, gst_state="Karnataka"
+        )
+        self._create_linked_template("_Test Karnataka In-State Template", category.name)
+
+        gst_details = self._sales_gst_details()
+        self.assertEqual(gst_details.get("taxes_and_charges"), DEFAULT_IN_STATE_TEMPLATE)
+
+    def test_state_specific_category_without_template_falls_back_to_default(self):
+        self._create_tax_category(
+            "_Test Gujarat No Template", is_inter_state=0, is_reverse_charge=0, gst_state=SOURCE_STATE
+        )
+
+        gst_details = self._sales_gst_details()
+        self.assertEqual(gst_details.get("taxes_and_charges"), DEFAULT_IN_STATE_TEMPLATE)
+
+    # ---------- inter-state & reverse-charge defaults still resolve ----------
+
+    def test_out_state_default_selection(self):
+        expected = frappe.db.get_value(
+            SALES_TEMPLATE, {"company": COMPANY, "tax_category": "Out-State", "disabled": 0}, "name"
+        )
+        gst_details = self._sales_gst_details(customer_address=KARNATAKA_CUSTOMER_ADDRESS)
+        self.assertEqual(gst_details.get("taxes_and_charges"), expected)
+
+    def test_purchase_reverse_charge_default_selection(self):
+        expected = frappe.db.get_value(
+            PURCHASE_TEMPLATE,
+            {"company": COMPANY, "tax_category": "Reverse Charge In-State", "disabled": 0},
+            "name",
+        )
+        self.assertTrue(expected, msg="default purchase reverse-charge template missing")
+
+        gst_details = self._gst_details(
+            doctype="Purchase Invoice",
+            supplier="_Test Registered Supplier",
+            supplier_address=GUJARAT_SUPPLIER_ADDRESS,
+            is_reverse_charge=1,
+        )
+        self.assertEqual(gst_details.get("taxes_and_charges"), expected)
+
+    def test_no_template_when_company_not_registered(self):
+        gst_details = get_gst_details(
+            frappe._dict(customer="_Test Registered Customer", customer_address=GUJARAT_CUSTOMER_ADDRESS),
+            "Sales Invoice",
+            "_Test Foreign Company",
+        )
+        self.assertFalse(gst_details.get("taxes_and_charges"))
+
+    # ---------- explicit tax category on the document wins ----------
+
+    def test_explicit_tax_category_overrides_auto_selection(self):
+        category = self._create_tax_category("_Test Explicit Category", is_inter_state=1, is_reverse_charge=1)
+        template = self._create_linked_template("_Test Explicit Template", category.name)
+
+        gst_details = self._sales_gst_details(tax_category=category.name)
+        self.assertEqual(gst_details.get("taxes_and_charges"), template)
+
+    def test_explicit_tax_category_without_template_falls_back(self):
+        category = self._create_tax_category(
+            "_Test Explicit No Template", is_inter_state=0, is_reverse_charge=0
+        )
+
+        gst_details = self._sales_gst_details(tax_category=category.name)
+        self.assertEqual(gst_details.get("taxes_and_charges"), DEFAULT_IN_STATE_TEMPLATE)
+
+    # ---------- validation ----------
+
+    def test_duplicate_india_compliance_default_is_blocked(self):
+        self.assertRaises(
+            ValidationError,
+            self._create_tax_category,
+            "_Test Duplicate Default",
+            is_inter_state=0,
+            is_reverse_charge=0,
+            is_india_compliance_default=1,
+        )
+
+    def test_state_specific_category_cannot_be_default(self):
+        self.assertRaises(
+            ValidationError,
+            self._create_tax_category,
+            "_Test State Default",
+            is_inter_state=0,
+            is_reverse_charge=0,
+            gst_state=SOURCE_STATE,
+            is_india_compliance_default=1,
+        )
+
+    def test_plain_user_tax_category_is_allowed(self):
+        category = self._create_tax_category("_Test Plain Category", is_inter_state=0, is_reverse_charge=0)
+        self.assertTrue(frappe.db.exists("Tax Category", category.name))

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -968,26 +968,34 @@ def get_tax_template_based_on_category(master_doctype, company, party_details):
 def get_tax_template(master_doctype, company, is_inter_state, state_code, is_reverse_charge):
     tax_categories = frappe.get_all(
         "Tax Category",
-        fields=["name", "is_inter_state", "gst_state"],
+        fields=["name", "gst_state"],
         filters={
             "is_inter_state": 1 if is_inter_state else 0,
             "is_reverse_charge": 1 if is_reverse_charge else 0,
             "disabled": 0,
         },
+        or_filters={"is_india_compliance_default": 1, "gst_state": ["!=", ""]},
     )
 
-    default_tax = ""
-
+    state_specific = []
+    default = []
     for tax_category in tax_categories:
-        if STATE_NUMBERS.get(tax_category.gst_state) == state_code or (
-            not default_tax and not tax_category.gst_state
-        ):
-            default_tax = frappe.db.get_value(
-                master_doctype,
-                {"company": company, "disabled": 0, "tax_category": tax_category.name},
-                "name",
-            )
-    return default_tax
+        if tax_category.gst_state:
+            if STATE_NUMBERS.get(tax_category.gst_state) == state_code:
+                state_specific.append(tax_category.name)
+        else:
+            default.append(tax_category.name)
+
+    for tax_category in state_specific + default:
+        default_tax = frappe.db.get_value(
+            master_doctype,
+            {"company": company, "disabled": 0, "tax_category": tax_category},
+            "name",
+        )
+        if default_tax:
+            return default_tax
+
+    return ""
 
 
 def validate_reverse_charge_transaction(doc):

--- a/india_compliance/hooks.py
+++ b/india_compliance/hooks.py
@@ -101,6 +101,7 @@ doctype_js = {
         "gst_india/client_scripts/party.js",
         "gst_india/client_scripts/supplier.js",
     ],
+    "Tax Category": "gst_india/client_scripts/tax_category.js",
     "Tax Withholding Category": "income_tax_india/client_scripts/tax_withholding_category.js",
     "Accounts Settings": "audit_trail/client_scripts/accounts_settings.js",
     "Customize Form": "audit_trail/client_scripts/customize_form.js",

--- a/india_compliance/patches.txt
+++ b/india_compliance/patches.txt
@@ -87,3 +87,4 @@ india_compliance.patches.v16.update_tax_id_for_tax_withholding_entries
 india_compliance.patches.v16.sync_financial_report_templates
 india_compliance.patches.v16.update_tds_section_display_name
 execute:import frappe; frappe.db.set_single_value("GST Settings", "nil_exempt_e_invoice_treatment", "Do Not Generate")
+india_compliance.patches.v15.set_india_compliance_default_tax_category

--- a/india_compliance/patches.txt
+++ b/india_compliance/patches.txt
@@ -5,7 +5,7 @@ execute:from frappe.installer import add_module_defs; add_module_defs("india_com
 
 [post_model_sync]
 india_compliance.patches.v14.set_default_for_overridden_accounts_setting
-execute:from india_compliance.gst_india.setup import create_custom_fields; create_custom_fields() #72
+execute:from india_compliance.gst_india.setup import create_custom_fields; create_custom_fields() #73
 execute:from india_compliance.gst_india.setup import create_property_setters; create_property_setters() #12
 execute:from india_compliance.income_tax_india.setup import create_custom_fields; create_custom_fields() #7
 india_compliance.patches.post_install.remove_old_fields #2

--- a/india_compliance/patches/v15/set_india_compliance_default_tax_category.py
+++ b/india_compliance/patches/v15/set_india_compliance_default_tax_category.py
@@ -1,0 +1,65 @@
+import frappe
+
+TEMPLATE_DOCTYPES = (
+    "Sales Taxes and Charges Template",
+    "Purchase Taxes and Charges Template",
+)
+
+DEFAULT_SCENARIOS = ((0, 0), (1, 0), (0, 1), (1, 1))
+
+
+def execute():
+    """Backfill the `is_india_compliance_default` flag on Tax Categories.
+
+    Automatic GST tax template selection now only considers Tax Categories flagged as
+    India Compliance defaults.
+    """
+    if not frappe.db.has_column("Tax Category", "is_india_compliance_default"):
+        return
+
+    if frappe.db.exists("Tax Category", {"is_india_compliance_default": 1}):
+        return
+
+    used_categories = set()
+    for master_doctype in TEMPLATE_DOCTYPES:
+        used_categories.update(
+            frappe.get_all(
+                master_doctype, filters={"disabled": 0, "tax_category": ["is", "set"]}, pluck="tax_category"
+            )
+        )
+    if not used_categories:
+        return
+
+    tax_categories = frappe.get_all(
+        "Tax Category",
+        fields=["name", "is_inter_state", "is_reverse_charge", "gst_state"],
+        filters={"disabled": 0, "gst_state": ["is", "not set"]},
+    )
+
+    defaults = []
+    for is_inter_state, is_reverse_charge in DEFAULT_SCENARIOS:
+        category = get_default_tax_category(
+            tax_categories, used_categories, is_inter_state, is_reverse_charge
+        )
+        if category:
+            defaults.append(category)
+
+    if not defaults:
+        return
+
+    tax_category = frappe.qb.DocType("Tax Category")
+    frappe.qb.update(tax_category).set(tax_category.is_india_compliance_default, 1).where(
+        tax_category.name.isin(defaults)
+    ).run()
+
+
+def get_default_tax_category(categories, used_categories, is_inter_state, is_reverse_charge):
+    for category in categories:
+        if (
+            category.is_inter_state == is_inter_state
+            and category.is_reverse_charge == is_reverse_charge
+            and category.name in used_categories
+        ):
+            return category.name
+
+    return None


### PR DESCRIPTION
Issue: The automatic Sales/Purchase tax template selection matched any Tax Category by is_inter_state / is_reverse_charge. A user-created Tax Category defaults to the same flags as the shipped In-State, so it could shadow the default and the wrong (or a non-deterministic) template was applied.

Solution: 
- Introduce an editable is_india_compliance_default flag on Tax Category 
- Make selection consider only IC defaults plus user state-specific overrides
- Resolve deterministically (state-specific → default, skipping categories without a template).

A category with states cannot be the default.

<img width="1726" height="856" alt="image" src="https://github.com/user-attachments/assets/9839b9f8-0845-452d-8a45-eccffc111cd9" />
<img width="980" height="390" alt="image" src="https://github.com/user-attachments/assets/98207754-4d7a-4be1-b185-ad440868c2d1" />
