### PR TITLE
fix: payment reconciliation with GST on advance payments

### DIFF
--- a/india_compliance/gst_india/overrides/payment_entry.py
+++ b/india_compliance/gst_india/overrides/payment_entry.py
@@ -95,7 +95,8 @@ def on_submit(doc, method=None):
 
 
 def on_update_after_submit(doc, method=None):
-    make_gst_revesal_entry_from_advance_payment(doc)
+    # outstanding reduced by allocated_amount via_reconciliation (see reconcile_against_document)
+    make_gst_revesal_entry_from_advance_payment(doc, via_reconciliation=True)
 
 
 def before_cancel(doc, method=None):
@@ -139,7 +140,7 @@ def update_party_details(party_details: str | dict | frappe._dict, doctype: str,
     return response
 
 
-def make_gst_revesal_entry_from_advance_payment(doc):
+def make_gst_revesal_entry_from_advance_payment(doc, via_reconciliation=False):
     """
     This functionality aims to create a GST reversal entry where GST was paid in advance
 
@@ -147,7 +148,7 @@ def make_gst_revesal_entry_from_advance_payment(doc):
     On Update after Submit: Creates GLEs for new references. Creates PLEs for all references.
     """
     gl_dict = []
-    update_gl_for_advance_gst_reversal(gl_dict, doc)
+    update_gl_for_advance_gst_reversal(gl_dict, doc, via_reconciliation)
 
     if not gl_dict:
         return
@@ -156,7 +157,7 @@ def make_gst_revesal_entry_from_advance_payment(doc):
     make_gl_entries(gl_dict)
 
 
-def update_gl_for_advance_gst_reversal(gl_dict, doc):
+def update_gl_for_advance_gst_reversal(gl_dict, doc, via_reconciliation=False):
     if not doc.taxes:
         return
 
@@ -164,10 +165,10 @@ def update_gl_for_advance_gst_reversal(gl_dict, doc):
         if row.reference_doctype not in ("Sales Invoice", "Journal Entry"):
             continue
 
-        gl_dict.extend(_get_gl_for_advance_gst_reversal(doc, row))
+        gl_dict.extend(_get_gl_for_advance_gst_reversal(doc, row, via_reconciliation))
 
 
-def _get_gl_for_advance_gst_reversal(payment_entry, reference_row):
+def _get_gl_for_advance_gst_reversal(payment_entry, reference_row, via_reconciliation=False):
     gl_dicts = []
     voucher_date = frappe.db.get_value(
         reference_row.reference_doctype, reference_row.reference_name, "posting_date"
@@ -218,8 +219,13 @@ def _get_gl_for_advance_gst_reversal(payment_entry, reference_row):
         return gl_dicts
 
     if not frappe.flags.gst_excess_allocation_validated:
+        outstanding_amount = reference_row.outstanding_amount
+        if via_reconciliation:
+            # add back allocated_amount to outstanding_amount for comparison
+            outstanding_amount += reference_row.allocated_amount
+
         total_allocation = total_amount + reference_row.allocated_amount
-        excess_allocation = total_allocation - reference_row.outstanding_amount
+        excess_allocation = total_allocation - outstanding_amount
 
         if excess_allocation > 1:
             frappe.throw(
@@ -227,7 +233,7 @@ def _get_gl_for_advance_gst_reversal(payment_entry, reference_row):
                     "Outstanding amount {0} is less than the total allocated amount"
                     " with taxes {1} for {2} {3}"
                 ).format(
-                    reference_row.outstanding_amount,
+                    outstanding_amount,
                     total_allocation,
                     reference_row.reference_doctype,
                     reference_row.reference_name,
@@ -283,15 +289,22 @@ def get_proportionate_taxes_for_reversal(payment_entry, reference_row):
     return get_proportionate_taxes_for_row(payment_entry, reference_row, taxes)
 
 
+def get_taxable_base_amount(payment_entry):
+    # taxable value. exclusive -> base_paid_amount, inclusive -> base_paid_amount - included_taxes
+    return flt(payment_entry.base_paid_amount) - flt(payment_entry.get_included_taxes())
+
+
 def get_proportionate_taxes_for_row(payment_entry, reference_row, taxes):
     base_allocated_amount = payment_entry.calculate_base_allocated_amount_for_reference(reference_row)
+    base_amount = get_taxable_base_amount(payment_entry)
     for account, amount in taxes.items():
-        taxes[account] = flt(amount * base_allocated_amount / payment_entry.base_paid_amount, 2)
+        taxes[account] = flt(amount * base_allocated_amount / base_amount, 2)
 
     return taxes
 
 
 def balance_taxes(payment_entry, reference_row, taxes):
+    base_amount = get_taxable_base_amount(payment_entry)
     for account, amount in taxes.items():
         for allocation_row in payment_entry.references:
             if allocation_row.reference_name == reference_row.reference_name:
@@ -300,7 +313,7 @@ def balance_taxes(payment_entry, reference_row, taxes):
             taxes[account] = taxes[account] - flt(
                 amount
                 * payment_entry.calculate_base_allocated_amount_for_reference(allocation_row)
-                / payment_entry.base_paid_amount,
+                / base_amount,
                 2,
             )
 
@@ -369,7 +382,7 @@ def adjust_allocations_for_taxes_in_payment_reconciliation(doc):
         tax.payment_entry: frappe._dict(
             {
                 **tax,
-                "paid_proportion": tax.paid_amount / (tax.paid_amount + tax.tax_amount),
+                "paid_proportion": tax.taxable_amount / (tax.taxable_amount + tax.tax_amount),
             }
         )
         for tax in taxes.values()
@@ -428,5 +441,24 @@ def get_taxes_summary(company, payment_entries):
     )
 
     taxes = {tax.payment_entry: tax for tax in taxes}
+
+    if not taxes:
+        return taxes
+
+    # carve out GST embedded in paid_amount (included_in_paid_amount); exclusive -> 0
+    pe_tax = frappe.qb.DocType("Advance Taxes and Charges")
+    included_taxes = (
+        frappe.qb.from_(pe_tax)
+        .select(pe_tax.parent, Sum(pe_tax.base_tax_amount).as_("included_taxes"))
+        .where(pe_tax.parent.isin(list(taxes.keys())))
+        .where(pe_tax.included_in_paid_amount == 1)
+        .where(pe_tax.account_head.isin(gst_accounts))
+        .groupby(pe_tax.parent)
+        .run(as_dict=True)
+    )
+    included_taxes = {row.parent: flt(row.included_taxes) for row in included_taxes}
+
+    for payment_entry, tax in taxes.items():
+        tax.taxable_amount = flt(tax.paid_amount) - included_taxes.get(payment_entry, 0)
 
     return taxes

--- a/india_compliance/gst_india/overrides/payment_entry.py
+++ b/india_compliance/gst_india/overrides/payment_entry.py
@@ -218,27 +218,25 @@ def _get_gl_for_advance_gst_reversal(payment_entry, reference_row, via_reconcili
 
         return gl_dicts
 
-    if not frappe.flags.gst_excess_allocation_validated:
-        outstanding_amount = reference_row.outstanding_amount
-        if via_reconciliation:
-            # add back allocated_amount to outstanding_amount for comparison
-            outstanding_amount += reference_row.allocated_amount
+    outstanding_amount = reference_row.outstanding_amount
+    if via_reconciliation:
+        # add back allocated_amount to outstanding_amount for comparison
+        outstanding_amount += reference_row.allocated_amount
 
-        total_allocation = total_amount + reference_row.allocated_amount
-        excess_allocation = total_allocation - outstanding_amount
+    total_allocation = total_amount + reference_row.allocated_amount
+    excess_allocation = total_allocation - outstanding_amount
 
-        if excess_allocation > 1:
-            frappe.throw(
-                _(
-                    "Outstanding amount {0} is less than the total allocated amount"
-                    " with taxes {1} for {2} {3}"
-                ).format(
-                    outstanding_amount,
-                    total_allocation,
-                    reference_row.reference_doctype,
-                    reference_row.reference_name,
-                )
+    if excess_allocation > 1:
+        frappe.throw(
+            _(
+                "Outstanding amount {0} is less than the total allocated amount with taxes {1} for {2} {3}"
+            ).format(
+                outstanding_amount,
+                total_allocation,
+                reference_row.reference_doctype,
+                reference_row.reference_name,
             )
+        )
 
     gl_dicts.append(gl_entry)
 

--- a/india_compliance/gst_india/overrides/payment_entry.py
+++ b/india_compliance/gst_india/overrides/payment_entry.py
@@ -292,11 +292,19 @@ def get_taxable_base_amount(payment_entry):
     return flt(payment_entry.base_paid_amount) - flt(payment_entry.get_included_taxes())
 
 
+def get_proportionate_tax(amount, base_allocated_amount, base_amount):
+    # base_amount is 0 only when paid amount is fully tax (no taxable base) -> nothing to reverse
+    if not base_amount:
+        return 0
+
+    return flt(amount * base_allocated_amount / base_amount, 2)
+
+
 def get_proportionate_taxes_for_row(payment_entry, reference_row, taxes):
     base_allocated_amount = payment_entry.calculate_base_allocated_amount_for_reference(reference_row)
     base_amount = get_taxable_base_amount(payment_entry)
     for account, amount in taxes.items():
-        taxes[account] = flt(amount * base_allocated_amount / base_amount, 2)
+        taxes[account] = get_proportionate_tax(amount, base_allocated_amount, base_amount)
 
     return taxes
 
@@ -308,11 +316,10 @@ def balance_taxes(payment_entry, reference_row, taxes):
             if allocation_row.reference_name == reference_row.reference_name:
                 continue
 
-            taxes[account] = taxes[account] - flt(
-                amount
-                * payment_entry.calculate_base_allocated_amount_for_reference(allocation_row)
-                / base_amount,
-                2,
+            taxes[account] = taxes[account] - get_proportionate_tax(
+                amount,
+                payment_entry.calculate_base_allocated_amount_for_reference(allocation_row),
+                base_amount,
             )
 
     return taxes

--- a/india_compliance/gst_india/overrides/payment_entry.py
+++ b/india_compliance/gst_india/overrides/payment_entry.py
@@ -407,6 +407,30 @@ def adjust_allocations_for_taxes_in_payment_reconciliation(doc):
         )
 
 
+def get_included_taxes_query(gst_accounts, payment_entries=None):
+    """
+    Subquery summing the GST embedded in paid_amount per Payment Entry
+    (taxes flagged `included_in_paid_amount` on tax-inclusive advances).
+    Exclusive payments have no such taxes, so they contribute no row -> 0.
+    """
+    pe_tax = frappe.qb.DocType("Advance Taxes and Charges")
+    query = (
+        frappe.qb.from_(pe_tax)
+        .select(
+            pe_tax.parent,
+            Sum(pe_tax.base_tax_amount).as_("included_taxes"),
+        )
+        .where(pe_tax.included_in_paid_amount == 1)
+        .where(pe_tax.account_head.isin(gst_accounts))
+        .groupby(pe_tax.parent)
+    )
+
+    if payment_entries is not None:
+        query = query.where(pe_tax.parent.isin(payment_entries))
+
+    return query
+
+
 def get_taxes_summary(company, payment_entries):
     gst_accounts = get_all_gst_accounts(company)
     if not gst_accounts:
@@ -451,15 +475,8 @@ def get_taxes_summary(company, payment_entries):
         return taxes
 
     # carve out GST embedded in paid_amount (included_in_paid_amount); exclusive -> 0
-    pe_tax = frappe.qb.DocType("Advance Taxes and Charges")
-    included_taxes = (
-        frappe.qb.from_(pe_tax)
-        .select(pe_tax.parent, Sum(pe_tax.base_tax_amount).as_("included_taxes"))
-        .where(pe_tax.parent.isin(list(taxes.keys())))
-        .where(pe_tax.included_in_paid_amount == 1)
-        .where(pe_tax.account_head.isin(gst_accounts))
-        .groupby(pe_tax.parent)
-        .run(as_dict=True)
+    included_taxes = get_included_taxes_query(gst_accounts, payment_entries=list(taxes.keys())).run(
+        as_dict=True
     )
     included_taxes = {row.parent: flt(row.included_taxes) for row in included_taxes}
 

--- a/india_compliance/gst_india/overrides/sales_invoice.py
+++ b/india_compliance/gst_india/overrides/sales_invoice.py
@@ -342,9 +342,10 @@ def set_and_validate_advances_with_gst(doc):
         if not advance.allocated_amount:
             continue
 
-        tax_row = taxes.get(advance.reference_name, frappe._dict(paid_amount=1, tax_amount=0))
+        tax_row = taxes.get(advance.reference_name, frappe._dict(taxable_amount=1, tax_amount=0))
 
-        _tax_amount = flt(advance.allocated_amount / tax_row.paid_amount * tax_row.tax_amount, 2)
+        # proportion off net base so inclusive (paid_amount = gross) reverses like exclusive
+        _tax_amount = flt(advance.allocated_amount / tax_row.taxable_amount * tax_row.tax_amount, 2)
         tax_amount += _tax_amount
         allocated_amount_with_taxes += _tax_amount
         allocated_amount_with_taxes += advance.allocated_amount
@@ -370,4 +371,3 @@ def set_and_validate_advances_with_gst(doc):
 
     PaymentScheduleService(doc).set_payment_schedule()
     doc.outstanding_amount -= tax_amount
-    frappe.flags.gst_excess_allocation_validated = True

--- a/india_compliance/gst_india/overrides/sales_invoice.py
+++ b/india_compliance/gst_india/overrides/sales_invoice.py
@@ -5,7 +5,10 @@ from frappe.desk.form.load import run_onload
 from frappe.utils import flt, fmt_money
 
 from india_compliance.gst_india.constants import VALID_HSN_LENGTHS
-from india_compliance.gst_india.overrides.payment_entry import get_taxes_summary
+from india_compliance.gst_india.overrides.payment_entry import (
+    get_proportionate_tax,
+    get_taxes_summary,
+)
 from india_compliance.gst_india.overrides.transaction import (
     _validate_hsn_codes,
     ignore_gst_validations,
@@ -345,7 +348,9 @@ def set_and_validate_advances_with_gst(doc):
         tax_row = taxes.get(advance.reference_name, frappe._dict(taxable_amount=1, tax_amount=0))
 
         # proportion off net base so inclusive (paid_amount = gross) reverses like exclusive
-        _tax_amount = flt(advance.allocated_amount / tax_row.taxable_amount * tax_row.tax_amount, 2)
+        _tax_amount = get_proportionate_tax(
+            tax_row.tax_amount, advance.allocated_amount, tax_row.taxable_amount
+        )
         tax_amount += _tax_amount
         allocated_amount_with_taxes += _tax_amount
         allocated_amount_with_taxes += advance.allocated_amount

--- a/india_compliance/gst_india/overrides/test_advance_payment_entry.py
+++ b/india_compliance/gst_india/overrides/test_advance_payment_entry.py
@@ -18,8 +18,10 @@ from erpnext.controllers.accounts_controller import (
 )
 from erpnext.controllers.stock_controller import show_accounting_ledger_preview
 from frappe.tests import IntegrationTestCase
-from frappe.utils import flt
+from frappe.utils import flt, getdate
 
+from india_compliance.gst_india.utils.gstr_1 import GSTR1_DataField as inv_f
+from india_compliance.gst_india.utils.gstr_1.gstr_1_json_map import GSTR1BooksData
 from india_compliance.gst_india.utils.tests import create_transaction
 
 
@@ -748,6 +750,12 @@ class TestPaymentReconciliationMatrix(IntegrationTestCase):
             {invoice_doc.name: inv_pl, payment_doc.name: pe_pl},
         )
 
+        # --- GSTR-1 advance reporting (11A received / 11B adjusted) ---
+        # taxable values must be NET of GST however inclusivity is entered:
+        # 11A = full advance base 500 @ 18%; 11B = net adjusted 100 @ 18% (negative).
+        # (gross paid 590 of an inclusive advance would wrongly report rate 15%.)
+        self._assert_advance_report(payment_doc, received=500.0, adjusted=-100.0)
+
         # --- unreconcile round-trip: ledgers return to the pure-advance snapshot ---
         self._unreconcile(payment_doc, invoice_doc)
         self.assertEqual(self._gl_net_by_account(payment_doc), advance_gl, "GL should revert on unreconcile")
@@ -757,6 +765,9 @@ class TestPaymentReconciliationMatrix(IntegrationTestCase):
             118.0,
             "invoice outstanding should be restored on unreconcile",
         )
+
+        # 11A still shows the (now partly adjusted) advance; the 11B adjustment is gone
+        self._assert_advance_report(payment_doc, received=500.0, adjusted=None)
 
     # ---- builders ----
 
@@ -828,6 +839,42 @@ class TestPaymentReconciliationMatrix(IntegrationTestCase):
                 ]
             )
         )
+
+    # ---- GSTR-1 advance reporting helpers (11A received / 11B adjusted) ----
+
+    def _assert_advance_report(self, payment_doc, received, adjusted):
+        books = GSTR1BooksData(
+            filters=frappe._dict(
+                company=payment_doc.company,
+                company_gstin=payment_doc.company_gstin,
+                from_date=getdate(),
+                to_date=getdate(),
+            )
+        )
+
+        # 11A Advances Received: full advance base, reported net of GST
+        self._assert_advance_row(books.prepare_advances_recevied_data(), payment_doc.name, received)
+        # 11B Advances Adjusted: net adjusted base, reported negative
+        self._assert_advance_row(books.prepare_advances_adjusted_data(), payment_doc.name, adjusted)
+
+    def _assert_advance_row(self, prepared, payment_name, taxable_value):
+        row = next(
+            (r for rows in prepared.values() for r in rows if r[inv_f.DOC_NUMBER] == payment_name),
+            None,
+        )
+
+        if taxable_value is None:
+            self.assertIsNone(row, f"no advance row expected for {payment_name}")
+            return
+
+        self.assertIsNotNone(row, f"advance row expected for {payment_name}")
+        self.assertEqual(row[inv_f.TAX_RATE], 18)
+        self.assertEqual(flt(row[inv_f.TAXABLE_VALUE], 2), taxable_value)
+        # intra-state @ 18% => CGST 9% + SGST 9%, no IGST/cess
+        self.assertEqual(flt(row[inv_f.CGST], 2), flt(taxable_value * 0.09, 2))
+        self.assertEqual(flt(row[inv_f.SGST], 2), flt(taxable_value * 0.09, 2))
+        self.assertEqual(flt(row[inv_f.IGST], 2), 0.0)
+        self.assertEqual(flt(row[inv_f.CESS], 2), 0.0)
 
     # ---- ledger helpers (net per account / per against-voucher, drops zero nets) ----
 

--- a/india_compliance/gst_india/overrides/test_advance_payment_entry.py
+++ b/india_compliance/gst_india/overrides/test_advance_payment_entry.py
@@ -18,6 +18,7 @@ from erpnext.controllers.accounts_controller import (
 )
 from erpnext.controllers.stock_controller import show_accounting_ledger_preview
 from frappe.tests import IntegrationTestCase
+from frappe.utils import flt
 
 from india_compliance.gst_india.utils.tests import create_transaction
 
@@ -213,7 +214,8 @@ class TestAdvancePaymentEntry(IntegrationTestCase):
         )
         self.assertEqual(out_str, expected_str)
 
-    def validate_payment_entry_allocation(self):
+    def test_over_allocated_advance_payment_raises(self):
+        # allocating more than the invoice outstanding (incl. the GST reversal) must raise
         invoice_doc = self._create_sales_invoice()
         payment_doc = self._create_payment_entry(do_not_submit=True)
 
@@ -348,6 +350,38 @@ class TestAdvancePaymentEntry(IntegrationTestCase):
                 {"amount": -440.68, "against_voucher_no": payment_doc.name},
             ],
         )
+
+    def test_payment_entry_allocation_with_inclusive_tax_invoice(self):
+        """
+        Reconcile an advance payment (with GST) against a tax-inclusive
+        Sales Invoice.
+        """
+        payment_doc = self._create_payment_entry()
+        invoice_doc = self._create_inclusive_sales_invoice()
+
+        # invoice: rate 100 inclusive of 18% GST => net 84.75, tax 15.25, grand total 100
+        self.assertEqual(invoice_doc.grand_total, 100)
+        self.assertEqual(invoice_doc.outstanding_amount, 100)
+
+        # Should reconcile without raising.
+        make_payment_reconciliation(payment_doc, invoice_doc, 100)
+
+        # Fully reconciled apart from a 1-paisa residual
+        outstanding_amount = frappe.db.get_value("Sales Invoice", invoice_doc.name, "outstanding_amount")
+        self.assertEqual(flt(outstanding_amount, 2), -0.01)
+
+    def _create_inclusive_sales_invoice(self):
+        invoice_doc = create_transaction(
+            doctype="Sales Invoice",
+            is_in_state=1,
+            do_not_save=True,
+        )
+        for tax in invoice_doc.taxes:
+            tax.included_in_print_rate = 1
+
+        invoice_doc.submit()
+
+        return invoice_doc
 
     def _create_sales_invoice(self, payment_doc=None):
         invoice_doc = create_transaction(

--- a/india_compliance/gst_india/overrides/test_advance_payment_entry.py
+++ b/india_compliance/gst_india/overrides/test_advance_payment_entry.py
@@ -584,3 +584,274 @@ def make_payment_reconciliation(payment_doc, invoice_doc, amount):
     pr.allocate_entries(frappe._dict({"invoices": invoices, "payments": payments}))
     pr.allocation[0].allocated_amount = amount
     pr.reconcile()
+
+
+# ---------------------------------------------------------------------------
+# Full matrix: payment {inclusive, exclusive} x invoice {inclusive, exclusive}
+# x flow {reconciliation tool, advance-in-invoice}.
+#
+# Every cell is the SAME economic event, so a correct implementation must produce
+# identical ledgers however tax-inclusivity is entered:
+#   advance: base 500 + 18% GST = 590 cash  (excl: paid 500 + tax; incl: paid 590 carved)
+#   invoice: net 100 + 18% GST = 118 grand   (excl: rate 100 + tax; incl: rate 118 carved)
+# Full reconcile consumes 100 of base, reverses 90*100/500 = 18 GST exactly, 400 left.
+# ---------------------------------------------------------------------------
+
+# net (debit - credit) per account on the Payment Entry after a full reconcile
+MATRIX_RECONCILED_GL: dict = {
+    "Cash - _TIRC": 590.0,  # full cash received: 500 base + 90 GST
+    "Debtors - _TIRC": -518.0,  # 500 advance + 18 GST reversal (both credits)
+    "Output Tax CGST - _TIRC": -36.0,  # 45 charged on advance - 9 reversed
+    "Output Tax SGST - _TIRC": -36.0,
+}
+# separate-account variant (book_advance_payments_in_separate_party_account)
+MATRIX_RECONCILED_GL_SEPARATE: dict = {
+    "Cash - _TIRC": 590.0,
+    "Creditors - _TIRC": -400.0,  # 500 advance liability - 100 reclassed to receivable
+    "Debtors - _TIRC": -118.0,  # 100 reclass + 18 GST reversal
+    "Output Tax CGST - _TIRC": -36.0,
+    "Output Tax SGST - _TIRC": -36.0,
+}
+
+
+class TestPaymentReconciliationMatrix(IntegrationTestCase):
+    # ---- the 8 core cells (no separate party account) ----
+
+    def test_excl_payment_excl_invoice_via_reconcile_tool(self):
+        self._run_cell(payment_inclusive=False, invoice_inclusive=False, flow="reconcile_tool")
+
+    def test_excl_payment_excl_invoice_via_advance_in_invoice(self):
+        self._run_cell(payment_inclusive=False, invoice_inclusive=False, flow="advance_in_invoice")
+
+    def test_excl_payment_incl_invoice_via_reconcile_tool(self):
+        self._run_cell(payment_inclusive=False, invoice_inclusive=True, flow="reconcile_tool")
+
+    def test_excl_payment_incl_invoice_via_advance_in_invoice(self):
+        self._run_cell(payment_inclusive=False, invoice_inclusive=True, flow="advance_in_invoice")
+
+    def test_incl_payment_excl_invoice_via_reconcile_tool(self):
+        self._run_cell(payment_inclusive=True, invoice_inclusive=False, flow="reconcile_tool")
+
+    def test_incl_payment_excl_invoice_via_advance_in_invoice(self):
+        self._run_cell(payment_inclusive=True, invoice_inclusive=False, flow="advance_in_invoice")
+
+    def test_incl_payment_incl_invoice_via_reconcile_tool(self):
+        self._run_cell(payment_inclusive=True, invoice_inclusive=True, flow="reconcile_tool")
+
+    def test_incl_payment_incl_invoice_via_advance_in_invoice(self):
+        self._run_cell(payment_inclusive=True, invoice_inclusive=True, flow="advance_in_invoice")
+
+    # ---- representative separate-party-account coverage ----
+
+    @toggle_seperate_advance_accounting()
+    def test_separate_account_excl_payment_via_advance_in_invoice(self):
+        self._run_cell(
+            payment_inclusive=False,
+            invoice_inclusive=False,
+            flow="advance_in_invoice",
+            reconciled_gl=MATRIX_RECONCILED_GL_SEPARATE,
+            pe_pl=400.0,
+        )
+
+    @toggle_seperate_advance_accounting()
+    def test_separate_account_incl_payment_via_advance_in_invoice(self):
+        self._run_cell(
+            payment_inclusive=True,
+            invoice_inclusive=False,
+            flow="advance_in_invoice",
+            reconciled_gl=MATRIX_RECONCILED_GL_SEPARATE,
+            pe_pl=400.0,
+        )
+
+    def test_multiple_advances_in_one_invoice(self):
+        # two advances (one exclusive, one inclusive) fully cover one invoice via the
+        # advances table; the per-reference reversal + over-allocation check must hold
+        # for each reference (the cells above cover only a single advance)
+        pay_excl = self._matrix_payment(inclusive=False)
+        pay_incl = self._matrix_payment(inclusive=True)
+
+        # invoice net 200 + 18% GST = 236 grand; allocate net 100 from each advance
+        invoice_doc = create_transaction(doctype="Sales Invoice", is_in_state=1, rate=200, do_not_save=True)
+        invoice_doc.save()
+        invoice_doc.set_advances()
+        for row in invoice_doc.advances:
+            row.allocated_amount = 100 if row.reference_name in (pay_excl.name, pay_incl.name) else 0
+        invoice_doc.submit()
+
+        self.assertEqual(flt(invoice_doc.net_total, 2), 200.0)
+        self.assertEqual(
+            flt(frappe.db.get_value("Sales Invoice", invoice_doc.name, "outstanding_amount"), 2),
+            0.0,
+            "invoice should be fully cleared by both advances",
+        )
+        # each advance reverses its own proportional GST (90 * 100 / 500 = 18 each)
+        for pay in (pay_excl, pay_incl):
+            refs = [
+                r
+                for r in frappe.get_doc("Payment Entry", pay.name).references
+                if r.reference_name == invoice_doc.name
+            ]
+            self.assertEqual(len(refs), 1)
+            self.assertEqual(flt(refs[0].allocated_amount, 2), 100.0)
+
+    # ---- shared workflow ----
+
+    def _run_cell(
+        self,
+        payment_inclusive,
+        invoice_inclusive,
+        flow,
+        reconciled_gl=None,
+        inv_pl=-118.0,
+        pe_pl=-400.0,
+    ):
+        reconciled_gl = reconciled_gl or MATRIX_RECONCILED_GL
+
+        payment_doc = self._matrix_payment(inclusive=payment_inclusive)
+        # economic setup sanity: both inclusive and exclusive advances are base 500 + GST 90
+        self.assertEqual(flt(payment_doc.total_taxes_and_charges, 2), 90.0, "advance GST should be 90")
+        self.assertEqual(flt(payment_doc.unallocated_amount, 2), 500.0, "advance base should be 500")
+
+        # snapshot the pure-advance ledgers to assert the unreconcile round-trip later
+        advance_gl = self._gl_net_by_account(payment_doc)
+        advance_pl = self._pl_net_by_voucher(payment_doc)
+
+        if flow == "advance_in_invoice":
+            invoice_doc = self._matrix_invoice(inclusive=invoice_inclusive, advance_payment=payment_doc)
+        else:
+            invoice_doc = self._matrix_invoice(inclusive=invoice_inclusive)
+            make_payment_reconciliation(payment_doc, invoice_doc, invoice_doc.grand_total)
+
+        self.assertEqual(flt(invoice_doc.net_total, 2), 100.0, "invoice net should be 100")
+        self.assertEqual(flt(invoice_doc.grand_total, 2), 118.0, "invoice grand total should be 118")
+
+        # --- fully reconciled state ---
+        self.assertEqual(
+            flt(frappe.db.get_value("Sales Invoice", invoice_doc.name, "outstanding_amount"), 2),
+            0.0,
+            "invoice should be fully reconciled",
+        )
+
+        refs = [
+            r
+            for r in frappe.get_doc("Payment Entry", payment_doc.name).references
+            if r.reference_name == invoice_doc.name
+        ]
+        self.assertEqual(len(refs), 1, "expected exactly one PE reference to the invoice")
+        self.assertEqual(flt(refs[0].allocated_amount, 2), 100.0, "reference allocated should be net 100")
+        self.assertEqual(flt(refs[0].total_amount, 2), 118.0, "reference total should be grand 118")
+
+        self.assertEqual(self._gl_net_by_account(payment_doc), reconciled_gl)
+        self.assertEqual(
+            self._pl_net_by_voucher(payment_doc),
+            {invoice_doc.name: inv_pl, payment_doc.name: pe_pl},
+        )
+
+        # --- unreconcile round-trip: ledgers return to the pure-advance snapshot ---
+        self._unreconcile(payment_doc, invoice_doc)
+        self.assertEqual(self._gl_net_by_account(payment_doc), advance_gl, "GL should revert on unreconcile")
+        self.assertEqual(self._pl_net_by_voucher(payment_doc), advance_pl, "PL should revert on unreconcile")
+        self.assertEqual(
+            flt(frappe.db.get_value("Sales Invoice", invoice_doc.name, "outstanding_amount"), 2),
+            118.0,
+            "invoice outstanding should be restored on unreconcile",
+        )
+
+    # ---- builders ----
+
+    def _matrix_payment(self, inclusive=False):
+        paid_amount = 590 if inclusive else 500
+        payment_doc = create_transaction(
+            doctype="Payment Entry",
+            payment_type="Receive",
+            mode_of_payment="Cash",
+            company_address="_Test Indian Registered Company-Billing",
+            party_type="Customer",
+            party="_Test Registered Customer",
+            customer_address="_Test Registered Customer-Billing",
+            paid_to="Cash - _TIRC",
+            paid_amount=paid_amount,
+            is_in_state=1,
+            do_not_save=True,
+        )
+        if inclusive:
+            for tax in payment_doc.taxes:
+                tax.included_in_paid_amount = 1
+                # mirror the client: set computed tax so get_included_taxes (runs before
+                # apply_taxes) doesn't hit a None base_tax_amount; apply_taxes re-derives it
+                tax.tax_amount = 45
+                tax.base_tax_amount = 45
+
+        payment_doc.setup_party_account_field()
+        payment_doc.set_missing_values()
+        payment_doc.set_exchange_rate()
+        payment_doc.received_amount = payment_doc.paid_amount / payment_doc.target_exchange_rate
+        payment_doc.save()
+        payment_doc.submit()
+
+        return payment_doc
+
+    def _matrix_invoice(self, inclusive=False, advance_payment=None):
+        # exclusive: rate 100 + 18% on top; inclusive: rate 118 with tax embedded -> net 100
+        rate = 118 if inclusive else 100
+        invoice_doc = create_transaction(
+            doctype="Sales Invoice",
+            is_in_state=1,
+            rate=rate,
+            do_not_save=True,
+        )
+        if inclusive:
+            for tax in invoice_doc.taxes:
+                tax.included_in_print_rate = 1
+
+        invoice_doc.save()
+
+        if advance_payment:
+            invoice_doc.set_advances()
+            for row in invoice_doc.advances:
+                row.allocated_amount = (
+                    invoice_doc.net_total if row.reference_name == advance_payment.name else 0
+                )
+
+        invoice_doc.submit()
+
+        return invoice_doc
+
+    def _unreconcile(self, payment_doc, invoice_doc):
+        create_unreconcile_doc_for_selection(
+            frappe.as_json(
+                [
+                    {
+                        "company": payment_doc.company,
+                        "voucher_type": payment_doc.doctype,
+                        "voucher_no": payment_doc.name,
+                        "against_voucher_type": invoice_doc.doctype,
+                        "against_voucher_no": invoice_doc.name,
+                    }
+                ]
+            )
+        )
+
+    # ---- ledger helpers (net per account / per against-voucher, drops zero nets) ----
+
+    def _gl_net_by_account(self, payment_doc):
+        rows = frappe.get_all(
+            "GL Entry",
+            filters={"voucher_no": payment_doc.name, "is_cancelled": 0},
+            fields=["account", "debit", "credit"],
+        )
+        net = {}
+        for row in rows:
+            net[row.account] = flt(net.get(row.account, 0) + row.debit - row.credit, 2)
+        return {account: amount for account, amount in net.items() if amount}
+
+    def _pl_net_by_voucher(self, payment_doc):
+        rows = frappe.get_all(
+            "Payment Ledger Entry",
+            filters={"voucher_type": payment_doc.doctype, "voucher_no": payment_doc.name, "delinked": 0},
+            fields=["against_voucher_no", "amount"],
+        )
+        net = {}
+        for row in rows:
+            net[row.against_voucher_no] = flt(net.get(row.against_voucher_no, 0) + row.amount, 2)
+        return {voucher: amount for voucher, amount in net.items() if amount}

--- a/india_compliance/gst_india/overrides/test_advance_payment_entry.py
+++ b/india_compliance/gst_india/overrides/test_advance_payment_entry.py
@@ -366,7 +366,8 @@ class TestAdvancePaymentEntry(IntegrationTestCase):
         # Should reconcile without raising.
         make_payment_reconciliation(payment_doc, invoice_doc, 100)
 
-        # Fully reconciled apart from a 1-paisa residual
+        # A clean fix needs ERPNext to derive the net allocation/tax split together so this rounding
+        # difference is absorbed into the net amount instead of being left in outstanding.
         outstanding_amount = frappe.db.get_value("Sales Invoice", invoice_doc.name, "outstanding_amount")
         self.assertEqual(flt(outstanding_amount, 2), -0.01)
 
@@ -777,10 +778,6 @@ class TestPaymentReconciliationMatrix(IntegrationTestCase):
         if inclusive:
             for tax in payment_doc.taxes:
                 tax.included_in_paid_amount = 1
-                # mirror the client: set computed tax so get_included_taxes (runs before
-                # apply_taxes) doesn't hit a None base_tax_amount; apply_taxes re-derives it
-                tax.tax_amount = 45
-                tax.base_tax_amount = 45
 
         payment_doc.setup_party_account_field()
         payment_doc.set_missing_values()

--- a/india_compliance/gst_india/utils/gstr_1/gstr_1_data.py
+++ b/india_compliance/gst_india/utils/gstr_1/gstr_1_data.py
@@ -969,7 +969,9 @@ class GSTR11A11BData:
             .left_join(included_taxes_query)
             .on(included_taxes_query.parent == self.pe.name)
             .select(
-                (self.pe.paid_amount - IfNull(included_taxes_query.included_taxes, 0)).as_("taxable_value")
+                (self.pe.base_paid_amount - IfNull(included_taxes_query.included_taxes, 0)).as_(
+                    "taxable_value"
+                )
             )
             .groupby(self.pe.name)
         )

--- a/india_compliance/gst_india/utils/gstr_1/gstr_1_data.py
+++ b/india_compliance/gst_india/utils/gstr_1/gstr_1_data.py
@@ -957,8 +957,21 @@ class GSTR11A11BData:
         return self.process_data(records)
 
     def get_11A_query(self):
+        # For tax-inclusive payments the GST is embedded in paid_amount, exclusive -> 0.
+        from india_compliance.gst_india.overrides.payment_entry import (
+            get_included_taxes_query,
+        )
+
+        gst_accounts_list = [account_head for account_head in self.gst_accounts.values() if account_head]
+        included_taxes_query = get_included_taxes_query(gst_accounts_list)
         return (
-            self.get_query("Advances").select(self.pe.paid_amount.as_("taxable_value")).groupby(self.pe.name)
+            self.get_query("Advances")
+            .left_join(included_taxes_query)
+            .on(included_taxes_query.parent == self.pe.name)
+            .select(
+                (self.pe.paid_amount - IfNull(included_taxes_query.included_taxes, 0)).as_("taxable_value")
+            )
+            .groupby(self.pe.name)
         )
 
     def get_11B_query(self):


### PR DESCRIPTION
Caused errors because of changes in it's reconciliation flow.

Fixes:
- Add back allocated amount to get true outstanding - added `via_reconciliation` param for this
- remove flag `gst_excess_allocation_validated` as we can now always validate outstanding amount
- payment entry now supports inclusive taxes. now we calculate correct taxable values based on this
- tests cases

Pending:
- [x] changes needed for 11A and 11B queries for this -> for GSTR-1 reporting

closes: https://github.com/frappe/erpnext/issues/56029 https://github.com/resilient-tech/india-compliance/issues/4426