### PR TITLE
fix: validate GST refund accounts with non-GST charges

### DIFF
--- a/india_compliance/gst_india/overrides/test_transaction.py
+++ b/india_compliance/gst_india/overrides/test_transaction.py
@@ -1320,6 +1320,27 @@ class TestTransaction(IntegrationTestCase):
             return_doc.save,
         )
 
+    @change_settings("GST Settings", {"enable_overseas_transactions": 1})
+    def test_validate_gst_refund_accounts_with_other_charges(self):
+        """
+        Non-GST charges (e.g. freight) must not be counted when checking that
+        the refund amount offsets the GST amount.
+        """
+        doc = create_refund_transaction()
+
+        doc.append(
+            "taxes",
+            {
+                "charge_type": "Actual",
+                "account_head": "Freight and Forwarding Charges - _TIRC",
+                "description": "Freight",
+                "tax_amount": 20,
+                "cost_center": "Main - _TIRC",
+            },
+        )
+
+        doc.save()
+
     def test_item_gst_details_for_non_gst_transactions(self):
         """
         Test Non-GST Transactions can be processed without errors.

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -1066,6 +1066,9 @@ def validate_gst_refund_accounts(doc):
 
     for tax in doc.taxes:
         tax_amount = flt(tax.base_tax_amount_after_discount_amount)
+        if tax.gst_tax_type not in TAX_TYPES:
+            continue
+
         if tax.gst_tax_type not in GST_REFUND_TAX_TYPES:
             net_amount += tax_amount
             continue
@@ -1086,7 +1089,8 @@ def validate_gst_refund_accounts(doc):
         net_amount += tax_amount
 
     # Validate if refund amount is same as total gst amount
-    if has_refund and net_amount != 0:
+    tax_precision = doc.precision("base_tax_amount_after_discount_amount", "taxes")
+    if has_refund and flt(net_amount, tax_precision) != 0:
         frappe.throw(_("Total GST amount should be equal to Refund amount."))
 
 


### PR DESCRIPTION
Frappe Support Issue: https://support.frappe.io/desk/hd-ticket/71836