### PR TITLE
fix: add supplier gstin status in purchase reconciliation tool

### DIFF
--- a/india_compliance/gst_india/data/test_purchase_reconciliation_tool.json
+++ b/india_compliance/gst_india/data/test_purchase_reconciliation_tool.json
@@ -34,7 +34,9 @@
                     "irn_number": null,
                     "irn_source": null,
                     "itc_availability": "Yes",
-                    "reason_itc_unavailability": null
+                    "reason_itc_unavailability": null,
+                    "gstin_status": "",
+                    "gstin_cancelled_date": ""
                 }
             },
             {
@@ -88,7 +90,9 @@
                     "irn_number": null,
                     "irn_source": null,
                     "itc_availability": "Yes",
-                    "reason_itc_unavailability": null
+                    "reason_itc_unavailability": null,
+                    "gstin_status": "",
+                    "gstin_cancelled_date": ""
                 }
             },
             {
@@ -136,7 +140,9 @@
                     "irn_number": null,
                     "irn_source": null,
                     "itc_availability": "Yes",
-                    "reason_itc_unavailability": null
+                    "reason_itc_unavailability": null,
+                    "gstin_status": "",
+                    "gstin_cancelled_date": ""
                 }
             }
         ],
@@ -176,7 +182,9 @@
                     "irn_number": null,
                     "irn_source": null,
                     "itc_availability": "Yes",
-                    "reason_itc_unavailability": null
+                    "reason_itc_unavailability": null,
+                    "gstin_status": "",
+                    "gstin_cancelled_date": ""
                 }
             }
         ],
@@ -189,7 +197,7 @@
                     "bill_no": "BILL-23-00030",
                     "items": [
                         {
-                            "taxable_value": 10000.50,
+                            "taxable_value": 10000.5,
                             "rate": 18,
                             "sgst": 900.045,
                             "cgst": 900.045
@@ -223,7 +231,9 @@
                     "irn_number": null,
                     "irn_source": null,
                     "itc_availability": "Yes",
-                    "reason_itc_unavailability": null
+                    "reason_itc_unavailability": null,
+                    "gstin_status": "",
+                    "gstin_cancelled_date": ""
                 }
             }
         ],
@@ -261,7 +271,9 @@
                     "irn_number": null,
                     "irn_source": null,
                     "itc_availability": "Yes",
-                    "reason_itc_unavailability": null
+                    "reason_itc_unavailability": null,
+                    "gstin_status": "",
+                    "gstin_cancelled_date": ""
                 }
             }
         ],
@@ -301,7 +313,9 @@
                     "irn_number": null,
                     "irn_source": null,
                     "itc_availability": "Yes",
-                    "reason_itc_unavailability": null
+                    "reason_itc_unavailability": null,
+                    "gstin_status": "",
+                    "gstin_cancelled_date": ""
                 }
             }
         ],
@@ -341,7 +355,9 @@
                     "irn_number": null,
                     "irn_source": null,
                     "itc_availability": "Yes",
-                    "reason_itc_unavailability": null
+                    "reason_itc_unavailability": null,
+                    "gstin_status": "",
+                    "gstin_cancelled_date": ""
                 }
             }
         ],
@@ -382,7 +398,9 @@
                     "irn_number": null,
                     "irn_source": null,
                     "itc_availability": "Yes",
-                    "reason_itc_unavailability": null
+                    "reason_itc_unavailability": null,
+                    "gstin_status": "",
+                    "gstin_cancelled_date": ""
                 }
             }
         ],
@@ -390,7 +408,7 @@
             {
                 "PURCHASE_INVOICE": {
                     "bill_no": "BILL-23-00050",
-                    "items" : [
+                    "items": [
                         {
                             "item_code": "_Test Nil Rated Item",
                             "rate": 1000,
@@ -443,7 +461,9 @@
                     "irn_number": null,
                     "irn_source": null,
                     "itc_availability": "Yes",
-                    "reason_itc_unavailability": null
+                    "reason_itc_unavailability": null,
+                    "gstin_status": "",
+                    "gstin_cancelled_date": ""
                 }
             }
         ]

--- a/india_compliance/gst_india/doctype/purchase_reconciliation_tool/__init__.py
+++ b/india_compliance/gst_india/doctype/purchase_reconciliation_tool/__init__.py
@@ -1197,13 +1197,12 @@ class ReconciledData(BaseReconciliation):
         if not supplier_gstins:
             return frappe._dict()
 
-        return frappe._dict(
-            {
-                gstin: frappe.db.get_value("GSTIN", gstin, ["status", "cancelled_date"], as_dict=True)
-                or frappe._dict()
-                for gstin in supplier_gstins
-            }
+        records = frappe.get_all(
+            "GSTIN",
+            filters={"name": ("in", list(supplier_gstins))},
+            fields=["name", "status", "cancelled_date"],
         )
+        return frappe._dict({r.name: r for r in records})
 
     def update_amount_difference(self, data, purchase, inward_supply):
         data.taxable_value_difference = rounded(

--- a/india_compliance/gst_india/doctype/purchase_reconciliation_tool/__init__.py
+++ b/india_compliance/gst_india/doctype/purchase_reconciliation_tool/__init__.py
@@ -1014,7 +1014,6 @@ class ReconciledData(BaseReconciliation):
         for doc in purchases_and_bill_of_entry.values():
             reconciliation_data.append(frappe._dict({"_purchase_invoice": doc}))
 
-        self.gstin_map = self.get_gstin_status_map(reconciliation_data)
         self.process_data(reconciliation_data, retain_doc=retain_doc)
 
         return reconciliation_data
@@ -1123,6 +1122,8 @@ class ReconciledData(BaseReconciliation):
             "gstin_status": "",
             "gstin_cancelled_date": "",
         }
+
+        self.gstin_map = self.get_gstin_status_map(reconciliation_data)
 
         for data in reconciliation_data:
             data.update(default_dict)

--- a/india_compliance/gst_india/doctype/purchase_reconciliation_tool/__init__.py
+++ b/india_compliance/gst_india/doctype/purchase_reconciliation_tool/__init__.py
@@ -1188,16 +1188,11 @@ class ReconciledData(BaseReconciliation):
             data.action = "Ignore" if purchase.get("reconciliation_status") == "Ignored" else "No Action"
 
     def get_gstin_status_map(self, reconciliation_data):
-        supplier_gstins = set(
-            filter(
-                None,
-                [
-                    doc.get("_purchase_invoice", frappe._dict()).get("supplier_gstin")
-                    or doc.get("_inward_supply", frappe._dict()).get("supplier_gstin")
-                    for doc in reconciliation_data
-                ],
-            )
-        )
+        supplier_gstins = {
+            doc.get("_purchase_invoice", frappe._dict()).get("supplier_gstin")
+            or doc.get("_inward_supply", frappe._dict()).get("supplier_gstin")
+            for doc in reconciliation_data
+        } - {None, ""}
 
         if not supplier_gstins:
             return frappe._dict()

--- a/india_compliance/gst_india/doctype/purchase_reconciliation_tool/__init__.py
+++ b/india_compliance/gst_india/doctype/purchase_reconciliation_tool/__init__.py
@@ -935,6 +935,7 @@ class ReconciledData(BaseReconciliation):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.gstin_party_map = frappe._dict()
+        self.gstin_map = frappe._dict()
         self.dimension_fields = [*get_accounting_dimensions(), "cost_center", "project"]
 
     def get_consolidated_data(
@@ -1013,6 +1014,7 @@ class ReconciledData(BaseReconciliation):
         for doc in purchases_and_bill_of_entry.values():
             reconciliation_data.append(frappe._dict({"_purchase_invoice": doc}))
 
+        self.gstin_map = self.get_gstin_status_map(reconciliation_data)
         self.process_data(reconciliation_data, retain_doc=retain_doc)
 
         return reconciliation_data
@@ -1118,6 +1120,8 @@ class ReconciledData(BaseReconciliation):
             "irn_source": "",
             "irn_number": "",
             "irn_gen_date": "",
+            "gstin_status": "",
+            "gstin_cancelled_date": "",
         }
 
         for data in reconciliation_data:
@@ -1148,6 +1152,7 @@ class ReconciledData(BaseReconciliation):
         ):
             data[field] = purchase.get(field) or inward_supply.get(field)
 
+        gstin_info = self.gstin_map.get(data.supplier_gstin, frappe._dict())
         data.update(
             {
                 "supplier_name": data.supplier_name or self.guess_supplier_name(data.supplier_gstin),
@@ -1168,6 +1173,8 @@ class ReconciledData(BaseReconciliation):
                 "irn_source": inward_supply.get("irn_source"),
                 "irn_number": inward_supply.get("irn_number"),
                 "irn_gen_date": format_date(inward_supply.get("irn_gen_date")),
+                "gstin_status": gstin_info.get("status") or "",
+                "gstin_cancelled_date": gstin_info.get("cancelled_date") or "",
             }
         )
 
@@ -1179,6 +1186,29 @@ class ReconciledData(BaseReconciliation):
         elif not inward_supply:
             data.match_status = MatchStatus.MISSING_IN_2A_2B.value
             data.action = "Ignore" if purchase.get("reconciliation_status") == "Ignored" else "No Action"
+
+    def get_gstin_status_map(self, reconciliation_data):
+        supplier_gstins = set(
+            filter(
+                None,
+                [
+                    doc.get("_purchase_invoice", frappe._dict()).get("supplier_gstin")
+                    or doc.get("_inward_supply", frappe._dict()).get("supplier_gstin")
+                    for doc in reconciliation_data
+                ],
+            )
+        )
+
+        if not supplier_gstins:
+            return frappe._dict()
+
+        return frappe._dict(
+            {
+                gstin: frappe.db.get_value("GSTIN", gstin, ["status", "cancelled_date"], as_dict=True)
+                or frappe._dict()
+                for gstin in supplier_gstins
+            }
+        )
 
     def update_amount_difference(self, data, purchase, inward_supply):
         data.taxable_value_difference = rounded(

--- a/india_compliance/public/js/reconciliation_components/tabs.js
+++ b/india_compliance/public/js/reconciliation_components/tabs.js
@@ -5,7 +5,7 @@ function get_gstin_status_at_invoice_date(row) {
         row.gstin_status === "Cancelled" &&
         row.gstin_cancelled_date &&
         row.bill_date &&
-        row.bill_date < row.gstin_cancelled_date
+        frappe.datetime.str_to_obj(row.bill_date) < frappe.datetime.str_to_obj(row.gstin_cancelled_date)
     ) {
         return "Active";
     }
@@ -155,22 +155,13 @@ reconciliation.reconciliation_tabs = class ReconciliationTabs {
     }
 
     get_supplier_name_gstin(row) {
-        let gstin_link;
-        if (row.gstin_status) {
-            const status = get_gstin_status_at_invoice_date(row);
-            gstin_link = $(
-                `<a href="#" style="font-size: 0.9em;" class="supplier-gstin">${
-                    row.supplier_gstin || ""
-                }</a>`,
-            )
-                .addClass(`indicator ${get_gstin_indicator_color(status)}`)
-                .attr("title", status)
-                .prop("outerHTML");
-        } else {
-            gstin_link = `<a href="#" style="font-size: 0.9em;" class="supplier-gstin">${
-                row.supplier_gstin || ""
-            }</a>`;
-        }
+        const status = get_gstin_status_at_invoice_date(row);
+        const gstin_link = $(
+            `<a href="#" style="font-size: 0.9em;" class="supplier-gstin">${row.supplier_gstin || ""}</a>`,
+        )
+            .addClass(`indicator ${get_gstin_indicator_color(status)}`)
+            .attr("title", status || "Unknown")
+            .prop("outerHTML");
         return `${row.supplier_name}<br />${gstin_link}`;
     }
 
@@ -254,26 +245,21 @@ reconciliation.detail_view_dialog = class DetailViewDialog {
     init_dialog() {
         let gstin_text = "";
         if (this.row.supplier_gstin) {
-            let status_html = "";
-            if (this.row.gstin_status) {
-                const status = get_gstin_status_at_invoice_date(this.row);
-                const color = get_gstin_indicator_color(status);
-                let note = "";
-                if (
-                    status === "Active" &&
-                    this.row.gstin_status === "Cancelled" &&
-                    this.row.gstin_cancelled_date
-                ) {
-                    note = ` <span> — Currently Cancelled since ${frappe.datetime.str_to_user(
-                        this.row.gstin_cancelled_date,
-                    )}</span>`;
-                } else if (status === "Cancelled" && this.row.gstin_cancelled_date) {
-                    note = ` <span>since ${frappe.datetime.str_to_user(
-                        this.row.gstin_cancelled_date,
-                    )}</span>`;
-                }
-                status_html = ` — <span class="indicator ${color}">${status}</span>${note}`;
+            const status = get_gstin_status_at_invoice_date(this.row);
+            const color = get_gstin_indicator_color(status);
+            let note = "";
+            if (
+                status === "Active" &&
+                this.row.gstin_status === "Cancelled" &&
+                this.row.gstin_cancelled_date
+            ) {
+                note = ` <span> — Currently Cancelled since ${frappe.datetime.str_to_user(
+                    this.row.gstin_cancelled_date,
+                )}</span>`;
+            } else if (status === "Cancelled" && this.row.gstin_cancelled_date) {
+                note = ` <span>since ${frappe.datetime.str_to_user(this.row.gstin_cancelled_date)}</span>`;
             }
+            const status_html = ` — <span class="indicator ${color}">${status || "Unknown"}</span>${note}`;
             gstin_text = ` (${this.row.supplier_gstin}${status_html})`;
         }
         const supplier_details = `<h5>${this.row.supplier_name}${gstin_text}</h5>`;

--- a/india_compliance/public/js/reconciliation_components/tabs.js
+++ b/india_compliance/public/js/reconciliation_components/tabs.js
@@ -1,5 +1,24 @@
 frappe.provide("reconciliation");
 
+function get_gstin_status_at_invoice_date(row) {
+    if (
+        row.gstin_status === "Cancelled" &&
+        row.gstin_cancelled_date &&
+        row.bill_date &&
+        row.bill_date < row.gstin_cancelled_date
+    ) {
+        return "Active";
+    }
+    return row.gstin_status;
+}
+
+function get_gstin_indicator_color(status) {
+    if (status === "Active") return "green";
+    if (status === "Cancelled") return "red";
+    if (status === "Suspended") return "orange";
+    return "grey";
+}
+
 reconciliation.reconciliation_tabs = class ReconciliationTabs {
     constructor(frm, tabs, data_field) {
         this.frm = frm;
@@ -136,13 +155,23 @@ reconciliation.reconciliation_tabs = class ReconciliationTabs {
     }
 
     get_supplier_name_gstin(row) {
-        return `
-        ${row.supplier_name}
-        <br />
-        <a href="#" style="font-size: 0.9em;" class="supplier-gstin">
-            ${row.supplier_gstin || ""}
-        </a>
-        `;
+        let gstin_link;
+        if (row.gstin_status) {
+            const status = get_gstin_status_at_invoice_date(row);
+            gstin_link = $(
+                `<a href="#" style="font-size: 0.9em;" class="supplier-gstin">${
+                    row.supplier_gstin || ""
+                }</a>`,
+            )
+                .addClass(`indicator ${get_gstin_indicator_color(status)}`)
+                .attr("title", status)
+                .prop("outerHTML");
+        } else {
+            gstin_link = `<a href="#" style="font-size: 0.9em;" class="supplier-gstin">${
+                row.supplier_gstin || ""
+            }</a>`;
+        }
+        return `${row.supplier_name}<br />${gstin_link}`;
     }
 
     get_value_with_indicator(value, column, data) {
@@ -223,11 +252,31 @@ reconciliation.detail_view_dialog = class DetailViewDialog {
     }
 
     init_dialog() {
-        const supplier_details = `
-        <h5>${this.row.supplier_name}
-        ${this.row.supplier_gstin ? ` (${this.row.supplier_gstin})` : ""}
-        </h5>
-        `;
+        let gstin_text = "";
+        if (this.row.supplier_gstin) {
+            let status_html = "";
+            if (this.row.gstin_status) {
+                const status = get_gstin_status_at_invoice_date(this.row);
+                const color = get_gstin_indicator_color(status);
+                let note = "";
+                if (
+                    status === "Active" &&
+                    this.row.gstin_status === "Cancelled" &&
+                    this.row.gstin_cancelled_date
+                ) {
+                    note = ` <span> — Currently Cancelled since ${frappe.datetime.str_to_user(
+                        this.row.gstin_cancelled_date,
+                    )}</span>`;
+                } else if (status === "Cancelled" && this.row.gstin_cancelled_date) {
+                    note = ` <span>since ${frappe.datetime.str_to_user(
+                        this.row.gstin_cancelled_date,
+                    )}</span>`;
+                }
+                status_html = ` — <span class="indicator ${color}">${status}</span>${note}`;
+            }
+            gstin_text = ` (${this.row.supplier_gstin}${status_html})`;
+        }
+        const supplier_details = `<h5>${this.row.supplier_name}${gstin_text}</h5>`;
 
         this.dialog = new frappe.ui.Dialog({
             title: `Detail View (${this.row.classification})`,


### PR DESCRIPTION
### Changes:
- Supplier name column now shows a colored status indicator (green/red/orange/grey) next to the GSTIN — Active, Cancelled, Suspended, or unknown
- Status is derived at the invoice date: if a GSTIN is currently Cancelled but was Active at the time of the invoice, it shows as Active
- Detail view dialog header shows the full status context inline with the GSTIN — e.g. 07USERR0205A1ZS · Active — Currently Cancelled since 22/06/2026

### Screenshots: 
<img width="1468" height="797" alt="Screenshot 2026-06-22 at 12 21 40 PM" src="https://github.com/user-attachments/assets/9362f894-fa26-47d5-9357-5576a817dc14" />
<img width="610" height="726" alt="Screenshot 2026-06-22 at 12 21 56 PM" src="https://github.com/user-attachments/assets/439b8ab6-408c-4171-a683-d95ec1223dcb" />
<img width="619" height="718" alt="Screenshot 2026-06-22 at 12 22 10 PM" src="https://github.com/user-attachments/assets/801ceb41-03c8-4e72-8f08-2bbc902a19b3" />
