### PR TITLE
fix: prevent unwanted invoice removal in GSTR2B re-download

### DIFF
--- a/india_compliance/gst_india/utils/gstr_2/gstr.py
+++ b/india_compliance/gst_india/utils/gstr_2/gstr.py
@@ -10,6 +10,14 @@ def get_mapped_value(value, mapping):
     return mapping.get(value)
 
 
+def get_unique_key(transaction):
+    # Build the supplier_gstin-bill_no key used to match existing inward supplies.
+    supplier_gstin = transaction.get("supplier_gstin") or ""
+    bill_no = transaction.get("bill_no") or ""
+
+    return f"{supplier_gstin}-{bill_no}"
+
+
 class GSTR:
     # Maps of API keys to doctype fields
     KEY_MAPS = frappe._dict()
@@ -107,9 +115,7 @@ class GSTR:
         if transaction.get("items"):
             self.update_totals(transaction)
 
-        transaction["unique_key"] = (
-            f"{transaction.get('supplier_gstin', '')}-{transaction.get('bill_no', '')}"
-        )
+        transaction["unique_key"] = get_unique_key(transaction)
 
         return transaction
 

--- a/india_compliance/gst_india/utils/gstr_2/gstr_2a.py
+++ b/india_compliance/gst_india/utils/gstr_2/gstr_2a.py
@@ -3,7 +3,11 @@ from datetime import datetime
 import frappe
 
 from india_compliance.gst_india.utils import get_datetime, parse_datetime
-from india_compliance.gst_india.utils.gstr_2.gstr import GSTR, get_mapped_value
+from india_compliance.gst_india.utils.gstr_2.gstr import (
+    GSTR,
+    get_mapped_value,
+    get_unique_key,
+)
 
 
 def map_date_format(date_str, source_format, target_format):
@@ -26,12 +30,7 @@ class GSTR2a(GSTR):
             .where(gst_is.gstr_1_filled == 0)
         ).run(as_dict=True)
 
-        return {
-            f"{transaction.get('supplier_gstin', '')}-{transaction.get('bill_no', '')}": transaction.get(
-                "name"
-            )
-            for transaction in existing_transactions
-        }
+        return {get_unique_key(transaction): transaction.get("name") for transaction in existing_transactions}
 
     def handle_missing_transactions(self):
         """

--- a/india_compliance/gst_india/utils/gstr_2/gstr_2b.py
+++ b/india_compliance/gst_india/utils/gstr_2/gstr_2b.py
@@ -1,7 +1,11 @@
 import frappe
 
 from india_compliance.gst_india.utils import parse_datetime
-from india_compliance.gst_india.utils.gstr_2.gstr import GSTR, get_mapped_value
+from india_compliance.gst_india.utils.gstr_2.gstr import (
+    GSTR,
+    get_mapped_value,
+    get_unique_key,
+)
 
 
 class GSTR2b(GSTR):
@@ -14,12 +18,7 @@ class GSTR2b(GSTR):
             .where(gst_is.classification == self.category)
         ).run(as_dict=True)
 
-        return {
-            f"{transaction.get('supplier_gstin', '')}-{transaction.get('bill_no', '')}": transaction.get(
-                "name"
-            )
-            for transaction in existing_transactions
-        }
+        return {get_unique_key(transaction): transaction.get("name") for transaction in existing_transactions}
 
     def handle_missing_transactions(self):
         """

--- a/india_compliance/gst_india/utils/gstr_2/ims.py
+++ b/india_compliance/gst_india/utils/gstr_2/ims.py
@@ -13,7 +13,7 @@ from india_compliance.gst_india.doctype.gst_inward_supply.gst_inward_supply impo
     update_previous_ims_action as _update_previous_ims_action,
 )
 from india_compliance.gst_india.utils import parse_datetime
-from india_compliance.gst_india.utils.gstr_2.gstr import get_mapped_value
+from india_compliance.gst_india.utils.gstr_2.gstr import get_mapped_value, get_unique_key
 
 CLASSIFICATION_MAP = {
     "B2B": ["B2B", "Invoice"],
@@ -91,9 +91,7 @@ class IMS:
             **self.get_invoice_details(invoice),
         )
 
-        transaction["unique_key"] = (
-            f"{transaction.get('supplier_gstin', '')}-{transaction.get('bill_no', '')}"
-        )
+        transaction["unique_key"] = get_unique_key(transaction)
 
         return transaction
 
@@ -156,12 +154,7 @@ class IMS:
             .run(as_dict=True)
         )
 
-        return {
-            f"{transaction.get('supplier_gstin', '')}-{transaction.get('bill_no', '')}": transaction.get(
-                "name"
-            )
-            for transaction in existing_transactions
-        }
+        return {get_unique_key(transaction): transaction.get("name") for transaction in existing_transactions}
 
     def handle_missing_transactions(self):
         if not self.existing_transactions:

--- a/india_compliance/gst_india/utils/gstr_2/test_gstr_2b_v4_0.py
+++ b/india_compliance/gst_india/utils/gstr_2/test_gstr_2b_v4_0.py
@@ -1,10 +1,12 @@
 from datetime import date
 
+import frappe
 from frappe import parse_json, read_file
 from frappe.tests import IntegrationTestCase
 
 from india_compliance.gst_india.utils import get_data_file_path
 from india_compliance.gst_india.utils.gstr_2 import GSTRCategory, save_gstr_2b
+from india_compliance.gst_india.utils.gstr_2.gstr import get_unique_key
 from india_compliance.gst_india.utils.gstr_2.test_gstr_2a import TestGSTRMixin
 
 
@@ -261,3 +263,30 @@ class TestGSTR2b(TestGSTRMixin, IntegrationTestCase):
             },
             doc,
         )
+
+    def test_impg_return_period_persists_on_redownload(self):
+        """
+        A 2B re-download must not clear return_period_2b for IMPG rows.
+        """
+        doc = self.get_doc(GSTRCategory.IMPG)
+        self.assertEqual(doc.return_period_2b, self.return_period)
+        self.assertEqual(doc.is_downloaded_from_2b, 1)
+
+        save_gstr_2b(self.gstin, self.return_period, self.test_data)
+
+        doc.reload()
+        self.assertEqual(doc.return_period_2b, self.return_period)
+        self.assertEqual(doc.is_downloaded_from_2b, 1)
+
+
+class TestGetUniqueKey(IntegrationTestCase):
+    def test_null_gstin_matches_empty_gstin(self):
+        # DB row with NULL supplier_gstin -> None, vs incoming with field absent
+        existing = frappe._dict(supplier_gstin=None, bill_no="2566282")
+        incoming = frappe._dict(bill_no="2566282")
+        self.assertEqual(get_unique_key(existing), get_unique_key(incoming))
+        self.assertEqual(get_unique_key(existing), "-2566282")
+
+    def test_normal_gstin(self):
+        t = frappe._dict(supplier_gstin="01AABCE2207R1Z5", bill_no="INV-1")
+        self.assertEqual(get_unique_key(t), "01AABCE2207R1Z5-INV-1")


### PR DESCRIPTION
Issue: An IMPG Bill of Entry showed in the Purchase Reconciliation Tool, then disappeared after GSTR-2B was downloaded a second time — even though the BoE was present in every 2B download. 
IMPG rows have a NULL supplier_gstin. The unique_key matching an existing inward supply against a fresh download was comparing None with "".