### PR TITLE
fix: make GSP support email a clickable mailto link

### DIFF
--- a/india_compliance/gst_india/api_classes/base.py
+++ b/india_compliance/gst_india/api_classes/base.py
@@ -1,7 +1,7 @@
 import copy
 from base64 import b64decode
 from typing import ClassVar
-from urllib.parse import urljoin
+from urllib.parse import quote, urljoin
 
 import frappe
 import requests
@@ -280,8 +280,8 @@ class BaseAPI:
             frappe.throw(
                 _(
                     "Error establishing connection to GSP. Please contact India"
-                    " Compliance API support at <strong>api-support@indiacompliance.app</strong>."
-                ),
+                    " Compliance API support at {0}."
+                ).format(self.get_support_email_link()),
                 title=_("GSP Connection Error"),
             )
 
@@ -300,6 +300,20 @@ class BaseAPI:
 
         if status_code == 504:
             raise GatewayTimeoutError
+
+    def get_support_email_link(self):
+        """Return a clickable mailto: link for India Compliance API support."""
+        support_email = "api-support@indiacompliance.app"
+
+        subject = "Error establishing connection to GSP"
+        if company := getattr(self, "company", None):
+            subject = f"{subject} for {company}"
+
+        body = "Hello India Compliance Team,\n\n\n// Please describe the issue and paste the error here\n"
+
+        # &amp; keeps the href valid HTML; the browser decodes it before parsing the mailto.
+        mailto = f"mailto:{support_email}?subject={quote(subject)}&amp;body={quote(body)}"
+        return f'<a href="{mailto}">{support_email}</a>'
 
     def generate_request_id(self, length=12):
         return f"IC{frappe.generate_hash(length=length - 2)}".upper()

--- a/india_compliance/gst_india/api_classes/base.py
+++ b/india_compliance/gst_india/api_classes/base.py
@@ -18,6 +18,7 @@ from india_compliance.gst_india.utils import is_api_enabled
 from india_compliance.gst_india.utils.api import enqueue_integration_request
 
 BASE_URL = "https://asp.resilient.tech"
+SUPPORT_EMAIL = "api-support@indiacompliance.app"
 
 
 class BaseAPI:
@@ -278,10 +279,9 @@ class BaseAPI:
             status_code == 403 and response_json and response_json.get("error") == "access_denied"
         ):
             frappe.throw(
-                _(
-                    "Error establishing connection to GSP. Please contact India"
-                    " Compliance API support at {0}."
-                ).format(frappe.bold(self.get_support_email_link())),
+                _("Error establishing connection to GSP.<br><br>Please contact support at {0}").format(
+                    frappe.bold(self.get_support_email_link(error=response_json))
+                ),
                 title=_("GSP Connection Error"),
             )
 
@@ -302,16 +302,21 @@ class BaseAPI:
             raise GatewayTimeoutError
 
     def get_support_email_link(self, subject="Error establishing connection to GSP", error=None):
-        support_email = "api-support@indiacompliance.app"
+        email = self.support_email or SUPPORT_EMAIL
+
+        if company := getattr(self, "company", None):
+            subject = f"{subject} - {company}"
 
         if error:
             body = f"Hello India Compliance Team,\n\n\n{error}\n"
         else:
-            body = "Hello India Compliance Team,\n\n\n// Please describe the issue and paste the error here\n"
+            body = (
+                "Hello India Compliance Team,\n\n\n// Please describe the issue and paste the error here...\n"
+            )
 
         # &amp; keeps the href valid HTML.
-        mailto = f"mailto:{support_email}?subject={quote(subject)}&amp;body={quote(body)}"
-        return f'<a href="{mailto}">{support_email}</a>'
+        mailto = f"mailto:{email}?subject={quote(subject)}&amp;body={quote(body)}"
+        return f'<a href="{mailto}">{email}</a>'
 
     def generate_request_id(self, length=12):
         return f"IC{frappe.generate_hash(length=length - 2)}".upper()

--- a/india_compliance/gst_india/api_classes/base.py
+++ b/india_compliance/gst_india/api_classes/base.py
@@ -18,15 +18,13 @@ from india_compliance.gst_india.utils import is_api_enabled
 from india_compliance.gst_india.utils.api import enqueue_integration_request
 
 BASE_URL = "https://asp.resilient.tech"
-SUPPORT_EMAIL = "api-support@indiacompliance.app"
+DEFAULT_SUPPORT_EMAIL = "api-support@indiacompliance.app"
 
 
 class BaseAPI:
     API_NAME = "GST"
     BASE_PATH = ""
     PLACEHOLDER = "*****"
-    # Subclasses may override this; falls back to the module-level SUPPORT_EMAIL.
-    support_email = None
     DEFAULT_MASK_MAP: ClassVar[dict] = {
         "headers": [
             "x-api-key",
@@ -64,6 +62,7 @@ class BaseAPI:
             )
         }
         self.default_log_values = {}
+        self.support_email = None
 
         self.setup(*args, **kwargs)
 
@@ -304,7 +303,7 @@ class BaseAPI:
             raise GatewayTimeoutError
 
     def get_support_email_link(self, subject="Error establishing connection to GSP", error=None):
-        email = self.support_email or SUPPORT_EMAIL
+        email = self.support_email or DEFAULT_SUPPORT_EMAIL
 
         if company := getattr(self, "company", None):
             subject = f"{subject} - {company}"

--- a/india_compliance/gst_india/api_classes/base.py
+++ b/india_compliance/gst_india/api_classes/base.py
@@ -281,7 +281,7 @@ class BaseAPI:
                 _(
                     "Error establishing connection to GSP. Please contact India"
                     " Compliance API support at {0}."
-                ).format(self.get_support_email_link()),
+                ).format(frappe.bold(self.get_support_email_link())),
                 title=_("GSP Connection Error"),
             )
 
@@ -301,17 +301,15 @@ class BaseAPI:
         if status_code == 504:
             raise GatewayTimeoutError
 
-    def get_support_email_link(self):
-        """Return a clickable mailto: link for India Compliance API support."""
+    def get_support_email_link(self, subject="Error establishing connection to GSP", error=None):
         support_email = "api-support@indiacompliance.app"
 
-        subject = "Error establishing connection to GSP"
-        if company := getattr(self, "company", None):
-            subject = f"{subject} for {company}"
+        if error:
+            body = f"Hello India Compliance Team,\n\n\n{error}\n"
+        else:
+            body = "Hello India Compliance Team,\n\n\n// Please describe the issue and paste the error here\n"
 
-        body = "Hello India Compliance Team,\n\n\n// Please describe the issue and paste the error here\n"
-
-        # &amp; keeps the href valid HTML; the browser decodes it before parsing the mailto.
+        # &amp; keeps the href valid HTML.
         mailto = f"mailto:{support_email}?subject={quote(subject)}&amp;body={quote(body)}"
         return f'<a href="{mailto}">{support_email}</a>'
 

--- a/india_compliance/gst_india/api_classes/base.py
+++ b/india_compliance/gst_india/api_classes/base.py
@@ -25,6 +25,8 @@ class BaseAPI:
     API_NAME = "GST"
     BASE_PATH = ""
     PLACEHOLDER = "*****"
+    # Subclasses may override this; falls back to the module-level SUPPORT_EMAIL.
+    support_email = None
     DEFAULT_MASK_MAP: ClassVar[dict] = {
         "headers": [
             "x-api-key",


### PR DESCRIPTION
## Summary

Closes #3300

The **GSP Connection Error** message previously showed the support address as plain bold text:

> Please contact India Compliance API support at **api-support@indiacompliance.app**.

Users had to manually copy the address to report the issue. This PR wraps it in a clickable `mailto:` link with a pre-filled subject and body, so support is one click away.

## Changes
- Added `BaseAPI.get_support_email_link()` which builds a `mailto:` anchor with a URL-encoded subject (including the company name when available) and a short body template.
- Updated the 401/`access_denied` error in `handle_http_code` to use the link.

## Notes
- The company name is read via `getattr(self, "company", None)` so the message is safe even when credentials haven't been fetched yet (i.e. `self.company` is unset).
- `&amp;` is used as the query separator so the `href` is valid HTML; the browser decodes it to `&` before parsing the `mailto:`.

## Testing
- `ruff check` passes; file parses.
- Manual verification of the rendered link is recommended on a live instance (trigger a 401 from GSP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWcVfgCNvDj4wqsjMWTHx8

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWcVfgCNvDj4wqsjMWTHx8)_