### PR TITLE
fix: avoid duplicate get_import_history calls on dialog init

### DIFF
--- a/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.js
+++ b/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.js
@@ -935,23 +935,39 @@ class ImportDialog {
     async fetch_import_history() {
         if (!this.company_gstin || !this.return_type || !this.date_range) return;
 
-        // Skip duplicate requests for identical arguments
+        // Skip duplicate requests for identical arguments, whether already
+        // in-flight or last completed successfully. The signature is only
+        // marked as completed after a successful fetch, so a failed request
+        // can still be retried with the same arguments.
         const args_signature = JSON.stringify([
             this.company_gstin,
             this.return_type,
             this.date_range,
             this.for_download,
         ]);
-        if (args_signature === this._last_import_history_signature) return;
-        this._last_import_history_signature = args_signature;
+        if (
+            args_signature === this._last_import_history_signature ||
+            args_signature === this._pending_import_history_signature
+        ) {
+            return;
+        }
+        this._pending_import_history_signature = args_signature;
 
         // fetch history
-        const { message } = await this.frm._call("get_import_history", {
-            company_gstin: this.company_gstin,
-            return_type: this.return_type,
-            date_range: this.date_range,
-            for_download: this.for_download,
-        });
+        let message;
+        try {
+            ({ message } = await this.frm._call("get_import_history", {
+                company_gstin: this.company_gstin,
+                return_type: this.return_type,
+                date_range: this.date_range,
+                for_download: this.for_download,
+            }));
+            this._last_import_history_signature = args_signature;
+        } finally {
+            if (this._pending_import_history_signature === args_signature) {
+                this._pending_import_history_signature = null;
+            }
+        }
 
         // ensure sequence is maintained
         function get_map(message) {

--- a/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.js
+++ b/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.js
@@ -935,6 +935,19 @@ class ImportDialog {
     async fetch_import_history() {
         if (!this.company_gstin || !this.return_type || !this.date_range) return;
 
+        // Skip duplicate requests for identical arguments. While the dialog
+        // applies its field defaults, several field onchange handlers (and the
+        // explicit call in init_dialog) can invoke this with the same arguments,
+        // which would otherwise fire the same API call more than once.
+        const args_signature = JSON.stringify([
+            this.company_gstin,
+            this.return_type,
+            this.date_range,
+            this.for_download,
+        ]);
+        if (args_signature === this._last_import_history_signature) return;
+        this._last_import_history_signature = args_signature;
+
         // fetch history
         const { message } = await this.frm._call("get_import_history", {
             company_gstin: this.company_gstin,

--- a/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.js
+++ b/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.js
@@ -935,39 +935,19 @@ class ImportDialog {
     async fetch_import_history() {
         if (!this.company_gstin || !this.return_type || !this.date_range) return;
 
-        // Skip duplicate requests for identical arguments, whether already
-        // in-flight or last completed successfully. The signature is only
-        // marked as completed after a successful fetch, so a failed request
-        // can still be retried with the same arguments.
-        const args_signature = JSON.stringify([
-            this.company_gstin,
-            this.return_type,
-            this.date_range,
-            this.for_download,
-        ]);
-        if (
-            args_signature === this._last_import_history_signature ||
-            args_signature === this._pending_import_history_signature
-        ) {
-            return;
-        }
-        this._pending_import_history_signature = args_signature;
+        // Skip repeat calls for identical arguments
+        const args = {
+            company_gstin: this.company_gstin,
+            return_type: this.return_type,
+            date_range: this.date_range,
+            for_download: this.for_download,
+        };
+        const signature = JSON.stringify(args);
+        if (signature === this._import_history_signature) return;
+        this._import_history_signature = signature;
 
         // fetch history
-        let message;
-        try {
-            ({ message } = await this.frm._call("get_import_history", {
-                company_gstin: this.company_gstin,
-                return_type: this.return_type,
-                date_range: this.date_range,
-                for_download: this.for_download,
-            }));
-            this._last_import_history_signature = args_signature;
-        } finally {
-            if (this._pending_import_history_signature === args_signature) {
-                this._pending_import_history_signature = null;
-            }
-        }
+        const { message } = await this.frm._call("get_import_history", args);
 
         // ensure sequence is maintained
         function get_map(message) {

--- a/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.js
+++ b/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.js
@@ -935,10 +935,7 @@ class ImportDialog {
     async fetch_import_history() {
         if (!this.company_gstin || !this.return_type || !this.date_range) return;
 
-        // Skip duplicate requests for identical arguments. While the dialog
-        // applies its field defaults, several field onchange handlers (and the
-        // explicit call in init_dialog) can invoke this with the same arguments,
-        // which would otherwise fire the same API call more than once.
+        // Skip duplicate requests for identical arguments
         const args_signature = JSON.stringify([
             this.company_gstin,
             this.return_type,


### PR DESCRIPTION
## Summary

Closes #4137

When the **Import** dialog (`ImportDialog`) in the Purchase Reconciliation Tool initialises, it applies defaults to its fields (`return_type`, `company_gstin`, `period`, `date_range`). Each field's `onchange` handler calls `fetch_import_history()`, and `init_dialog()` also calls it explicitly. The early-return guard (`!company_gstin || !return_type || !date_range`) only blocks calls until all three are set — so once `period`/`date_range` defaults land, **two** `get_import_history` requests fire for the *same* arguments.

## Fix
`fetch_import_history()` now builds a signature from its arguments (`company_gstin`, `return_type`, `date_range`, `for_download`) and skips the request when it matches the previous one. A genuine field change produces a different signature, so user-driven refreshes still fetch as before.

## Why this approach
The `onchange` handlers are needed for interactive use, and the explicit init call guarantees one fetch regardless of frappe's default-application order. Deduping by argument signature fixes the duplicate robustly without depending on the exact order in which defaults fire.

## Testing
- Prettier passes on the changed file.
- Recommend a quick manual check: open the Download/Upload dialog and confirm only **one** `get_import_history` call is made on open (Network tab), and that changing GSTIN/return type/period still triggers a fresh call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWcVfgCNvDj4wqsjMWTHx8

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWcVfgCNvDj4wqsjMWTHx8)_