### PR TITLE
ci: don't run server tests twice for releases

### DIFF
--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -14,16 +14,18 @@ on:
 
   pull_request:
 
+  # Note: the release-target branches (version-14/15/16) are intentionally
+  # excluded here. Code reaches them only via the automated release PR
+  # (version-X-hotfix -> version-X), which is already tested by the
+  # pull_request event above. Including them would run the suite a second
+  # time on the post-merge push. See #4206.
   push:
     branches:
       [
         develop,
         version-14-hotfix,
-        version-14,
         version-15-hotfix,
-        version-15,
         version-16-hotfix,
-        version-16,
       ]
 
   workflow_dispatch:


### PR DESCRIPTION
## Summary

Closes #4206

`initiate_release.yml` opens a PR from `version-X-hotfix` → `version-X` for each version (14/15/16). That PR runs the server tests via the **`pull_request`** event, and then merging it pushes to `version-X`, which was also in the **`push`** branch list of `server-tests.yml` — so the full suite ran **twice per version** on every release.

The existing `concurrency` group is keyed by `github.event_name`, so the `push` and `pull_request` runs land in different groups and aren't deduped that way.

## Fix
Remove the release-target branches (`version-14`, `version-15`, `version-16`) from the `push` trigger. Code only reaches those branches through the automated release PR, which already validates it pre-merge.

After this change, per release version:
- Release PR (`version-X-hotfix` → `version-X`): tested once via `pull_request`. ✅ (pre-merge gate)
- Post-merge push to `version-X`: no longer re-runs the suite.
- `on_release.yml` still runs on the `version-X` push independently (unchanged).
- `develop` and the `version-X-hotfix` branches keep their push-triggered runs.

## Alternative considered
The mirror image — keep the `push` runs and scope `pull_request` to exclude version-branch bases — also halves the runs, but that would make the release test post-merge (non-gating). Gating the release on the PR seemed preferable. Happy to flip it if you'd rather keep the push run as the release gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWcVfgCNvDj4wqsjMWTHx8

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWcVfgCNvDj4wqsjMWTHx8)_