### PR TITLE
feat(gst): allow marking transactions Out of Scope of GST

### DIFF
--- a/india_compliance/gst_india/client_scripts/e_invoice_actions.js
+++ b/india_compliance/gst_india/client_scripts/e_invoice_actions.js
@@ -317,6 +317,11 @@ function is_e_invoice_applicable(frm, show_message = false) {
     let is_einv_applicable = true;
     let message_list = [];
 
+    if (frm.doc.is_out_of_scope_of_gst) {
+        is_einv_applicable = false;
+        message_list.push("e-Invoice is not applicable for transactions Out of Scope of GST.");
+    }
+
     if (!frm.doc.company_gstin) {
         is_einv_applicable = false;
         message_list.push("Company GSTIN is not set. Ensure its set in Company Address.");

--- a/india_compliance/gst_india/client_scripts/e_waybill_applicability.js
+++ b/india_compliance/gst_india/client_scripts/e_waybill_applicability.js
@@ -21,6 +21,11 @@ class EwaybillApplicability {
             );
         }
 
+        if (this.frm.doc.is_out_of_scope_of_gst) {
+            is_ewb_applicable = false;
+            message_list.push("e-Waybill is not applicable for transactions Out of Scope of GST.");
+        }
+
         // at least one item is not a service
         is_ewb_applicable = this.has_goods_item(is_ewb_applicable, message_list);
 

--- a/india_compliance/gst_india/constants/custom_fields.py
+++ b/india_compliance/gst_india/constants/custom_fields.py
@@ -805,7 +805,7 @@ CUSTOM_FIELDS = {
             "fieldname": "gst_treatment",
             "label": "GST Treatment",
             "fieldtype": "Autocomplete",
-            "options": "Taxable\nZero-Rated\nNil-Rated\nExempted\nNon-GST",
+            "options": "Taxable\nZero-Rated\nNil-Rated\nExempted\nNon-GST\nOut of Scope",
             "fetch_from": "item_tax_template.gst_treatment",
             "fetch_if_empty": 1,
             "insert_after": "item_tax_template",
@@ -1412,6 +1412,21 @@ PURCHASE_REVERSE_CHARGE_FIELDS = {
     "Purchase Receipt": {**reverse_charge_field, "insert_after": "is_return"},
     "Purchase Order": {**reverse_charge_field, "insert_after": "supplier_warehouse"},
     "Supplier Quotation": {**reverse_charge_field, "insert_after": "has_unit_price_items"},
+}
+
+out_of_scope_field = {
+    "fieldname": "is_out_of_scope_of_gst",
+    "label": "Out of Scope of GST",
+    "fieldtype": "Check",
+    "print_hide": 1,
+    "default": "0",
+}
+
+# Manual override to keep a transaction out of GST entirely (eg. merchant trade).
+# Same doctypes as reverse charge => POS Invoice and Stock Entry excluded.
+OUT_OF_SCOPE_OF_GST_FIELDS = {
+    doctype: {**out_of_scope_field, "insert_after": "is_reverse_charge"}
+    for doctype in (*SALES_REVERSE_CHARGE_FIELDS, *PURCHASE_REVERSE_CHARGE_FIELDS)
 }
 
 E_INVOICE_FIELDS = {

--- a/india_compliance/gst_india/doctype/gst_return_log/generate_gstr_1.py
+++ b/india_compliance/gst_india/doctype/gst_return_log/generate_gstr_1.py
@@ -235,6 +235,7 @@ class SummarizeGSTR1:
             "Excluded from Report (Invalid Invoice Number)",
             "Excluded from Report (Same GSTIN Billing)",
             "Excluded from Report (Is Opening Entry)",
+            "Excluded from Report (Out of Scope of GST)",
         ):
             return
 

--- a/india_compliance/gst_india/overrides/purchase_invoice.py
+++ b/india_compliance/gst_india/overrides/purchase_invoice.py
@@ -63,6 +63,9 @@ def onload(doc, method=None):
 
 def validate(doc, method=None):
     if validate_transaction(doc) is False:
+        # validate_transaction bails for out-of-scope docs before set_reconciliation_status runs below
+        if doc.get("is_out_of_scope_of_gst"):
+            set_reconciliation_status(doc)
         return
 
     validate_hsn_codes(doc)
@@ -105,7 +108,7 @@ def on_cancel(doc, method=None):
 def set_reconciliation_status(doc):
     reconciliation_status = "Not Applicable"
 
-    if is_b2b_invoice(doc):
+    if is_b2b_invoice(doc) and not doc.get("is_out_of_scope_of_gst"):
         reconciliation_status = "Unreconciled"
 
     doc.reconciliation_status = reconciliation_status

--- a/india_compliance/gst_india/overrides/sales_invoice.py
+++ b/india_compliance/gst_india/overrides/sales_invoice.py
@@ -252,6 +252,7 @@ def is_e_waybill_applicable(doc, gst_settings=None):
 
     if (
         not gst_settings.enable_e_waybill
+        or doc.get("is_out_of_scope_of_gst")
         or doc.company_gstin == doc.billing_address_gstin
         or doc.ewaybill
         or not are_goods_supplied(doc)

--- a/india_compliance/gst_india/overrides/test_transaction.py
+++ b/india_compliance/gst_india/overrides/test_transaction.py
@@ -146,6 +146,21 @@ class TestTransaction(IntegrationTestCase):
         doc = create_transaction(**self.transaction_details, is_out_of_scope_of_gst=1)
         self.assertEqual(doc.reconciliation_status, "Not Applicable")
 
+    def test_out_of_scope_of_gst_forbids_gst_accounts_after_submit(self):
+        # validate does not run on submitted edits; the submit hook carries the guard
+        if self.doctype != "Sales Invoice":
+            return
+
+        doc = create_transaction(**self.transaction_details, is_out_of_scope_of_gst=1)
+        _append_taxes(doc, ("CGST", "SGST"), rate=9)
+
+        self.assertRaisesRegex(
+            frappe.exceptions.ValidationError,
+            re.compile(r"Out of Scope of GST"),
+            sync_address_dependent_fields_on_submit,
+            doc,
+        )
+
     @change_settings(
         "GST Settings",
         {"enable_rcm_for_unregistered_supplier": 1, "rcm_threshold": 5000},

--- a/india_compliance/gst_india/overrides/test_transaction.py
+++ b/india_compliance/gst_india/overrides/test_transaction.py
@@ -122,6 +122,30 @@ class TestTransaction(IntegrationTestCase):
 
         doc.insert()
 
+    def test_out_of_scope_of_gst(self):
+        # items marked Out of Scope, GST skipped
+        doc = create_transaction(**self.transaction_details, is_out_of_scope_of_gst=1)
+
+        for item in doc.items:
+            self.assertEqual(item.gst_treatment, "Out of Scope")
+
+    def test_out_of_scope_of_gst_forbids_gst_accounts(self):
+        self.assertRaisesRegex(
+            frappe.exceptions.ValidationError,
+            re.compile(r"Out of Scope of GST"),
+            create_transaction,
+            **self.transaction_details,
+            is_in_state=True,
+            is_out_of_scope_of_gst=1,
+        )
+
+    def test_out_of_scope_of_gst_not_reconcilable(self):
+        if self.doctype != "Purchase Invoice":
+            return
+
+        doc = create_transaction(**self.transaction_details, is_out_of_scope_of_gst=1)
+        self.assertEqual(doc.reconciliation_status, "Not Applicable")
+
     @change_settings(
         "GST Settings",
         {"enable_rcm_for_unregistered_supplier": 1, "rcm_threshold": 5000},

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -836,7 +836,8 @@ def get_gst_details(
 
     # Taxes Not Applicable
     if (
-        (
+        party_details.get("is_out_of_scope_of_gst")
+        or (
             not allow_same_gstin
             and (
                 party_details.get(company_gstin_field)
@@ -1391,6 +1392,10 @@ class ItemGSTTreatment:
         self.doc = doc
         is_sales_transaction = doc.doctype in SALES_DOCTYPES
 
+        if doc.get("is_out_of_scope_of_gst"):
+            self.set_for_out_of_scope()
+            return
+
         if is_sales_transaction and is_overseas_doc(doc):
             self.set_for_overseas()
             return
@@ -1411,6 +1416,10 @@ class ItemGSTTreatment:
 
         self.update_gst_treatment_map()
         self.set_default_treatment()
+
+    def set_for_out_of_scope(self):
+        for item in self.doc.items:
+            item.gst_treatment = "Out of Scope"
 
     def set_for_overseas(self):
         for item in self.doc.items:
@@ -1612,6 +1621,9 @@ def _update_place_of_supply_and_taxes(doc):
 
 def validate_transaction(doc, method=None):
     if ignore_gst_validations(doc):
+        if doc.get("is_out_of_scope_of_gst"):
+            validate_out_of_scope(doc)
+
         set_gst_tax_type(doc)
         update_item_gst_treatment(doc)
         update_item_gst_details(doc)
@@ -1834,8 +1846,25 @@ def reset_gst_details_on_cross_mapping(target_doc, source_doc):
 
 
 def ignore_gst_validations(doc):
-    if not is_indian_registered_company(doc) or doc.get("is_opening") == "Yes":
+    if (
+        not is_indian_registered_company(doc)
+        or doc.get("is_opening") == "Yes"
+        or doc.get("is_out_of_scope_of_gst")
+    ):
         return True
+
+
+def validate_out_of_scope(doc):
+    # no GST account allowed when transaction is out of scope of GST
+    # gst_tax_type is blank under the skip gate, so match account heads directly
+    gst_accounts = set(get_all_gst_accounts(doc.company))
+    for row in doc.get("taxes") or []:
+        if row.account_head in gst_accounts:
+            frappe.throw(
+                _(
+                    "Row #{0}: Cannot charge GST account {1} since the transaction is Out of Scope of GST"
+                ).format(row.idx, bold(row.account_head))
+            )
 
 
 def on_change_item(doc, method=None):
@@ -1857,6 +1886,9 @@ def on_change_item(doc, method=None):
 
 
 def before_update_after_submit(doc, method=None):
+    if doc.get("is_out_of_scope_of_gst"):
+        validate_out_of_scope(doc)
+
     if ignore_gst_validations(doc):
         return
 
@@ -1884,6 +1916,9 @@ ADDRESS_DEPENDENT_FIELDS = {
 
 
 def sync_address_dependent_fields_on_submit(doc, method=None):
+    if doc.docstatus == 1 and doc.get("is_out_of_scope_of_gst"):
+        validate_out_of_scope(doc)
+
     if doc.docstatus != 1 or ignore_gst_validations(doc):
         return
 

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -268,7 +268,9 @@ def set_gst_tax_type(doc, method=None):
     if not doc.taxes:
         return
 
-    gst_tax_account_map = {} if ignore_gst_validations(doc) else get_gst_account_gst_tax_type_map()
+    # out-of-scope still needs tax types resolved so GST accounts can be forbidden
+    skip_gst_tax_type = ignore_gst_validations(doc) and not doc.get("is_out_of_scope_of_gst")
+    gst_tax_account_map = {} if skip_gst_tax_type else get_gst_account_gst_tax_type_map()
 
     for tax in doc.taxes:
         # Setting as None if not GST Account
@@ -1622,9 +1624,10 @@ def _update_place_of_supply_and_taxes(doc):
 def validate_transaction(doc, method=None):
     if ignore_gst_validations(doc):
         if doc.get("is_out_of_scope_of_gst"):
-            validate_out_of_scope(doc)
+            validate_out_of_scope(doc)  # also resolves gst_tax_type
+        else:
+            set_gst_tax_type(doc)
 
-        set_gst_tax_type(doc)
         update_item_gst_treatment(doc)
         update_item_gst_details(doc)
         return False
@@ -1856,10 +1859,10 @@ def ignore_gst_validations(doc):
 
 def validate_out_of_scope(doc):
     # no GST account allowed when transaction is out of scope of GST
-    # gst_tax_type is blank under the skip gate, so match account heads directly
-    gst_accounts = set(get_all_gst_accounts(doc.company))
+    # resolve gst_tax_type first since the skip gate leaves it blank otherwise
+    set_gst_tax_type(doc)
     for row in doc.get("taxes") or []:
-        if row.account_head in gst_accounts:
+        if row.gst_tax_type:
             frappe.throw(
                 _(
                     "Row #{0}: Cannot charge GST account {1} since the transaction is Out of Scope of GST"

--- a/india_compliance/gst_india/report/e_invoice_summary/e_invoice_summary.py
+++ b/india_compliance/gst_india/report/e_invoice_summary/e_invoice_summary.py
@@ -64,6 +64,7 @@ def get_data(filters=None):
         .where(IfNull(sales_invoice.einvoice_status, "") != "")
         .where(sales_invoice.docstatus != 0)
         .where(sales_invoice.is_opening != "Yes")
+        .where(IfNull(sales_invoice.is_out_of_scope_of_gst, 0) == 0)
     )
 
     if filters.get("company"):

--- a/india_compliance/gst_india/report/gst_account_wise_summary/gst_account_wise_summary.py
+++ b/india_compliance/gst_india/report/gst_account_wise_summary/gst_account_wise_summary.py
@@ -329,6 +329,7 @@ class AccountWiseSummary:
 
         if filters.get("doctype") not in ["Journal Entry", "Bill of Entry"]:
             query = query.where(doc.company_gstin != IfNull(doc[filters.gstin_field], ""))
+            query = query.where(IfNull(doc.is_out_of_scope_of_gst, 0) == 0)
 
         if filters.get("doctype") != "Bill of Entry":
             query = query.where(doc.is_opening == "No")

--- a/india_compliance/gst_india/report/gst_tax_rate_wise_summary/gst_tax_rate_wise_summary.py
+++ b/india_compliance/gst_india/report/gst_tax_rate_wise_summary/gst_tax_rate_wise_summary.py
@@ -132,6 +132,7 @@ def process_data(data):
         "Nil-Rated",
         "Exempted",
         "Non-GST",
+        "Out of Scope",
     ]
 
     # Sort the dictionary based on the sort order
@@ -168,6 +169,7 @@ def get_doctype_wise_data(filters, doctype):
             (doc.is_opening == "No")
             & (doc.company_gstin != IfNull(doc[filters.gstin_field], ""))
             & (doc.is_reverse_charge == filters.is_reverse_charge)
+            & (IfNull(doc.is_out_of_scope_of_gst, 0) == 0)
         )
 
     if filters.get("company_gstin"):

--- a/india_compliance/gst_india/report/summary_of_itc_availed/summary_of_itc_availed.py
+++ b/india_compliance/gst_india/report/summary_of_itc_availed/summary_of_itc_availed.py
@@ -142,6 +142,7 @@ class ITCAvailedData:
                 (doc.company_gstin != IfNull(doc.supplier_gstin, ""))
                 & (doc.is_opening == "No")
                 & (doc.is_boe_applicable == 0)
+                & (IfNull(doc.is_out_of_scope_of_gst, 0) == 0)
             )
         )
 

--- a/india_compliance/gst_india/setup/__init__.py
+++ b/india_compliance/gst_india/setup/__init__.py
@@ -13,6 +13,7 @@ from india_compliance.gst_india.constants.custom_fields import (
     EDUCATION_CUSTOM_FIELDS,
     HEALTHCARE_CUSTOM_FIELDS,
     HRMS_CUSTOM_FIELDS,
+    OUT_OF_SCOPE_OF_GST_FIELDS,
     PURCHASE_REVERSE_CHARGE_FIELDS,
     SALES_REVERSE_CHARGE_FIELDS,
 )
@@ -331,6 +332,7 @@ def get_all_custom_fields():
         CUSTOM_FIELDS,
         SALES_REVERSE_CHARGE_FIELDS,
         PURCHASE_REVERSE_CHARGE_FIELDS,
+        OUT_OF_SCOPE_OF_GST_FIELDS,
         E_INVOICE_FIELDS,
         E_WAYBILL_FIELDS,
     ):

--- a/india_compliance/gst_india/utils/e_invoice.py
+++ b/india_compliance/gst_india/utils/e_invoice.py
@@ -537,6 +537,9 @@ def validate_e_invoice_applicability(doc, gst_settings=None, throw=True):
             exc=AlreadyGeneratedError,
         )
 
+    if doc.get("is_out_of_scope_of_gst"):
+        return _throw(_("e-Invoice is not applicable for transactions Out of Scope of GST"))
+
     if doc.company_gstin == doc.billing_address_gstin:
         return _throw(_("e-Invoice is not applicable for invoices with same company and billing GSTIN"))
 

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -1393,6 +1393,12 @@ class EWaybillData(GSTTransactionData):
         - Outward Material Transfer with different company and supplier gstin
         """
 
+        if self.doc.get("is_out_of_scope_of_gst"):
+            frappe.throw(
+                _("e-Waybill is not applicable for transactions Out of Scope of GST"),
+                exc=NotApplicableError,
+            )
+
         address = ADDRESS_FIELDS.get(self.doc.doctype)
         for key in ("bill_from", "bill_to"):
             if not self.doc.get(address[key]):

--- a/india_compliance/gst_india/utils/gstr3b/gstr3b_inward_data.py
+++ b/india_compliance/gst_india/utils/gstr3b/gstr3b_inward_data.py
@@ -258,6 +258,7 @@ class GSTR3BInwardQuery:
             .where(self.PI.is_opening == "No")
             .where(self.PI.company_gstin != IfNull(self.PI.supplier_gstin, ""))
             .where(self.PI.is_boe_applicable == 0)
+            .where(IfNull(self.PI.is_out_of_scope_of_gst, 0) == 0)
         )
 
         return self.get_query_with_common_filters(query, self.PI)

--- a/india_compliance/gst_india/utils/gstr_1/gstr_1_data.py
+++ b/india_compliance/gst_india/utils/gstr_1/gstr_1_data.py
@@ -133,6 +133,7 @@ class GSTR1Query:
             )
             .where(self.si.docstatus == 1)
             .where(self.si.is_opening != "Yes")
+            .where(IfNull(self.si.is_out_of_scope_of_gst, 0) == 0)
             .where(IfNull(self.si.billing_address_gstin, "") != self.si.company_gstin)
             .orderby(
                 self.si.posting_date,
@@ -736,6 +737,7 @@ class GSTR1DocumentIssuedSummary:
             self.sales_invoice.is_return,
             self.sales_invoice.is_debit_note,
             self.sales_invoice.is_opening,
+            self.sales_invoice.is_out_of_scope_of_gst,
         ]
 
         query = self.build_query(
@@ -756,6 +758,7 @@ class GSTR1DocumentIssuedSummary:
     def get_query_for_purchase_invoice(self):
         additional_selects = [
             self.purchase_invoice.is_opening,
+            self.purchase_invoice.is_out_of_scope_of_gst,
         ]
 
         additional_conditions = [
@@ -892,6 +895,7 @@ class GSTR1DocumentIssuedSummary:
             "Excluded from Report (Invalid Invoice Number)": [],
             "Excluded from Report (Same GSTIN Billing)": [],
             "Excluded from Report (Is Opening Entry)": [],
+            "Excluded from Report (Out of Scope of GST)": [],
             "Invoices for outward supply": [],
             "Debit Note": [],
             "Credit Note": [],
@@ -907,6 +911,8 @@ class GSTR1DocumentIssuedSummary:
                 nature_of_document["Excluded from Report (Is Opening Entry)"].append(doc)
             elif doc.same_gstin_billing:
                 nature_of_document["Excluded from Report (Same GSTIN Billing)"].append(doc)
+            elif doc.get("is_out_of_scope_of_gst"):
+                nature_of_document["Excluded from Report (Out of Scope of GST)"].append(doc)
             elif doctype == "Purchase Invoice":
                 nature_of_document["Invoices for inward supply from unregistered person"].append(doc)
             elif doctype == "Stock Entry" or doctype == "Subcontracting Receipt":

--- a/india_compliance/gst_india/utils/gstr_1/gstr_1_data.py
+++ b/india_compliance/gst_india/utils/gstr_1/gstr_1_data.py
@@ -910,6 +910,7 @@ class GSTR1DocumentIssuedSummary:
             elif doc.is_opening == "Yes":
                 nature_of_document["Excluded from Report (Is Opening Entry)"].append(doc)
             elif doc.same_gstin_billing:
+                # same-GSTIN is the more specific reason; out-of-scope catches the rest
                 nature_of_document["Excluded from Report (Same GSTIN Billing)"].append(doc)
             elif doc.get("is_out_of_scope_of_gst"):
                 nature_of_document["Excluded from Report (Out of Scope of GST)"].append(doc)

--- a/india_compliance/patches.txt
+++ b/india_compliance/patches.txt
@@ -5,7 +5,7 @@ execute:from frappe.installer import add_module_defs; add_module_defs("india_com
 
 [post_model_sync]
 india_compliance.patches.v14.set_default_for_overridden_accounts_setting
-execute:from india_compliance.gst_india.setup import create_custom_fields; create_custom_fields() #73
+execute:from india_compliance.gst_india.setup import create_custom_fields; create_custom_fields() #74
 execute:from india_compliance.gst_india.setup import create_property_setters; create_property_setters() #12
 execute:from india_compliance.income_tax_india.setup import create_custom_fields; create_custom_fields() #7
 india_compliance.patches.post_install.remove_old_fields #2
@@ -87,3 +87,4 @@ india_compliance.patches.v16.update_tax_id_for_tax_withholding_entries
 india_compliance.patches.v16.sync_financial_report_templates
 india_compliance.patches.v16.update_tds_section_display_name
 execute:import frappe; frappe.db.set_single_value("GST Settings", "nil_exempt_e_invoice_treatment", "Do Not Generate")
+india_compliance.patches.v16.set_out_of_scope_for_internal_transactions

--- a/india_compliance/patches/v16/set_out_of_scope_for_internal_transactions.py
+++ b/india_compliance/patches/v16/set_out_of_scope_for_internal_transactions.py
@@ -1,0 +1,28 @@
+import frappe
+from frappe.query_builder.functions import IfNull
+
+# Internal transfer / self-billing: company GSTIN == party GSTIN.
+# These are already cleared of GST and excluded from returns; flag them so the
+# new override is visible and consistent. Only invoices (not DN/PR, which can be
+# legitimate same-GSTIN goods movements that still need an e-Waybill).
+# (doctype, party_gstin_field)
+TRANSACTIONS = [
+    ("Sales Invoice", "billing_address_gstin"),
+    ("Purchase Invoice", "supplier_gstin"),
+]
+
+
+def execute():
+    if not frappe.get_all("Company", {"country": "India"}, pluck="name"):
+        return
+
+    for doctype, party_field in TRANSACTIONS:
+        doc = frappe.qb.DocType(doctype)
+        (
+            frappe.qb.update(doc)
+            .set(doc.is_out_of_scope_of_gst, 1)
+            .where(doc.docstatus == 1)
+            .where(IfNull(doc.company_gstin, "") != "")  # both-empty must not match
+            .where(doc.company_gstin == doc[party_field])
+            .where(IfNull(doc.is_out_of_scope_of_gst, 0) == 0)
+        ).run()

--- a/india_compliance/patches/v16/set_out_of_scope_for_internal_transactions.py
+++ b/india_compliance/patches/v16/set_out_of_scope_for_internal_transactions.py
@@ -13,7 +13,8 @@ TRANSACTIONS = [
 
 
 def execute():
-    if not frappe.get_all("Company", {"country": "India"}, pluck="name"):
+    indian_companies = frappe.get_all("Company", {"country": "India"}, pluck="name")
+    if not indian_companies:
         return
 
     for doctype, party_field in TRANSACTIONS:
@@ -21,7 +22,8 @@ def execute():
         (
             frappe.qb.update(doc)
             .set(doc.is_out_of_scope_of_gst, 1)
-            .where(doc.docstatus == 1)
+            .where(doc.company.isin(indian_companies))  # multi-company: only Indian companies
+            .where(doc.docstatus == 1)  # submitted only; cancelled docs left as-is
             .where(IfNull(doc.company_gstin, "") != "")  # both-empty must not match
             .where(doc.company_gstin == doc[party_field])
             .where(IfNull(doc.is_out_of_scope_of_gst, 0) == 0)

--- a/india_compliance/public/js/transaction.js
+++ b/india_compliance/public/js/transaction.js
@@ -38,7 +38,13 @@ for (const doctype of ["Sales Invoice", "Sales Order", "Delivery Note"]) {
 }
 
 function fetch_gst_details(doctype) {
-    const event_fields = ["tax_category", "company_gstin", "place_of_supply", "is_reverse_charge"];
+    const event_fields = [
+        "tax_category",
+        "company_gstin",
+        "place_of_supply",
+        "is_reverse_charge",
+        "is_out_of_scope_of_gst",
+    ];
 
     // we are using address below to prevent multiple event triggers
     if (frappe.boot.sales_doctypes.includes(doctype)) {
@@ -122,6 +128,7 @@ async function update_gst_details(frm, event) {
         "company_gstin",
         "place_of_supply",
         "is_reverse_charge",
+        "is_out_of_scope_of_gst",
     ];
 
     if (frappe.boot.sales_doctypes.includes(frm.doc.doctype)) {


### PR DESCRIPTION
> **no-docs** — end-user documentation for this override will follow as a separate PR in `india-compliance-docs`.

## Summary

Adds a manual document-level override **"Out of Scope of GST"** so a transaction (e.g. merchant trade) is kept entirely outside the GST framework — no GST accounts, no e-Waybill/e-Invoice, and excluded from every GST report and return. Self-billing / internal-transfer invoices (which the framework already treats as outside GST) are auto-flagged via a migration patch.

Closes #1455

## What's included (maps to the issue checklist)

- **Checkbox on documents** — new `is_out_of_scope_of_gst` Check on all sales/purchase transactions (same doctype set as reverse charge; POS Invoice & Stock Entry excluded, matching existing convention).
- **Item GST Treatment** — new item `gst_treatment` value `"Out of Scope"`, assigned to all items when the flag is set.
- **Validate GST Accounts** — the flag is routed through `ignore_gst_validations` (skips the GST pipeline) and a dedicated `validate_out_of_scope()` forbids any GST tax account on the document, detected via `gst_tax_type` (`set_gst_tax_type` resolves it for out-of-scope docs). Wired into the create path **and** the after-submit hooks.
- **Reporting exclusion** — one WHERE on the outward backbone (`GSTR1Query.get_base_query`) and one on the inward backbone (`GSTR3BInwardQuery.get_base_purchase_query`) cover GSTR-1/3B + the sales/purchase/HSN registers. Explicit filters added to the tax-rate-wise, ITC-availed, account-wise (inside the existing JE/BOE guard) and e-invoice-summary reports. Flagged docs surface in a dedicated **"Excluded from Report (Out of Scope of GST)"** bucket in the Document Issued Summary, so issued-document counts stay correct.
- **e-Waybill & e-Invoice applicability** — predicate guards force "Not Applicable", plus a hard block in `EWaybillData.validate_applicability` (the manual-generation path the predicate doesn't gate).
- **Purchase Reconciliation** — `set_reconciliation_status` is flag-aware and now runs on the out-of-scope early-return path, so flagged Purchase Invoices become "Not Applicable" and drop out of both the Purchase Reconciliation Tool and IMS.
- **Auto-enable patch** — `v16/set_out_of_scope_for_internal_transactions` backfills the flag for historical self-billing **invoices** (`company_gstin == party_gstin`), scoped to Indian companies, with a both-empty-GSTIN guard and idempotency. Delivery Notes/Receipts are intentionally excluded (same-GSTIN goods movements still need an e-Waybill). The `create_custom_fields` patch marker is bumped so existing sites create the new field on migrate.

## Design notes

- **Document-level checkbox is authoritative**; the new item treatment value is set from it. Reporting exclusion happens at the query level, so a Non-GST-style "still reported" leak is avoided.
- `"Out of Scope"` is deliberately **not** in `TAXABLE_GST_TREATMENTS`, so it is treated as non-taxable everywhere automatically.
- No `no_copy` on the field — it carries through amend and the document flow (SO → DN → SI), matching `is_reverse_charge`.
- No new GST Settings toggle (checkbox ships always-on, per maintainer direction).

## Tests

Added to the parametrized `TestTransaction`: items become `"Out of Scope"`, charging a GST account throws (insert and after-submit paths), and an out-of-scope Purchase Invoice gets `reconciliation_status = "Not Applicable"`.

## Verification

`py_compile`, `node --check`, `ruff check`, `ruff format --check` and `prettier --check` all pass on the changed files. The Frappe integration suite was **not** run in the authoring environment (no `bench`/DB) — recommend `bench run-tests --module india_compliance.gst_india.overrides.test_transaction` on a real site before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H3HCYgtY9m57W2Mm7tqdTu