### PR TITLE
fix: multiple fixes to custom taxes controller

### DIFF
--- a/india_compliance/gst_india/doctype/bill_of_entry/test_bill_of_entry.py
+++ b/india_compliance/gst_india/doctype/bill_of_entry/test_bill_of_entry.py
@@ -271,6 +271,10 @@ class TestBillofEntry(IntegrationTestCase):
         self.assertEqual(actual_row.item_wise_tax_rates, manual_rates)
         self.assertEqual(actual_row.tax_amount, 18)
 
+        # Actual rows are user-entered and must still be included in the totals.
+        self.assertEqual(boe.total_taxes, 18)
+        self.assertEqual(boe.total_amount_payable, boe.total_customs_duty + 18)
+
     def test_pending_boe_qty(self):
         pi = create_purchase_invoice(supplier="_Test Foreign Supplier", update_stock=1)
 

--- a/india_compliance/gst_india/doctype/bill_of_entry/test_bill_of_entry.py
+++ b/india_compliance/gst_india/doctype/bill_of_entry/test_bill_of_entry.py
@@ -243,6 +243,34 @@ class TestBillofEntry(IntegrationTestCase):
 
         boe.save()
 
+    def test_charge_type_actual_preserves_item_wise_tax_rates(self):
+
+        pi = create_purchase_invoice(supplier="_Test Foreign Supplier", update_stock=1)
+
+        boe = make_bill_of_entry(pi.name)
+        boe.bill_of_entry_no = "123"
+        boe.bill_of_entry_date = today()
+        boe.save()
+
+        manual_rates = json.dumps({boe.items[0].name: 18})
+        boe.taxes = []
+        boe.append(
+            "taxes",
+            {
+                "charge_type": "Actual",
+                "account_head": "Input Tax IGST - _TIRC",
+                "tax_amount": 18,
+                "cost_center": "Main - _TIRC",
+                "item_wise_tax_rates": manual_rates,
+            },
+        )
+
+        boe.save()
+
+        actual_row = next(tax for tax in boe.taxes if tax.charge_type == "Actual")
+        self.assertEqual(actual_row.item_wise_tax_rates, manual_rates)
+        self.assertEqual(actual_row.tax_amount, 18)
+
     def test_pending_boe_qty(self):
         pi = create_purchase_invoice(supplier="_Test Foreign Supplier", update_stock=1)
 

--- a/india_compliance/gst_india/overrides/test_subcontracting_transaction.py
+++ b/india_compliance/gst_india/overrides/test_subcontracting_transaction.py
@@ -1,3 +1,4 @@
+import json
 import re
 
 import frappe
@@ -12,8 +13,12 @@ from erpnext.stock.doctype.stock_entry.stock_entry import make_stock_in_entry
 from erpnext.subcontracting.doctype.subcontracting_order.subcontracting_order import (
     make_subcontracting_receipt,
 )
-from frappe.tests import IntegrationTestCase
+from frappe.tests import IntegrationTestCase, UnitTestCase
 
+from india_compliance.gst_india.utils.taxes_controller import (
+    CustomTaxController,
+    set_item_wise_tax_rates,
+)
 from india_compliance.gst_india.utils.tests import (
     SUBCONTRACTING_TEST_FINISHED_ITEM,
     SUBCONTRACTING_TEST_FINISHED_ITEM_2,
@@ -561,3 +566,70 @@ class TestAddressMappingAfterMapping(IntegrationTestCase):
         self.assertEqual(target_se.bill_to_gstin, source_se.bill_to_gstin)
         self.assertEqual(target_se.ship_from_address, source_se.ship_from_address)
         self.assertEqual(target_se.ship_to_address, source_se.ship_to_address)
+
+
+def _make_taxes_controller_doc(items=None, taxes=None):
+    """Build a client-style _dict doc as produced by json.loads(..., object_hook=_dict)."""
+    data = {"doctype": "Subcontracting Order"}
+    if items is not None:
+        data["items"] = items
+    if taxes is not None:
+        data["taxes"] = taxes
+    return json.loads(json.dumps(data), object_hook=frappe._dict)
+
+
+class TestCustomTaxController(UnitTestCase):
+    def test_get_rows_to_update_defaults_empty_items_to_list(self):
+        """Missing/null items (new doc before any row is added) must yield [], not None."""
+        doc = _make_taxes_controller_doc(items=None, taxes=[{"name": "tax1"}])
+        items, taxes = CustomTaxController(doc).get_rows_to_update()
+
+        self.assertEqual(items, [])
+        self.assertEqual(len(taxes), 1)
+
+    def test_get_rows_to_update_filters_by_name(self):
+        """item_name/tax_name must actually filter (the old _dict.get default form never did)."""
+        doc = _make_taxes_controller_doc(
+            items=[{"name": "item1"}, {"name": "item2"}],
+            taxes=[{"name": "tax1"}, {"name": "tax2"}],
+        )
+
+        items, taxes = CustomTaxController(doc).get_rows_to_update(item_name="item2", tax_name="tax1")
+        self.assertEqual([item.name for item in items], ["item2"])
+        self.assertEqual([tax.name for tax in taxes], ["tax1"])
+
+        # No filter => all rows.
+        items, taxes = CustomTaxController(doc).get_rows_to_update()
+        self.assertEqual(len(items), 2)
+        self.assertEqual(len(taxes), 2)
+
+    def test_taxes_calculation_when_item_is_null(self):
+        edited_tax = "new-india-compliance-taxes-and-charges-jaoikbhpue"
+        doc_json = json.dumps(
+            {
+                "doctype": "Subcontracting Order",
+                "company": "_Test Company",
+                "items": None,
+                "taxes": [
+                    {
+                        "name": "new-india-compliance-taxes-and-charges-orwoljgdqa",
+                        "charge_type": "On Net Total",
+                        "account_head": "Input Tax CGST - FP",
+                        "gst_tax_type": "cgst",
+                    },
+                    {
+                        "name": edited_tax,
+                        "charge_type": "On Net Total",
+                        "account_head": "Input Tax SGST - FP",
+                        "gst_tax_type": "sgst",
+                    },
+                ],
+            }
+        )
+
+        frappe.response.docs = []
+        set_item_wise_tax_rates(doc=doc_json, item_name="", tax_name=edited_tax)
+
+        echoed = frappe.response.docs[0]
+        edited_row = next(tax for tax in echoed.taxes if tax.name == edited_tax)
+        self.assertEqual(edited_row.get("item_wise_tax_rates"), "{}")

--- a/india_compliance/gst_india/utils/taxes_controller.py
+++ b/india_compliance/gst_india/utils/taxes_controller.py
@@ -132,12 +132,14 @@ class CustomTaxController:
 
         for tax in taxes:
             if tax.charge_type == "Actual":
+                # User may set item_wise_tax_rates manually for Actual; only default it.
                 if not tax.item_wise_tax_rates:
                     tax.item_wise_tax_rates = "{}"
 
                 continue
 
             if not items:
+                # No items to rate: clear any stale per-item rates; skip the rate lookup.
                 tax.item_wise_tax_rates = "{}"
                 continue
 

--- a/india_compliance/gst_india/utils/taxes_controller.py
+++ b/india_compliance/gst_india/utils/taxes_controller.py
@@ -137,6 +137,10 @@ class CustomTaxController:
 
                 continue
 
+            if not items:
+                tax.item_wise_tax_rates = "{}"
+                continue
+
             item_wise_tax_rates = json.loads(tax.item_wise_tax_rates) if tax.item_wise_tax_rates else {}
 
             for item in items:
@@ -211,9 +215,16 @@ class CustomTaxController:
         """
         Returns items and taxes to update based on item_name and tax_name passed.
         If item_name and tax_name are not passed, all items and taxes are returned.
+
         """
-        items = self.doc.get("items", {"name": item_name}) if item_name else self.doc.get("items")
-        taxes = self.doc.get("taxes", {"name": tax_name}) if tax_name else self.doc.taxes
+        items = self.doc.get("items") or []
+        taxes = self.doc.get("taxes") or []
+
+        if item_name:
+            items = [item for item in items if item.name == item_name]
+
+        if tax_name:
+            taxes = [tax for tax in taxes if tax.name == tax_name]
 
         return items, taxes
 

--- a/india_compliance/gst_india/utils/taxes_controller.py
+++ b/india_compliance/gst_india/utils/taxes_controller.py
@@ -164,12 +164,12 @@ class CustomTaxController:
 
         for tax in self.doc.taxes:
             if tax.charge_type == "Actual":
-                continue
+                tax.tax_amount = flt(tax.tax_amount)
+            else:
+                tax.tax_amount = self.get_tax_amount(tax.item_wise_tax_rates, tax.charge_type)
 
-            tax.tax_amount = self.get_tax_amount(tax.item_wise_tax_rates, tax.charge_type)
-
-            if tax.account_head in round_off_accounts:
-                tax.tax_amount = round(tax.tax_amount, 0)
+                if tax.account_head in round_off_accounts:
+                    tax.tax_amount = round(tax.tax_amount, 0)
 
             total_taxes += tax.tax_amount
             tax.base_total = total_taxes + total_taxable_value

--- a/india_compliance/public/js/taxes_controller.js
+++ b/india_compliance/public/js/taxes_controller.js
@@ -192,7 +192,7 @@ india_compliance.taxes_controller = class TaxesController {
         return (
             this.frm.doc.items.reduce((total, item) => {
                 let multiplier =
-                    item.charge_type === "On Item Quantity" ? item.qty : item.taxable_value / 100;
+                    tax_row.charge_type === "On Item Quantity" ? item.qty : item.taxable_value / 100;
                 return total + multiplier * (item_wise_tax_rates[item.name] || tax_row.rate);
             }, 0) || 0
         );

--- a/india_compliance/public/js/taxes_controller.js
+++ b/india_compliance/public/js/taxes_controller.js
@@ -95,7 +95,7 @@ india_compliance.taxes_controller = class TaxesController {
 
         taxes.forEach((tax) => {
             const item_wise_tax_rates = JSON.parse(tax.item_wise_tax_rates || "{}");
-            this.frm.doc.items.forEach((item) => {
+            (this.frm.doc.items || []).forEach((item) => {
                 if (item.item_tax_template) return;
                 item_wise_tax_rates[item.name] = tax.rate;
             });
@@ -153,12 +153,16 @@ india_compliance.taxes_controller = class TaxesController {
         const total_taxable_value = this.calculate_total_taxable_value();
 
         this.frm.doc.taxes.forEach(async (row) => {
-            if (!row.charge_type || row.charge_type === "Actual") return;
+            if (!row.charge_type) return;
 
-            row.tax_amount = this.get_tax_amount(row);
+            if (row.charge_type === "Actual") {
+                row.tax_amount = flt(row.tax_amount);
+            } else {
+                row.tax_amount = this.get_tax_amount(row);
 
-            if (frappe.flags.round_off_applicable_accounts?.includes(row.account_head))
-                row.tax_amount = Math.round(row.tax_amount);
+                if (frappe.flags.round_off_applicable_accounts?.includes(row.account_head))
+                    row.tax_amount = Math.round(row.tax_amount);
+            }
 
             total_taxes += row.tax_amount;
             row.base_total = total_taxes + total_taxable_value;
@@ -191,7 +195,7 @@ india_compliance.taxes_controller = class TaxesController {
 
         const item_wise_tax_rates = JSON.parse(tax_row.item_wise_tax_rates || "{}");
         return (
-            this.frm.doc.items.reduce((total, item) => {
+            (this.frm.doc.items || []).reduce((total, item) => {
                 let multiplier =
                     tax_row.charge_type === "On Item Quantity" ? item.qty : item.taxable_value / 100;
                 return total + multiplier * (item_wise_tax_rates[item.name] || tax_row.rate);
@@ -201,7 +205,7 @@ india_compliance.taxes_controller = class TaxesController {
 
     calculate_total_taxable_value() {
         return (
-            this.frm.doc.items.reduce((total, item) => {
+            (this.frm.doc.items || []).reduce((total, item) => {
                 return total + item.taxable_value;
             }, 0) || 0
         );

--- a/india_compliance/public/js/taxes_controller.js
+++ b/india_compliance/public/js/taxes_controller.js
@@ -133,10 +133,11 @@ india_compliance.taxes_controller = class TaxesController {
             return flt(flt(qty) * flt(rate), precision(precisionType, row));
         };
 
-        if (this.frm.doc.doctype === "Subcontracting Receipt") {
-            amount = calculateAmount(row.qty, row.rate, "amount");
-        } else if (this.frm.doc.doctype === "Stock Entry") {
+        if (this.frm.doc.doctype === "Stock Entry") {
             amount = calculateAmount(row.transfer_qty, row.basic_rate, "basic_amount");
+        } else {
+            // Subcontracting Order / Subcontracting Receipt use qty * rate
+            amount = calculateAmount(row.qty, row.rate, "amount");
         }
 
         row.taxable_value = amount;


### PR DESCRIPTION
- calculate correct taxes for `On Quantity` charge type
- calculate the correct taxable value for the subcontracting order
- handle tax calculation when the item is empty
- add test case for actual row preservation
- correct totals incase of Actual Charge Type

closes: #4508 