### PR TITLE
fix: resolve virtual fields using property instead of handling them manually using onload

### DIFF
--- a/india_compliance/gst_india/overrides/ineligible_itc.py
+++ b/india_compliance/gst_india/overrides/ineligible_itc.py
@@ -10,6 +10,7 @@ from frappe import _
 from frappe.utils import flt, get_link_to_form
 
 from india_compliance.gst_india.constants import GST_TAX_TYPES
+from india_compliance.gst_india.overrides.purchase_invoice import get_ineligibility_reason
 from india_compliance.gst_india.overrides.transaction import (
     is_indian_registered_company,
 )
@@ -311,14 +312,10 @@ class IneligibleITC:
         )
 
     def is_eligibility_restricted_due_to_pos(self):
-        return self.doc.get("ineligibility_reason") == "ITC restricted due to PoS rules"
+        return get_ineligibility_reason(self.doc) == "ITC restricted due to PoS rules"
 
 
 class PurchaseReceipt(IneligibleITC):
-    def __init__(self, doc):
-        doc.run_method("onload")
-        super().__init__(doc)
-
     def update_valuation_rate(self):
         for item in self.doc.items:
             item._remarks = self.doc.get("remarks") or _("Accounting Entry for {0}").format(

--- a/india_compliance/gst_india/overrides/purchase_invoice.py
+++ b/india_compliance/gst_india/overrides/purchase_invoice.py
@@ -261,26 +261,43 @@ def get_tax_amount(taxes, gst_tax_type):
     )
 
 
-def set_ineligibility_reason(doc, show_alert=True):
-    doc.ineligibility_reason = ""
+def get_ineligibility_reason(doc):
+    """
+    Return the ITC ineligibility reason.
+    """
+    ineligibility_reason = ""
 
     for item in doc.items:
         if item.is_ineligible_for_itc:
-            doc.ineligibility_reason = "Ineligible As Per Section 17(5)"
+            ineligibility_reason = "Ineligible As Per Section 17(5)"
             break
 
     if (
-        doc.place_of_supply not in ["96-Other Countries", "97-Other Territory"]
+        doc.place_of_supply
+        and doc.company_gstin
+        and doc.place_of_supply not in ["96-Other Countries", "97-Other Territory"]
         and doc.place_of_supply[:2] != doc.company_gstin[:2]
     ):
-        doc.ineligibility_reason = "ITC restricted due to PoS rules"
+        ineligibility_reason = "ITC restricted due to PoS rules"
 
-    if show_alert and doc.ineligibility_reason:
-        frappe.msgprint(
-            _("ITC Ineligible: {0}").format(frappe.bold(doc.ineligibility_reason)),
-            alert=True,
-            indicator="orange",
-        )
+    return ineligibility_reason
+
+
+def show_ineligibility_alert(reason):
+    if not reason:
+        return
+    frappe.msgprint(
+        _("ITC Ineligible: {0}").format(frappe.bold(reason)),
+        alert=True,
+        indicator="orange",
+    )
+
+
+def set_ineligibility_reason(doc, show_alert=True):
+    doc.ineligibility_reason = get_ineligibility_reason(doc)
+
+    if show_alert:
+        show_ineligibility_alert(doc.ineligibility_reason)
 
 
 def validate_reverse_charge(doc):

--- a/india_compliance/gst_india/overrides/purchase_receipt.py
+++ b/india_compliance/gst_india/overrides/purchase_receipt.py
@@ -1,7 +1,8 @@
 import frappe
 
 from india_compliance.gst_india.overrides.purchase_invoice import (
-    set_ineligibility_reason,
+    get_ineligibility_reason,
+    show_ineligibility_alert,
 )
 from india_compliance.gst_india.overrides.sales_invoice import (
     update_dashboard_with_gst_logs,
@@ -34,8 +35,6 @@ def onload(doc, method=None):
     ):
         return
 
-    set_ineligibility_reason(doc, show_alert=False)
-
     # Load e-waybill info if applicable
     if not doc.get("ewaybill"):
         return
@@ -55,4 +54,5 @@ def validate(doc, method=None):
     if validate_transaction(doc) is False:
         return
 
-    set_ineligibility_reason(doc)
+    reason = get_ineligibility_reason(doc)
+    show_ineligibility_alert(reason)

--- a/india_compliance/gst_india/overrides/subcontracting_transaction.py
+++ b/india_compliance/gst_india/overrides/subcontracting_transaction.py
@@ -2,7 +2,7 @@ import frappe
 from erpnext.accounts.party import get_address_tax_category
 from erpnext.stock.get_item_details import ItemDetailsCtx, get_item_tax_template
 from frappe import _, bold
-from frappe.contacts.doctype.address.address import get_address_display, get_default_address
+from frappe.contacts.doctype.address.address import get_default_address
 from frappe.utils import flt
 from pypika import Order
 
@@ -119,8 +119,6 @@ def update_address_fields(doc, source_doc):
     doc.ship_from_address = address_map.ship_from
     doc.ship_to_address = address_map.ship_to
 
-    set_address_display(doc)
-
 
 def set_address_for_subcontracting_inward(doc, source_doc):
     """Set company (bill_from) -> customer (bill_to) addresses for Subcontracting Inward Stock Entries."""
@@ -129,8 +127,6 @@ def set_address_for_subcontracting_inward(doc, source_doc):
 
     if not doc.bill_to_address:
         doc.bill_to_address = get_default_address("Customer", source_doc.customer)
-
-    set_address_display(doc)
 
 
 def get_mapped_address(doc, source_doc):
@@ -253,9 +249,6 @@ def get_dashboard_data(data):
 
 def onload(doc, method=None):
     if doc.doctype == "Stock Entry":
-        set_address_display(doc)
-
-        # For e-Waybill data mapping
         doc.company_gstin = doc.bill_from_gstin
         doc.supplier_gstin = doc.bill_to_gstin
         doc.gst_category = doc.bill_to_gst_category
@@ -471,19 +464,6 @@ class SubcontractingGSTAccounts(GSTAccounts):
         for row in self.gst_tax_rows:
             # validating charge type "On Item Quantity" and non_cess_advol_account
             self.validate_charge_type_for_cess_non_advol_accounts(row)
-
-
-def set_address_display(doc):
-    adddress_fields = (
-        "bill_from_address",
-        "bill_to_address",
-        "ship_from_address",
-        "ship_to_address",
-    )
-
-    for address in adddress_fields:
-        if doc.get(address):
-            setattr(doc, address + "_display", get_address_display(doc.get(address)))
 
 
 @frappe.whitelist()

--- a/india_compliance/gst_india/overrides/test_subcontracting_transaction.py
+++ b/india_compliance/gst_india/overrides/test_subcontracting_transaction.py
@@ -273,8 +273,15 @@ class TestSubcontractingTransaction(IntegrationTestCase):
     def test_create_and_update_stock_entry(self):
         stock_entry = make_subcontracting_stock_entry(do_not_submit=True)
 
-        # Update the subcontracting transaction
-        stock_entry.run_method("onload")  # update virtual fields
+        self.assertTrue(stock_entry.bill_from_address_display)
+        self.assertTrue(stock_entry.bill_to_address_display)
+        self.assertEqual(
+            stock_entry.as_dict().get("bill_from_address_display"),
+            stock_entry.bill_from_address_display,
+        )
+
+        # onload maps the company/supplier GSTIN fields for e-Waybill data.
+        stock_entry.run_method("onload")
         stock_entry.select_print_heading = "Credit Note"
         stock_entry.save()
 

--- a/india_compliance/gst_india/overrides/test_transaction.py
+++ b/india_compliance/gst_india/overrides/test_transaction.py
@@ -666,6 +666,57 @@ class TestTransaction(IntegrationTestCase):
             doc.save,
         )
 
+    def test_gst_breakup_table_virtual_field(self):
+        if self.doctype not in DOCTYPES_WITH_GST_DETAIL:
+            return
+
+        doc = create_transaction(**self.transaction_details, is_in_state=True, do_not_submit=True)
+
+        breakup = doc.gst_breakup_table
+        self.assertTrue(breakup)
+        self.assertEqual(doc.as_dict().get("gst_breakup_table"), breakup)
+
+        doc.items[0].rate += 100
+        doc.save()
+
+        updated_breakup = doc.gst_breakup_table
+        self.assertTrue(updated_breakup)
+        self.assertNotEqual(updated_breakup, breakup)
+        self.assertEqual(doc.as_dict().get("gst_breakup_table"), updated_breakup)
+
+    def test_gst_breakup_table_in_print(self):
+        # The server print renderer gates on`doc.get(fieldname)` (instance dict, bypassing the property), so the
+        # `before_print` hook must materialize it.
+        # Fix required in Frappe
+        if self.doctype != "Sales Invoice":
+            return
+
+        doc = create_transaction(**self.transaction_details, is_in_state=True)
+        html = frappe.get_print(doc.doctype, doc.name, print_format="GST Tax Invoice")
+        html_no_letterhead = frappe.get_print(
+            doc.doctype, doc.name, print_format="GST Tax Invoice", no_letterhead=1
+        )
+
+        # `tax-break-up` is the wrapper class from templates/gst_breakup.html.
+        self.assertIn("tax-break-up", html)
+        self.assertIn("tax-break-up", html_no_letterhead)
+        self.assertIn(doc.gst_breakup_table, html)
+
+    def test_ecommerce_supply_type_virtual_field(self):
+        if self.doctype not in ("Sales Order", "Delivery Note", "Sales Invoice"):
+            return
+
+        with change_settings("GST Settings", {"enable_sales_through_ecommerce_operators": 1}):
+            doc = create_transaction(**self.transaction_details, is_in_state=True, do_not_submit=True)
+            doc.ecommerce_gstin = "29AABCF8078M1C8"
+            doc.save()
+
+            self.assertEqual(doc.ecommerce_supply_type, "Liable to collect tax u/s 52(TCS)")
+            self.assertEqual(doc.as_dict().get("ecommerce_supply_type"), doc.ecommerce_supply_type)
+
+            doc.is_reverse_charge = 1
+            self.assertEqual(doc.ecommerce_supply_type, "Liable to pay tax u/s 9(5)")
+
     def test_taxable_value_with_charges(self):
         if self.doctype not in DOCTYPES_WITH_GST_DETAIL:
             return

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -58,12 +58,18 @@ DOCTYPES_WITH_GST_DETAIL = {
 ALLOWED_TAX_DIFFERENCE = 1  # Allowable difference in tax amount due to rounding off
 
 
-def set_gst_breakup(doc):
+def get_gst_breakup_html(doc):
+    """
+    Return the rendered GST Breakup HTML for the `gst_breakup_table` virtual field.
+    """
+    if ignore_gst_validations(doc) or not doc.place_of_supply or not doc.company_gstin:
+        return
+
     gst_breakup_html = frappe.render_template("templates/gst_breakup.html", dict(doc=doc))  # nosemgrep
     if not gst_breakup_html:
         return
 
-    doc.gst_breakup_table = gst_breakup_html.replace("\n", "").replace("    ", "")
+    return gst_breakup_html.replace("\n", "").replace("    ", "")
 
 
 def update_taxable_values(doc):
@@ -1697,17 +1703,10 @@ def before_print(doc, method=None, print_settings=None):
     if ignore_gst_validations(doc) or not doc.place_of_supply or not doc.company_gstin:
         return
 
-    set_ecommerce_supply_type(doc)
-    set_gst_breakup(doc)
+    doc.set("gst_breakup_table", get_gst_breakup_html(doc))
 
-
-def onload(doc, method=None):
-    if ignore_gst_validations(doc) or not doc.place_of_supply or not doc.company_gstin:
-        return
-
-    set_ecommerce_supply_type(doc)
-    set_gst_breakup(doc)
-    doc.set_onload("_gst_breakup_table", doc.gst_breakup_table)
+    if doc.doctype in ("Sales Order", "Sales Invoice", "Delivery Note"):
+        doc.set("ecommerce_supply_type", get_ecommerce_supply_type(doc))
 
 
 def validate_ecommerce_gstin(doc):
@@ -1936,17 +1935,19 @@ def sync_gst_details_from_address(doc, changed_address_fields):
             doc.set(category_field, gst_category or "Unregistered")
 
 
-def set_ecommerce_supply_type(doc):
+def get_ecommerce_supply_type(doc):
+    """Return the GSTR-1 E-commerce section for the `ecommerce_supply_type` virtual field.
+
+    Pure getter (no assignment) so it can back the controller property. Returns None
+    when no e-commerce GSTIN is set.
     """
-    - Set GSTR-1 E-commerce section for virtual field ecommerce_supply_type
-    """
-    if doc.doctype not in ("Sales Order", "Sales Invoice", "Delivery Note"):
-        return
+    if ignore_gst_validations(doc):
+        return None
 
     if not doc.ecommerce_gstin:
         return
 
     if doc.is_reverse_charge:
-        doc.ecommerce_supply_type = SUPECOM.US_9_5.value
-    else:
-        doc.ecommerce_supply_type = SUPECOM.US_52.value
+        return SUPECOM.US_9_5.value
+
+    return SUPECOM.US_52.value

--- a/india_compliance/gst_india/overrides/virtual_fields.py
+++ b/india_compliance/gst_india/overrides/virtual_fields.py
@@ -1,0 +1,60 @@
+from frappe.contacts.doctype.address.address import get_address_display
+
+from india_compliance.gst_india.overrides.purchase_invoice import get_ineligibility_reason
+from india_compliance.gst_india.overrides.transaction import (
+    get_ecommerce_supply_type,
+    get_gst_breakup_html,
+)
+
+# class extensions for virtual fields
+
+
+class GSTBreakupExt:
+    """Resolves the ``gst_breakup_table`` virtual field (sales & purchase transactions)."""
+
+    @property
+    def gst_breakup_table(self):
+        return get_gst_breakup_html(self)
+
+
+class EcommerceSupplyTypeExt:
+    """Resolves the ``ecommerce_supply_type`` virtual field (Sales Order/Delivery Note/Sales Invoice)."""
+
+    @property
+    def ecommerce_supply_type(self):
+        return get_ecommerce_supply_type(self)
+
+
+class AddressDisplayExt:
+    """Resolves the four subcontracting ``*_address_display`` virtual fields (Stock Entry)."""
+
+    def _get_address_display(self, address_field):
+        address = self.get(address_field)
+        return get_address_display(address) if address else None
+
+    @property
+    def bill_from_address_display(self):
+        return self._get_address_display("bill_from_address")
+
+    @property
+    def bill_to_address_display(self):
+        return self._get_address_display("bill_to_address")
+
+    @property
+    def ship_from_address_display(self):
+        return self._get_address_display("ship_from_address")
+
+    @property
+    def ship_to_address_display(self):
+        return self._get_address_display("ship_to_address")
+
+
+class IneligibilityReasonExt:
+    """Resolves the virtual ``ineligibility_reason`` field (Purchase Receipt).
+
+    On Purchase Invoice this field is stored, so it is not extended here.
+    """
+
+    @property
+    def ineligibility_reason(self):
+        return get_ineligibility_reason(self)

--- a/india_compliance/hooks.py
+++ b/india_compliance/hooks.py
@@ -137,10 +137,7 @@ doc_events = {
         "after_insert": ("india_compliance.gst_india.overrides.party.create_primary_address"),
     },
     "Delivery Note": {
-        "onload": [
-            "india_compliance.gst_india.overrides.delivery_note.onload",
-            "india_compliance.gst_india.overrides.transaction.onload",
-        ],
+        "onload": "india_compliance.gst_india.overrides.delivery_note.onload",
         "before_print": "india_compliance.gst_india.overrides.transaction.before_print",
         "before_validate": "india_compliance.gst_india.overrides.transaction.before_validate_transaction",
         "before_update_after_submit": "india_compliance.gst_india.overrides.transaction.sync_address_dependent_fields_on_submit",
@@ -168,10 +165,7 @@ doc_events = {
         "before_cancel": "india_compliance.gst_india.overrides.payment_entry.before_cancel",
     },
     "Purchase Invoice": {
-        "onload": [
-            "india_compliance.gst_india.overrides.purchase_invoice.onload",
-            "india_compliance.gst_india.overrides.transaction.onload",
-        ],
+        "onload": "india_compliance.gst_india.overrides.purchase_invoice.onload",
         "before_print": "india_compliance.gst_india.overrides.transaction.before_print",
         "before_validate": [
             "india_compliance.gst_india.overrides.transaction.before_validate_transaction",
@@ -185,7 +179,6 @@ doc_events = {
         "on_cancel": "india_compliance.gst_india.overrides.purchase_invoice.on_cancel",
     },
     "Purchase Order": {
-        "onload": "india_compliance.gst_india.overrides.transaction.onload",
         "before_print": "india_compliance.gst_india.overrides.transaction.before_print",
         "before_validate": [
             "india_compliance.gst_india.overrides.transaction.before_validate_transaction",
@@ -198,10 +191,7 @@ doc_events = {
         "on_change": "india_compliance.gst_india.overrides.transaction.on_change_item",
     },
     "Purchase Receipt": {
-        "onload": [
-            "india_compliance.gst_india.overrides.transaction.onload",
-            "india_compliance.gst_india.overrides.purchase_receipt.onload",
-        ],
+        "onload": "india_compliance.gst_india.overrides.purchase_receipt.onload",
         "before_print": "india_compliance.gst_india.overrides.transaction.before_print",
         "before_validate": [
             "india_compliance.gst_india.overrides.transaction.before_validate_transaction",
@@ -214,10 +204,7 @@ doc_events = {
         "after_mapping": "india_compliance.gst_india.overrides.transaction.after_mapping",
     },
     "Sales Invoice": {
-        "onload": [
-            "india_compliance.gst_india.overrides.sales_invoice.onload",
-            "india_compliance.gst_india.overrides.transaction.onload",
-        ],
+        "onload": "india_compliance.gst_india.overrides.sales_invoice.onload",
         "before_print": "india_compliance.gst_india.overrides.transaction.before_print",
         "before_validate": "india_compliance.gst_india.overrides.transaction.before_validate_transaction",
         "validate": "india_compliance.gst_india.overrides.sales_invoice.validate",
@@ -230,7 +217,6 @@ doc_events = {
         "after_mapping": "india_compliance.gst_india.overrides.transaction.after_mapping",
     },
     "Sales Order": {
-        "onload": "india_compliance.gst_india.overrides.transaction.onload",
         "before_print": "india_compliance.gst_india.overrides.transaction.before_print",
         "before_validate": "india_compliance.gst_india.overrides.transaction.before_validate_transaction",
         "validate": ("india_compliance.gst_india.overrides.transaction.validate_transaction"),
@@ -278,13 +264,11 @@ doc_events = {
         "before_submit": "india_compliance.gst_india.overrides.unreconcile_payment.before_submit",
     },
     "POS Invoice": {
-        "onload": "india_compliance.gst_india.overrides.transaction.onload",
         "before_print": "india_compliance.gst_india.overrides.transaction.before_print",
         "before_validate": "india_compliance.gst_india.overrides.transaction.before_validate_transaction",
         "validate": ("india_compliance.gst_india.overrides.transaction.validate_transaction"),
     },
     "Quotation": {
-        "onload": "india_compliance.gst_india.overrides.transaction.onload",
         "before_print": "india_compliance.gst_india.overrides.transaction.before_print",
         "before_validate": "india_compliance.gst_india.overrides.transaction.before_validate_transaction",
         "validate": ("india_compliance.gst_india.overrides.transaction.validate_transaction"),
@@ -294,7 +278,6 @@ doc_events = {
         "on_change": "india_compliance.gst_india.overrides.transaction.on_change_item",
     },
     "Supplier Quotation": {
-        "onload": "india_compliance.gst_india.overrides.transaction.onload",
         "before_print": "india_compliance.gst_india.overrides.transaction.before_print",
         "before_validate": [
             "india_compliance.gst_india.overrides.transaction.before_validate_transaction",
@@ -403,6 +386,34 @@ override_doctype_dashboards = {
 override_doctype_class = {
     "Customize Form": ("india_compliance.audit_trail.overrides.customize_form.CustomizeForm"),
 }
+
+
+# Extended Doctype Map
+CLASS_EXTENSION_MAP = {
+    "india_compliance.gst_india.overrides.virtual_fields.GSTBreakupExt": (
+        "Quotation",
+        "Sales Order",
+        "Delivery Note",
+        "Sales Invoice",
+        "POS Invoice",
+        "Supplier Quotation",
+        "Purchase Order",
+        "Purchase Receipt",
+        "Purchase Invoice",
+    ),
+    "india_compliance.gst_india.overrides.virtual_fields.EcommerceSupplyTypeExt": (
+        "Sales Order",
+        "Delivery Note",
+        "Sales Invoice",
+    ),
+    "india_compliance.gst_india.overrides.virtual_fields.AddressDisplayExt": ("Stock Entry",),
+    "india_compliance.gst_india.overrides.virtual_fields.IneligibilityReasonExt": ("Purchase Receipt",),
+}
+
+extend_doctype_class = {}
+for extclass, _doctypes in CLASS_EXTENSION_MAP.items():
+    for _doctype in _doctypes:
+        extend_doctype_class.setdefault(_doctype, []).append(extclass)
 
 
 # DocTypes to be ignored while clearing transactions of a Company

--- a/india_compliance/public/js/transaction.js
+++ b/india_compliance/public/js/transaction.js
@@ -21,7 +21,6 @@ for (const doctype of TRANSACTION_DOCTYPES) {
     fetch_gst_details(doctype);
     validate_overseas_gst_category(doctype);
     set_and_validate_gstin_status(doctype);
-    set_gst_tax_breakup_on_load(doctype);
 }
 
 for (const doctype of SUBCONTRACTING_DOCTYPES) {
@@ -31,10 +30,6 @@ for (const doctype of SUBCONTRACTING_DOCTYPES) {
 
 for (const doctype of ["Sales Invoice", "Delivery Note"]) {
     ignore_port_code_validation(doctype);
-}
-
-for (const doctype of ["Sales Invoice", "Sales Order", "Delivery Note"]) {
-    set_e_commerce_ecommerce_supply_type(doctype);
 }
 
 function fetch_gst_details(doctype) {
@@ -202,15 +197,6 @@ function ignore_port_code_validation(doctype) {
     });
 }
 
-function set_gst_tax_breakup_on_load(doctype) {
-    frappe.ui.form.on(doctype, {
-        refresh(frm) {
-            frm.doc.gst_breakup_table = frm.doc.__onload?._gst_breakup_table;
-            frm.refresh_field("gst_breakup_table");
-        },
-    });
-}
-
 function is_foreign_transaction(frm) {
     return frm.doc.gst_category === "Overseas" && frm.doc.place_of_supply === "96-Other Countries";
 }
@@ -327,31 +313,6 @@ function is_invoice_no_validation_required(transaction_type) {
         (transaction_type === "Delivery Note" && gst_settings.enable_e_waybill_from_dn) ||
         (transaction_type === "Purchase Receipt" && gst_settings.enable_e_waybill_from_pr)
     );
-}
-
-function set_e_commerce_ecommerce_supply_type(doctype) {
-    const event_fields = ["ecommerce_gstin", "is_reverse_charge"];
-
-    const events = Object.fromEntries(
-        event_fields.map((field) => [field, (frm) => _set_e_commerce_ecommerce_supply_type(frm)]),
-    );
-
-    frappe.ui.form.on(doctype, events);
-}
-
-function _set_e_commerce_ecommerce_supply_type(frm) {
-    if (!gst_settings.enable_sales_through_ecommerce_operators) return;
-
-    if (!frm.doc.ecommerce_gstin) {
-        frm.set_value("ecommerce_supply_type", "");
-        return;
-    }
-
-    if (frm.doc.is_reverse_charge) {
-        frm.set_value("ecommerce_supply_type", "Liable to pay tax u/s 9(5)");
-    } else {
-        frm.set_value("ecommerce_supply_type", "Liable to collect tax u/s 52(TCS)");
-    }
 }
 
 function fetch_party_details(doctype) {


### PR DESCRIPTION
Issue: virtual fields needed to be handled manually; now we are resolving them by adding a property in the extended class.


Notes:

- Fields are not in ` __dict__` so we cant do .get so we shouldn't use virtual fields in logic.
- In Print, it also does .get, so we have not removed the before_print hook for now.
- From the frontend, print works, but in the backend, it will fail.
- This means virtual fields are only for the frontend.