### PR TITLE
feat: extend e-Waybill functionality for remaining stock entry purpose

### DIFF
--- a/india_compliance/gst_india/client_scripts/e_waybill_actions.js
+++ b/india_compliance/gst_india/client_scripts/e_waybill_actions.js
@@ -502,35 +502,30 @@ const SUBCONTRACTING_INWARD_SUB_SUPPLY_DESC = {
     "Return Raw Material to Customer": "Return Raw Material",
 };
 
+// Inward Stock Entries (company receives goods); "Others" + description is always
+// accepted by NIC for an inward supply, matching the SUBCONTRACTING_INWARD pattern.
+const INWARD_STOCK_ENTRY_SUB_SUPPLY_DESC = {
+    "Receive from Customer": "Job Work",
+    "Subcontracting Return": "Return of Finished Goods",
+};
+
+// Type - Document Type" mapping. Key: "<supply_type>:<same_gstin>".
+const DELIVERY_CHALLAN_SUB_SUPPLY_BUCKETS = {
+    "Outward:false": ["Job Work", "SKD/CKD", "Others"], // different GSTIN, Self -> Other/URP
+    "Outward:true": ["For Own Use", "Exhibition or Fairs", "Line Sales", "Recipient Not Known", "Others"], // same GSTIN, Self -> Self
+    "Inward:false": ["Job Work Returns", "Sales Return", "SKD/CKD", "Others"], // different GSTIN, Other/URP -> Self
+    "Inward:true": ["For Own Use", "Exhibition or Fairs", "Others"], // same GSTIN, Self -> Self
+};
+
 function get_sub_suppy_type_options(frm, is_foreign_transaction) {
     let supply_type, sub_supply_type, sub_supply_desc, document_type;
 
     if (frm.doctype === "Delivery Note") {
+        // Options follow the NIC 4-bucket matrix: direction x GSTIN match.
         const same_gstin = frm.doc.billing_address_gstin == frm.doc.company_gstin;
-
-        if (frm.doc.is_return) {
-            supply_type = "Inward";
-            document_type = "Delivery Challan";
-            if (same_gstin) {
-                sub_supply_type = ["For Own Use", "Exhibition or Fairs", "Others"];
-            } else {
-                sub_supply_type = ["Job Work Returns", "SKD/CKD", "Others"];
-            }
-        } else {
-            supply_type = "Outward";
-            document_type = "Delivery Challan";
-            if (same_gstin) {
-                sub_supply_type = [
-                    "For Own Use",
-                    "Exhibition or Fairs",
-                    "Line Sales",
-                    "Recipient Not Known",
-                    "Others",
-                ];
-            } else {
-                sub_supply_type = ["Job Work", "SKD/CKD", "Others"];
-            }
-        }
+        supply_type = frm.doc.is_return ? "Inward" : "Outward";
+        document_type = "Delivery Challan";
+        sub_supply_type = DELIVERY_CHALLAN_SUB_SUPPLY_BUCKETS[`${supply_type}:${same_gstin}`];
     } else if (frm.doctype === "Stock Entry") {
         document_type = "Delivery Challan";
 
@@ -541,25 +536,16 @@ function get_sub_suppy_type_options(frm, is_foreign_transaction) {
             supply_type = "Outward";
             sub_supply_type = ["Others"];
             sub_supply_desc = SUBCONTRACTING_INWARD_SUB_SUPPLY_DESC[frm.doc.purpose];
-        } else if (["Material Transfer", "Material Issue"].includes(frm.doc.purpose)) {
+        } else if (india_compliance.is_inward_stock_entry(frm.doc)) {
+            // Company receives goods; the registered recipient generates the e-Waybill
+            supply_type = "Inward";
+            sub_supply_type = ["Others"];
+            sub_supply_desc = INWARD_STOCK_ENTRY_SUB_SUPPLY_DESC[frm.doc.purpose];
+        } else if (india_compliance.STOCK_ENTRY_TRANSFER_PURPOSES.includes(frm.doc.purpose)) {
+            // Options follow the NIC 4-bucket matrix: direction x GSTIN match.
+            supply_type = frm.doc.is_return ? "Inward" : "Outward";
             const same_gstin = frm.doc.bill_from_gstin === frm.doc.bill_to_gstin;
-
-            if (frm.doc.is_return) {
-                supply_type = "Inward";
-                sub_supply_type = ["Job Work Returns"];
-            } else if (same_gstin) {
-                supply_type = "Outward";
-                sub_supply_type = [
-                    "For Own Use",
-                    "Exhibition or Fairs",
-                    "Line Sales",
-                    "Recipient Not Known",
-                    "Others",
-                ];
-            } else {
-                supply_type = "Outward";
-                sub_supply_type = ["Job Work", "SKD/CKD", "Others"];
-            }
+            sub_supply_type = DELIVERY_CHALLAN_SUB_SUPPLY_BUCKETS[`${supply_type}:${same_gstin}`];
         }
     } else if (frm.doctype === "Sales Invoice" && frm.doc.is_return === 0 && is_foreign_transaction) {
         supply_type = "Outward";

--- a/india_compliance/gst_india/client_scripts/e_waybill_actions.js
+++ b/india_compliance/gst_india/client_scripts/e_waybill_actions.js
@@ -502,14 +502,15 @@ const JOB_WORKER_OUTWARD_SUB_SUPPLY_DESC = {
     "Return Raw Material to Customer": "Return Raw Material",
 };
 
-// Inward Stock Entries (company receives goods); "Others" + description is always
-// accepted by NIC for an inward supply, matching the SUBCONTRACTING_INWARD pattern.
+// NIC has no specific inward sub-supply type for job work receipts, so
+// "Others" + description is used, same as JOB_WORKER_OUTWARD_SUB_SUPPLY_DESC.
 const JOB_WORKER_INWARD_SUB_SUPPLY_DESC = {
     "Receive from Customer": "Job Work",
     "Subcontracting Return": "Return of Finished Goods",
 };
 
-// Type - Document Type" mapping. Key: "<supply_type>:<same_gstin>".
+// Delivery-Challan-valid sub-supply types per the NIC "Supply Type - Document Type"
+// mapping, bucketed by direction x GSTIN match. Key: "<supply_type>:<same_gstin>".
 const DELIVERY_CHALLAN_SUB_SUPPLY_BUCKETS = {
     "Outward:false": ["Job Work", "SKD/CKD", "Others"], // different GSTIN, Self -> Other/URP
     "Outward:true": ["For Own Use", "Exhibition or Fairs", "Line Sales", "Recipient Not Known", "Others"], // same GSTIN, Self -> Self
@@ -521,7 +522,6 @@ function get_sub_suppy_type_options(frm, is_foreign_transaction) {
     let supply_type, sub_supply_type, sub_supply_desc, document_type;
 
     if (frm.doctype === "Delivery Note") {
-        // Options follow the NIC 4-bucket matrix: direction x GSTIN match.
         const same_gstin = frm.doc.billing_address_gstin == frm.doc.company_gstin;
         supply_type = frm.doc.is_return ? "Inward" : "Outward";
         document_type = "Delivery Challan";
@@ -537,12 +537,10 @@ function get_sub_suppy_type_options(frm, is_foreign_transaction) {
             sub_supply_type = ["Others"];
             sub_supply_desc = JOB_WORKER_OUTWARD_SUB_SUPPLY_DESC[frm.doc.purpose];
         } else if (india_compliance.is_job_worker_inward_entry(frm.doc)) {
-            // Company receives goods; the registered recipient generates the e-Waybill
             supply_type = "Inward";
             sub_supply_type = ["Others"];
             sub_supply_desc = JOB_WORKER_INWARD_SUB_SUPPLY_DESC[frm.doc.purpose];
         } else if (india_compliance.INTERNAL_STOCK_TRANSFER_PURPOSES.includes(frm.doc.purpose)) {
-            // Options follow the NIC 4-bucket matrix: direction x GSTIN match.
             supply_type = frm.doc.is_return ? "Inward" : "Outward";
             const same_gstin = frm.doc.bill_from_gstin === frm.doc.bill_to_gstin;
             sub_supply_type = DELIVERY_CHALLAN_SUB_SUPPLY_BUCKETS[`${supply_type}:${same_gstin}`];

--- a/india_compliance/gst_india/client_scripts/e_waybill_actions.js
+++ b/india_compliance/gst_india/client_scripts/e_waybill_actions.js
@@ -497,14 +497,14 @@ function get_generate_e_waybill_dialog(opts, frm) {
     return d;
 }
 
-const SUBCONTRACTING_INWARD_SUB_SUPPLY_DESC = {
+const JOB_WORKER_OUTWARD_SUB_SUPPLY_DESC = {
     "Subcontracting Delivery": "Job Work Delivery",
     "Return Raw Material to Customer": "Return Raw Material",
 };
 
 // Inward Stock Entries (company receives goods); "Others" + description is always
 // accepted by NIC for an inward supply, matching the SUBCONTRACTING_INWARD pattern.
-const INWARD_STOCK_ENTRY_SUB_SUPPLY_DESC = {
+const JOB_WORKER_INWARD_SUB_SUPPLY_DESC = {
     "Receive from Customer": "Job Work",
     "Subcontracting Return": "Return of Finished Goods",
 };
@@ -532,16 +532,16 @@ function get_sub_suppy_type_options(frm, is_foreign_transaction) {
         if (frm.doc.purpose === "Send to Subcontractor") {
             supply_type = "Outward";
             sub_supply_type = ["Job Work"];
-        } else if (india_compliance.is_subcontracting_inward_entry(frm.doc)) {
+        } else if (india_compliance.is_job_worker_outward_entry(frm.doc)) {
             supply_type = "Outward";
             sub_supply_type = ["Others"];
-            sub_supply_desc = SUBCONTRACTING_INWARD_SUB_SUPPLY_DESC[frm.doc.purpose];
-        } else if (india_compliance.is_inward_stock_entry(frm.doc)) {
+            sub_supply_desc = JOB_WORKER_OUTWARD_SUB_SUPPLY_DESC[frm.doc.purpose];
+        } else if (india_compliance.is_job_worker_inward_entry(frm.doc)) {
             // Company receives goods; the registered recipient generates the e-Waybill
             supply_type = "Inward";
             sub_supply_type = ["Others"];
-            sub_supply_desc = INWARD_STOCK_ENTRY_SUB_SUPPLY_DESC[frm.doc.purpose];
-        } else if (india_compliance.STOCK_ENTRY_TRANSFER_PURPOSES.includes(frm.doc.purpose)) {
+            sub_supply_desc = JOB_WORKER_INWARD_SUB_SUPPLY_DESC[frm.doc.purpose];
+        } else if (india_compliance.INTERNAL_STOCK_TRANSFER_PURPOSES.includes(frm.doc.purpose)) {
             // Options follow the NIC 4-bucket matrix: direction x GSTIN match.
             supply_type = frm.doc.is_return ? "Inward" : "Outward";
             const same_gstin = frm.doc.bill_from_gstin === frm.doc.bill_to_gstin;

--- a/india_compliance/gst_india/client_scripts/e_waybill_applicability.js
+++ b/india_compliance/gst_india/client_scripts/e_waybill_applicability.js
@@ -214,10 +214,7 @@ class StockEntryEwaybill extends EwaybillApplicability {
 
         let is_ewb_applicable = true;
         let message_list = [];
-        const is_return = this.frm.doc.is_return;
-        // The company (which self-generates the e-Waybill) sits on the bill_to side for
-        // returns and inward receipts, and on the bill_from side for outward movements.
-        const company_is_bill_to = is_return || india_compliance.is_job_worker_inward_entry(this.frm.doc);
+        const company_is_bill_to = india_compliance.company_is_bill_to(this.frm.doc);
 
         if (company_is_bill_to && !this.frm.doc.bill_to_gstin) {
             is_ewb_applicable = false;
@@ -231,7 +228,7 @@ class StockEntryEwaybill extends EwaybillApplicability {
 
         const same_gstin = this.frm.doc.bill_from_gstin === this.frm.doc.bill_to_gstin;
         const applicable_for_same_gstin = !(
-            is_return || india_compliance.SUBCONTRACTING_PURPOSES.includes(this.frm.doc.purpose)
+            this.frm.doc.is_return || india_compliance.SUBCONTRACTING_PURPOSES.includes(this.frm.doc.purpose)
         );
 
         if (same_gstin && !applicable_for_same_gstin) {

--- a/india_compliance/gst_india/client_scripts/e_waybill_applicability.js
+++ b/india_compliance/gst_india/client_scripts/e_waybill_applicability.js
@@ -217,7 +217,7 @@ class StockEntryEwaybill extends EwaybillApplicability {
         const is_return = this.frm.doc.is_return;
         // The company (which self-generates the e-Waybill) sits on the bill_to side for
         // returns and inward receipts, and on the bill_from side for outward movements.
-        const company_is_bill_to = is_return || india_compliance.is_inward_stock_entry(this.frm.doc);
+        const company_is_bill_to = is_return || india_compliance.is_job_worker_inward_entry(this.frm.doc);
 
         if (company_is_bill_to && !this.frm.doc.bill_to_gstin) {
             is_ewb_applicable = false;
@@ -263,7 +263,7 @@ class StockEntryEwaybill extends EwaybillApplicability {
 
         let message_list = [];
 
-        if (india_compliance.is_inward_stock_entry(this.frm.doc)) {
+        if (india_compliance.is_job_worker_inward_entry(this.frm.doc)) {
             if (!this.frm.doc.bill_from_address) {
                 is_ewb_generatable = false;
                 message_list.push("Bill From address is mandatory to generate e-Waybill.");

--- a/india_compliance/gst_india/client_scripts/e_waybill_applicability.js
+++ b/india_compliance/gst_india/client_scripts/e_waybill_applicability.js
@@ -265,6 +265,10 @@ class StockEntryEwaybill extends EwaybillApplicability {
                 is_ewb_generatable = false;
                 message_list.push("Bill From address is mandatory to generate e-Waybill.");
             }
+            if (!this.frm.doc.bill_to_address) {
+                is_ewb_generatable = false;
+                message_list.push("Bill To address is mandatory to generate e-Waybill.");
+            }
         } else if (!this.frm.doc.bill_to_address) {
             is_ewb_generatable = false;
             message_list.push("Bill To address is mandatory to generate e-Waybill.");

--- a/india_compliance/gst_india/client_scripts/e_waybill_applicability.js
+++ b/india_compliance/gst_india/client_scripts/e_waybill_applicability.js
@@ -215,13 +215,16 @@ class StockEntryEwaybill extends EwaybillApplicability {
         let is_ewb_applicable = true;
         let message_list = [];
         const is_return = this.frm.doc.is_return;
+        // The company (which self-generates the e-Waybill) sits on the bill_to side for
+        // returns and inward receipts, and on the bill_from side for outward movements.
+        const company_is_bill_to = is_return || india_compliance.is_inward_stock_entry(this.frm.doc);
 
-        if (is_return && !this.frm.doc.bill_to_gstin) {
+        if (company_is_bill_to && !this.frm.doc.bill_to_gstin) {
             is_ewb_applicable = false;
             message_list.push("Bill To GSTIN is not set. Ensure its set in Bill To Address.");
         }
 
-        if (!is_return && !this.frm.doc.bill_from_gstin) {
+        if (!company_is_bill_to && !this.frm.doc.bill_from_gstin) {
             is_ewb_applicable = false;
             message_list.push("Bill From GSTIN is not set. Ensure its set in Bill From Address.");
         }
@@ -260,7 +263,12 @@ class StockEntryEwaybill extends EwaybillApplicability {
 
         let message_list = [];
 
-        if (!this.frm.doc.bill_to_address) {
+        if (india_compliance.is_inward_stock_entry(this.frm.doc)) {
+            if (!this.frm.doc.bill_from_address) {
+                is_ewb_generatable = false;
+                message_list.push("Bill From address is mandatory to generate e-Waybill.");
+            }
+        } else if (!this.frm.doc.bill_to_address) {
             is_ewb_generatable = false;
             message_list.push("Bill To address is mandatory to generate e-Waybill.");
         }

--- a/india_compliance/gst_india/client_scripts/stock_entry.js
+++ b/india_compliance/gst_india/client_scripts/stock_entry.js
@@ -190,7 +190,6 @@ function get_field_and_label(frm, field) {
             company_field: ["bill_to_address", __("Bill To")],
         };
     } else if (india_compliance.is_job_worker_inward_entry(frm.doc)) {
-        // Company receives goods: counterparty (customer) is the consignor
         field_label_dict = {
             party_field: ["bill_from_address", __("Bill From (same as Customer Address)"), __("Bill From")],
             company_field: ["bill_to_address", __("Bill To")],

--- a/india_compliance/gst_india/client_scripts/stock_entry.js
+++ b/india_compliance/gst_india/client_scripts/stock_entry.js
@@ -189,13 +189,13 @@ function get_field_and_label(frm, field) {
             party_field: ["bill_from_address", __("Bill From (same as Supplier Address)"), __("Bill From")],
             company_field: ["bill_to_address", __("Bill To")],
         };
-    } else if (india_compliance.is_inward_stock_entry(frm.doc)) {
+    } else if (india_compliance.is_job_worker_inward_entry(frm.doc)) {
         // Company receives goods: counterparty (customer) is the consignor
         field_label_dict = {
             party_field: ["bill_from_address", __("Bill From (same as Customer Address)"), __("Bill From")],
             company_field: ["bill_to_address", __("Bill To")],
         };
-    } else if (india_compliance.is_subcontracting_inward_entry(frm.doc)) {
+    } else if (india_compliance.is_job_worker_outward_entry(frm.doc)) {
         // For Subcontracting Inward related entries
         // company bills to the customer
         field_label_dict = {

--- a/india_compliance/gst_india/client_scripts/stock_entry.js
+++ b/india_compliance/gst_india/client_scripts/stock_entry.js
@@ -189,6 +189,12 @@ function get_field_and_label(frm, field) {
             party_field: ["bill_from_address", __("Bill From (same as Supplier Address)"), __("Bill From")],
             company_field: ["bill_to_address", __("Bill To")],
         };
+    } else if (india_compliance.is_inward_stock_entry(frm.doc)) {
+        // Company receives goods: counterparty (customer) is the consignor
+        field_label_dict = {
+            party_field: ["bill_from_address", __("Bill From (same as Customer Address)"), __("Bill From")],
+            company_field: ["bill_to_address", __("Bill To")],
+        };
     } else if (india_compliance.is_subcontracting_inward_entry(frm.doc)) {
         // For Subcontracting Inward related entries
         // company bills to the customer

--- a/india_compliance/gst_india/constants/__init__.py
+++ b/india_compliance/gst_india/constants/__init__.py
@@ -29,27 +29,31 @@ TAX_TYPES = (*GST_TAX_TYPES, *GST_RCM_TAX_TYPES, *GST_REFUND_TAX_TYPES)
 
 GST_PARTY_TYPES = ("Customer", "Supplier", "Company")
 
-# Job Worker Company to Customer
-SUBCONTRACTING_INWARD_PURPOSES = ("Subcontracting Delivery", "Return Raw Material to Customer")
+# Company is the PRINCIPAL: it outsources manufacturing and sends its goods to a
+# subcontractor (Subcontracting Order).
+SUBCONTRACTING_AS_PRINCIPAL = ("Send to Subcontractor",)
 
-# Stock Entry purposes where goods move between subcontracting parties
-SUBCONTRACTING_PURPOSES = ("Send to Subcontractor", *SUBCONTRACTING_INWARD_PURPOSES)
+# Company is the JOB WORKER: it does the work for a customer (Subcontracting Inward
+# Order).
+#   - OUTWARD: job worker sends goods out to the customer
+JOB_WORKER_OUTWARD_PURPOSES = ("Subcontracting Delivery", "Return Raw Material to Customer")
+#   - INWARD:  job worker receives goods in from the customer
+JOB_WORKER_INWARD_PURPOSES = ("Receive from Customer", "Subcontracting Return")
+SUBCONTRACTING_AS_JOB_WORKER = (*JOB_WORKER_OUTWARD_PURPOSES, *JOB_WORKER_INWARD_PURPOSES)
 
-# Own-account transfers where the company ships goods out; same-GSTIN moves are
-# allowed here (unlike subcontracting), so these drive is_outward_stock_entry.
-STOCK_ENTRY_TRANSFER_PURPOSES = (
+# Same-GSTIN moves are allowed here (unlike subcontracting)
+INTERNAL_STOCK_TRANSFER_PURPOSES = (
     "Material Transfer",
     "Material Transfer for Manufacture",
     "Material Issue",
 )
 
-INWARD_STOCK_ENTRY_PURPOSES = ("Receive from Customer", "Subcontracting Return")
-
 # Stock Entry purposes eligible for e-Waybill
 E_WAYBILL_STOCK_ENTRY_PURPOSES = (
-    *STOCK_ENTRY_TRANSFER_PURPOSES,
-    *SUBCONTRACTING_PURPOSES,
-    *INWARD_STOCK_ENTRY_PURPOSES,
+    *SUBCONTRACTING_AS_PRINCIPAL,
+    *JOB_WORKER_OUTWARD_PURPOSES,
+    *JOB_WORKER_INWARD_PURPOSES,
+    *INTERNAL_STOCK_TRANSFER_PURPOSES,
 )
 
 # Transporter fields that stay editable after submit until an e-Waybill is generated.

--- a/india_compliance/gst_india/constants/__init__.py
+++ b/india_compliance/gst_india/constants/__init__.py
@@ -29,14 +29,28 @@ TAX_TYPES = (*GST_TAX_TYPES, *GST_RCM_TAX_TYPES, *GST_REFUND_TAX_TYPES)
 
 GST_PARTY_TYPES = ("Customer", "Supplier", "Company")
 
-# Stock Entry purposes for Subcontracting Inward (company is the job worker)
+# Job Worker Company to Customer
 SUBCONTRACTING_INWARD_PURPOSES = ("Subcontracting Delivery", "Return Raw Material to Customer")
 
 # Stock Entry purposes where goods move between subcontracting parties
 SUBCONTRACTING_PURPOSES = ("Send to Subcontractor", *SUBCONTRACTING_INWARD_PURPOSES)
 
+# Own-account transfers where the company ships goods out; same-GSTIN moves are
+# allowed here (unlike subcontracting), so these drive is_outward_stock_entry.
+STOCK_ENTRY_TRANSFER_PURPOSES = (
+    "Material Transfer",
+    "Material Transfer for Manufacture",
+    "Material Issue",
+)
+
+INWARD_STOCK_ENTRY_PURPOSES = ("Receive from Customer", "Subcontracting Return")
+
 # Stock Entry purposes eligible for e-Waybill
-E_WAYBILL_STOCK_ENTRY_PURPOSES = ("Material Transfer", "Material Issue", *SUBCONTRACTING_PURPOSES)
+E_WAYBILL_STOCK_ENTRY_PURPOSES = (
+    *STOCK_ENTRY_TRANSFER_PURPOSES,
+    *SUBCONTRACTING_PURPOSES,
+    *INWARD_STOCK_ENTRY_PURPOSES,
+)
 
 # Transporter fields that stay editable after submit until an e-Waybill is generated.
 TRANSPORTER_FIELDS = (

--- a/india_compliance/gst_india/constants/__init__.py
+++ b/india_compliance/gst_india/constants/__init__.py
@@ -41,7 +41,7 @@ JOB_WORKER_OUTWARD_PURPOSES = ("Subcontracting Delivery", "Return Raw Material t
 JOB_WORKER_INWARD_PURPOSES = ("Receive from Customer", "Subcontracting Return")
 SUBCONTRACTING_AS_JOB_WORKER = (*JOB_WORKER_OUTWARD_PURPOSES, *JOB_WORKER_INWARD_PURPOSES)
 
-# Same-GSTIN moves are allowed here (unlike subcontracting)
+# Own-account outward movements; same-GSTIN moves are allowed here.
 INTERNAL_STOCK_TRANSFER_PURPOSES = (
     "Material Transfer",
     "Material Transfer for Manufacture",
@@ -51,8 +51,7 @@ INTERNAL_STOCK_TRANSFER_PURPOSES = (
 # Stock Entry purposes eligible for e-Waybill
 E_WAYBILL_STOCK_ENTRY_PURPOSES = (
     *SUBCONTRACTING_AS_PRINCIPAL,
-    *JOB_WORKER_OUTWARD_PURPOSES,
-    *JOB_WORKER_INWARD_PURPOSES,
+    *SUBCONTRACTING_AS_JOB_WORKER,
     *INTERNAL_STOCK_TRANSFER_PURPOSES,
 )
 

--- a/india_compliance/gst_india/constants/custom_fields.py
+++ b/india_compliance/gst_india/constants/custom_fields.py
@@ -757,7 +757,7 @@ CUSTOM_FIELDS = {
             "no_copy": 1,
             "print_hide": 1,
             "hidden": 0,
-            "depends_on": "eval:india_compliance.JOB_WORKER_OUTWARD_PURPOSES.includes(parent.purpose)",
+            "depends_on": "eval:india_compliance.SUBCONTRACTING_AS_JOB_WORKER.includes(parent.purpose)",
             "description": "Value of customer-provided materials for Subcontracting Inward",
         },
     ],

--- a/india_compliance/gst_india/constants/custom_fields.py
+++ b/india_compliance/gst_india/constants/custom_fields.py
@@ -757,7 +757,7 @@ CUSTOM_FIELDS = {
             "no_copy": 1,
             "print_hide": 1,
             "hidden": 0,
-            "depends_on": "eval:india_compliance.SUBCONTRACTING_INWARD_PURPOSES.includes(parent.purpose)",
+            "depends_on": "eval:india_compliance.JOB_WORKER_OUTWARD_PURPOSES.includes(parent.purpose)",
             "description": "Value of customer-provided materials for Subcontracting Inward",
         },
     ],

--- a/india_compliance/gst_india/overrides/subcontracting_transaction.py
+++ b/india_compliance/gst_india/overrides/subcontracting_transaction.py
@@ -33,6 +33,7 @@ from india_compliance.gst_india.overrides.transaction import (
 from india_compliance.gst_india.utils import (
     get_gst_accounts_by_type,
     is_api_enabled,
+    is_inward_stock_entry,
     is_outward_stock_entry,
 )
 from india_compliance.gst_india.utils import (
@@ -123,12 +124,26 @@ def update_address_fields(doc, source_doc):
 
 
 def set_address_for_subcontracting_inward(doc, source_doc):
-    """Set company (bill_from) -> customer (bill_to) addresses for Subcontracting Inward Stock Entries."""
+    """Set bill_from/bill_to addresses for Subcontracting Inward Order Stock Entries.
+
+    Outbound legs (Subcontracting Delivery, Return Raw Material to Customer): the company
+    ships to the customer -> bill_from = company, bill_to = customer.
+    Inbound legs (Receive from Customer, Subcontracting Return): the customer ships to the
+    company -> bill_from = customer, bill_to = company.
+    """
+    company_address = get_default_address("Company", source_doc.company)
+    customer_address = get_default_address("Customer", source_doc.customer)
+
+    if is_inward_stock_entry(doc):
+        bill_from_address, bill_to_address = customer_address, company_address
+    else:
+        bill_from_address, bill_to_address = company_address, customer_address
+
     if not doc.bill_from_address:
-        doc.bill_from_address = get_default_address("Company", source_doc.company)
+        doc.bill_from_address = bill_from_address
 
     if not doc.bill_to_address:
-        doc.bill_to_address = get_default_address("Customer", source_doc.customer)
+        doc.bill_to_address = bill_to_address
 
     set_address_display(doc)
 
@@ -255,10 +270,17 @@ def onload(doc, method=None):
     if doc.doctype == "Stock Entry":
         set_address_display(doc)
 
-        # For e-Waybill data mapping
-        doc.company_gstin = doc.bill_from_gstin
-        doc.supplier_gstin = doc.bill_to_gstin
-        doc.gst_category = doc.bill_to_gst_category
+        # For e-Waybill data mapping. The company is the consignor (bill_from) for
+        # outward movements, but the consignee (bill_to) for inward receipts, where
+        # the registered recipient self-generates the e-Waybill.
+        if is_inward_stock_entry(doc):
+            doc.company_gstin = doc.bill_to_gstin
+            doc.supplier_gstin = doc.bill_from_gstin
+            doc.gst_category = doc.bill_from_gst_category
+        else:
+            doc.company_gstin = doc.bill_from_gstin
+            doc.supplier_gstin = doc.bill_to_gstin
+            doc.gst_category = doc.bill_to_gst_category
 
     if not doc.get("ewaybill"):
         return
@@ -349,7 +371,9 @@ def get_doctype_field_map(doc):
     )
 
     if doc.doctype == "Stock Entry":
-        if not doc.is_return:
+        # Company is the consignor (bill_from) for outward movements; for inward
+        # receipts and returns it is the consignee (bill_to).
+        if not doc.is_return and not is_inward_stock_entry(doc):
             doctype_field_map.update(
                 {
                     "company_gstin_field": "bill_from_gstin",
@@ -637,7 +661,7 @@ def ignore_gst_validations_for_subcontracting(doc):
     if is_outward_stock_entry(doc) and not doc.bill_from_address:
         return True
 
-    if doc.is_return and not doc.bill_to_address:
+    if (doc.is_return or is_inward_stock_entry(doc)) and not doc.bill_to_address:
         return True
 
 

--- a/india_compliance/gst_india/overrides/subcontracting_transaction.py
+++ b/india_compliance/gst_india/overrides/subcontracting_transaction.py
@@ -271,8 +271,8 @@ def onload(doc, method=None):
     if doc.doctype == "Stock Entry":
         set_address_display(doc)
 
-        # Map company/party GSTINs for the e-Waybill builder (company is bill_to for inward).
-        if is_job_worker_inward_entry(doc):
+        # Map company/party GSTINs for the e-Waybill builder. Company is on the bill_to
+        if company_is_bill_to(doc):
             doc.company_gstin = doc.bill_to_gstin
             doc.supplier_gstin = doc.bill_from_gstin
             doc.gst_category = doc.bill_from_gst_category

--- a/india_compliance/gst_india/overrides/subcontracting_transaction.py
+++ b/india_compliance/gst_india/overrides/subcontracting_transaction.py
@@ -33,8 +33,8 @@ from india_compliance.gst_india.overrides.transaction import (
 from india_compliance.gst_india.utils import (
     get_gst_accounts_by_type,
     is_api_enabled,
-    is_inward_stock_entry,
-    is_outward_stock_entry,
+    is_internal_stock_transfer,
+    is_job_worker_inward_entry,
 )
 from india_compliance.gst_india.utils import (
     validate_invoice_number as validate_transaction_name,
@@ -134,7 +134,7 @@ def set_address_for_subcontracting_inward(doc, source_doc):
     company_address = get_default_address("Company", source_doc.company)
     customer_address = get_default_address("Customer", source_doc.customer)
 
-    if is_inward_stock_entry(doc):
+    if is_job_worker_inward_entry(doc):
         bill_from_address, bill_to_address = customer_address, company_address
     else:
         bill_from_address, bill_to_address = company_address, customer_address
@@ -273,7 +273,7 @@ def onload(doc, method=None):
         # For e-Waybill data mapping. The company is the consignor (bill_from) for
         # outward movements, but the consignee (bill_to) for inward receipts, where
         # the registered recipient self-generates the e-Waybill.
-        if is_inward_stock_entry(doc):
+        if is_job_worker_inward_entry(doc):
             doc.company_gstin = doc.bill_to_gstin
             doc.supplier_gstin = doc.bill_from_gstin
             doc.gst_category = doc.bill_from_gst_category
@@ -373,7 +373,7 @@ def get_doctype_field_map(doc):
     if doc.doctype == "Stock Entry":
         # Company is the consignor (bill_from) for outward movements; for inward
         # receipts and returns it is the consignee (bill_to).
-        if not doc.is_return and not is_inward_stock_entry(doc):
+        if not doc.is_return and not is_job_worker_inward_entry(doc):
             doctype_field_map.update(
                 {
                     "company_gstin_field": "bill_from_gstin",
@@ -474,7 +474,7 @@ class SubcontractingGSTAccounts(GSTAccounts):
         self.validate_for_charge_type()
 
     def validate_for_same_party_gstin(self):
-        if is_outward_stock_entry(self.doc):
+        if is_internal_stock_transfer(self.doc):
             return
 
         doctype_field_map = get_doctype_field_map(self.doc)
@@ -658,10 +658,10 @@ def ignore_gst_validations_for_subcontracting(doc):
         return False
 
     # ignore if company address is not set
-    if is_outward_stock_entry(doc) and not doc.bill_from_address:
+    if is_internal_stock_transfer(doc) and not doc.bill_from_address:
         return True
 
-    if (doc.is_return or is_inward_stock_entry(doc)) and not doc.bill_to_address:
+    if (doc.is_return or is_job_worker_inward_entry(doc)) and not doc.bill_to_address:
         return True
 
 

--- a/india_compliance/gst_india/overrides/subcontracting_transaction.py
+++ b/india_compliance/gst_india/overrides/subcontracting_transaction.py
@@ -31,6 +31,7 @@ from india_compliance.gst_india.overrides.transaction import (
     validate_place_of_supply,
 )
 from india_compliance.gst_india.utils import (
+    company_is_bill_to,
     get_gst_accounts_by_type,
     is_api_enabled,
     is_internal_stock_transfer,
@@ -270,9 +271,7 @@ def onload(doc, method=None):
     if doc.doctype == "Stock Entry":
         set_address_display(doc)
 
-        # For e-Waybill data mapping. The company is the consignor (bill_from) for
-        # outward movements, but the consignee (bill_to) for inward receipts, where
-        # the registered recipient self-generates the e-Waybill.
+        # Map company/party GSTINs for the e-Waybill builder (company is bill_to for inward).
         if is_job_worker_inward_entry(doc):
             doc.company_gstin = doc.bill_to_gstin
             doc.supplier_gstin = doc.bill_from_gstin
@@ -371,9 +370,7 @@ def get_doctype_field_map(doc):
     )
 
     if doc.doctype == "Stock Entry":
-        # Company is the consignor (bill_from) for outward movements; for inward
-        # receipts and returns it is the consignee (bill_to).
-        if not doc.is_return and not is_job_worker_inward_entry(doc):
+        if not company_is_bill_to(doc):
             doctype_field_map.update(
                 {
                     "company_gstin_field": "bill_from_gstin",
@@ -642,8 +639,8 @@ def is_e_waybill_applicable(doc):
     if doc.doctype != "Stock Entry":
         return True
 
-    # Inward purposes (Delivery, RM Return) carry only an e-Waybill; the
-    # principal reports them in ITC-04 / GSTR-1, not the company (job worker).
+    # Purposes not in the eligible set (e.g. Manufacture, Repack — same-premises,
+    # no movement of goods between locations) carry no e-Waybill.
     if doc.purpose not in E_WAYBILL_STOCK_ENTRY_PURPOSES:
         return False
 
@@ -661,21 +658,25 @@ def ignore_gst_validations_for_subcontracting(doc):
     if is_internal_stock_transfer(doc) and not doc.bill_from_address:
         return True
 
-    if (doc.is_return or is_job_worker_inward_entry(doc)) and not doc.bill_to_address:
+    if company_is_bill_to(doc) and not doc.bill_to_address:
         return True
 
 
 def set_subcontracting_inward_taxable_value(doc):
     """Add the value of customer-provided materials to the e-Waybill taxable value
-    of Subcontracting Inward Stock Entries."""
-    if doc.purpose == "Subcontracting Delivery":
-        _set_subcontracting_delivery_additional_value(doc)
+    of Subcontracting Inward Stock Entries.
+
+    Subcontracting Return reverses a Subcontracting Delivery (customer sends the
+    finished goods back), so the returned goods carry the same per-unit value.
+    """
+    if doc.purpose in ("Subcontracting Delivery", "Subcontracting Return"):
+        _set_finished_goods_additional_value(doc)
     elif doc.purpose == "Return Raw Material to Customer":
         _set_return_raw_material_additional_value(doc)
 
 
-def _set_subcontracting_delivery_additional_value(doc):
-    """Add the value of consumed customer materials to the delivered finished goods.
+def _set_finished_goods_additional_value(doc):
+    """Add the value of consumed customer materials to the delivered / returned finished goods.
 
     additional = SUM(order_rate * consumed_qty) / produced_qty * delivered transfer_qty.
     Quantities are all in stock UOM (consumed_qty, produced_qty, transfer_qty), so

--- a/india_compliance/gst_india/overrides/test_subcontracting_transaction.py
+++ b/india_compliance/gst_india/overrides/test_subcontracting_transaction.py
@@ -20,6 +20,10 @@ from frappe.utils import add_to_date, flt, getdate, now_datetime
 from india_compliance.gst_india.overrides.subcontracting_transaction import (
     is_e_waybill_applicable,
 )
+from india_compliance.gst_india.utils import (
+    is_inward_stock_entry,
+    is_outward_stock_entry,
+)
 from india_compliance.gst_india.utils.e_waybill import mark_e_waybill_as_generated
 from india_compliance.gst_india.utils.taxes_controller import (
     CustomTaxController,
@@ -815,23 +819,29 @@ class TestSubcontractingInwardOrder(IntegrationTestCase):
         for item in se.items:
             self.assertFalse(item.get("additional_taxable_value"))
 
-    def test_e_waybill_applicable_for_inward_purposes(self):
-        """e-Waybill is applicable for the inward purposes, not for Receive from Customer."""
+    def test_e_waybill_applicable_for_stock_entry_purposes(self):
+        """e-Waybill is applicable for outward transfers, subcontracting legs and inward
+        receipts, but not for same-premises operations."""
         applicable_purposes = (
             "Material Transfer",
+            "Material Transfer for Manufacture",
             "Material Issue",
             "Send to Subcontractor",
             "Subcontracting Delivery",
             "Return Raw Material to Customer",
+            "Receive from Customer",
+            "Subcontracting Return",
         )
         for purpose in applicable_purposes:
             doc = frappe.new_doc("Stock Entry")
             doc.purpose = purpose
             self.assertTrue(is_e_waybill_applicable(doc), purpose)
 
-        doc = frappe.new_doc("Stock Entry")
-        doc.purpose = "Receive from Customer"
-        self.assertFalse(is_e_waybill_applicable(doc))
+        # Same-premises operations do not move goods between locations.
+        for purpose in ("Manufacture", "Repack", "Material Consumption for Manufacture", "Disassemble"):
+            doc = frappe.new_doc("Stock Entry")
+            doc.purpose = purpose
+            self.assertFalse(is_e_waybill_applicable(doc), purpose)
 
     @change_settings("GST Settings", {"enable_e_waybill_for_sc": 0})
     def test_e_waybill_not_applicable_when_sc_disabled(self):
@@ -839,6 +849,48 @@ class TestSubcontractingInwardOrder(IntegrationTestCase):
         doc = frappe.new_doc("Stock Entry")
         doc.purpose = "Subcontracting Delivery"
         self.assertFalse(is_e_waybill_applicable(doc))
+
+    def test_material_transfer_for_manufacture_is_outward(self):
+        """MTfM is an outward own-account transfer, treated like Material Transfer."""
+        doc = frappe.new_doc("Stock Entry")
+        doc.purpose = "Material Transfer for Manufacture"
+
+        self.assertTrue(is_outward_stock_entry(doc))
+        self.assertFalse(is_inward_stock_entry(doc))
+        self.assertTrue(is_e_waybill_applicable(doc))
+
+    def test_receive_from_customer_inward_orientation(self):
+        """Inward receipt: bill_from = customer (consignor), bill_to = company (consignee)."""
+        scio = create_subcontracting_inward_order()
+        receipt = receive_customer_materials(scio)
+
+        self.assertEqual(receipt.purpose, "Receive from Customer")
+        self.assertTrue(is_inward_stock_entry(receipt))
+        self.assertFalse(is_outward_stock_entry(receipt))
+
+        self.assertEqual(receipt.bill_from_address, get_default_address("Customer", scio.customer))
+        self.assertEqual(receipt.bill_to_address, get_default_address("Company", scio.company))
+        # Company (recipient) self-generates -> its GSTIN is the required side.
+        self.assertTrue(receipt.bill_to_gstin)
+        self.assertTrue(is_e_waybill_applicable(receipt))
+
+    def test_subcontracting_return_inward_orientation(self):
+        """Subcontracting Return (FG back from customer) is oriented inward."""
+        scio = create_subcontracting_inward_order()
+        receive_customer_materials(scio)
+        manufacture_for_subcontracting_inward(scio)
+        make_subcontracting_inward_delivery(scio=scio)
+
+        scio.reload()
+        sc_return = frappe.new_doc("Stock Entry").update(scio.make_subcontracting_return())
+        sc_return.save()
+
+        self.assertEqual(sc_return.purpose, "Subcontracting Return")
+        self.assertTrue(is_inward_stock_entry(sc_return))
+
+        self.assertEqual(sc_return.bill_from_address, get_default_address("Customer", scio.customer))
+        self.assertEqual(sc_return.bill_to_address, get_default_address("Company", scio.company))
+        self.assertTrue(is_e_waybill_applicable(sc_return))
 
     def test_subcontracting_delivery_multi_rate_receipts(self):
         """Delivery uses the weighted-average receipt rate across multiple receipts."""

--- a/india_compliance/gst_india/overrides/test_subcontracting_transaction.py
+++ b/india_compliance/gst_india/overrides/test_subcontracting_transaction.py
@@ -21,8 +21,8 @@ from india_compliance.gst_india.overrides.subcontracting_transaction import (
     is_e_waybill_applicable,
 )
 from india_compliance.gst_india.utils import (
-    is_inward_stock_entry,
-    is_outward_stock_entry,
+    is_internal_stock_transfer,
+    is_job_worker_inward_entry,
 )
 from india_compliance.gst_india.utils.e_waybill import mark_e_waybill_as_generated
 from india_compliance.gst_india.utils.taxes_controller import (
@@ -855,8 +855,8 @@ class TestSubcontractingInwardOrder(IntegrationTestCase):
         doc = frappe.new_doc("Stock Entry")
         doc.purpose = "Material Transfer for Manufacture"
 
-        self.assertTrue(is_outward_stock_entry(doc))
-        self.assertFalse(is_inward_stock_entry(doc))
+        self.assertTrue(is_internal_stock_transfer(doc))
+        self.assertFalse(is_job_worker_inward_entry(doc))
         self.assertTrue(is_e_waybill_applicable(doc))
 
     def test_receive_from_customer_inward_orientation(self):
@@ -865,8 +865,8 @@ class TestSubcontractingInwardOrder(IntegrationTestCase):
         receipt = receive_customer_materials(scio)
 
         self.assertEqual(receipt.purpose, "Receive from Customer")
-        self.assertTrue(is_inward_stock_entry(receipt))
-        self.assertFalse(is_outward_stock_entry(receipt))
+        self.assertTrue(is_job_worker_inward_entry(receipt))
+        self.assertFalse(is_internal_stock_transfer(receipt))
 
         self.assertEqual(receipt.bill_from_address, get_default_address("Customer", scio.customer))
         self.assertEqual(receipt.bill_to_address, get_default_address("Company", scio.company))
@@ -886,7 +886,7 @@ class TestSubcontractingInwardOrder(IntegrationTestCase):
         sc_return.save()
 
         self.assertEqual(sc_return.purpose, "Subcontracting Return")
-        self.assertTrue(is_inward_stock_entry(sc_return))
+        self.assertTrue(is_job_worker_inward_entry(sc_return))
 
         self.assertEqual(sc_return.bill_from_address, get_default_address("Customer", scio.customer))
         self.assertEqual(sc_return.bill_to_address, get_default_address("Company", scio.company))

--- a/india_compliance/gst_india/overrides/test_subcontracting_transaction.py
+++ b/india_compliance/gst_india/overrides/test_subcontracting_transaction.py
@@ -892,6 +892,40 @@ class TestSubcontractingInwardOrder(IntegrationTestCase):
         self.assertEqual(sc_return.bill_to_address, get_default_address("Company", scio.company))
         self.assertTrue(is_e_waybill_applicable(sc_return))
 
+    def test_subcontracting_return_taxable_value(self):
+        """Returned FG carry the same customer-material value as the delivery (Rule 138)."""
+        scio = create_subcontracting_inward_order()
+        receive_customer_materials(scio)
+        manufacture_for_subcontracting_inward(scio)
+        make_subcontracting_inward_delivery(scio=scio)
+
+        scio.reload()
+        sc_return = frappe.new_doc("Stock Entry").update(scio.make_subcontracting_return())
+        sc_return.save()
+
+        priced_rows = 0
+        for item in sc_return.items:
+            if not item.get("scio_detail"):
+                continue
+
+            precision = sc_return.precision("additional_taxable_value", "items")
+            expected_additional = flt(self._expected_delivery_value(item), precision)
+
+            self.assertEqual(flt(item.additional_taxable_value), expected_additional)
+            self.assertEqual(
+                flt(item.taxable_value),
+                flt(item.amount) + flt(item.additional_taxable_value),
+            )
+            # Customer FG are zero-valued in the company's books (design invariant), so
+            # the consignment value comes entirely from additional_taxable_value and is
+            # not double-counted on top of an own-cost amount.
+            self.assertEqual(flt(item.amount), 0)
+            self.assertEqual(flt(item.taxable_value), expected_additional)
+            self.assertGreater(item.taxable_value, 0)
+            priced_rows += 1
+
+        self.assertTrue(priced_rows, "No finished-good rows were priced")
+
     def test_subcontracting_delivery_multi_rate_receipts(self):
         """Delivery uses the weighted-average receipt rate across multiple receipts."""
         scio = create_subcontracting_inward_order()

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -39,7 +39,7 @@ from india_compliance.gst_india.utils import (
     has_changed,
     has_gst_taxes,
     is_import_transaction,
-    is_inward_stock_entry,
+    is_job_worker_inward_entry,
     is_overseas_doc,
     join_list_with_custom_separators,
     validate_gst_category,
@@ -580,7 +580,7 @@ def is_inter_state_supply(doc):
         # The counterparty is on the bill_from side for returns and inward receipts.
         party_gst_category = (
             doc.bill_from_gst_category
-            if doc.is_return or is_inward_stock_entry(doc)
+            if doc.is_return or is_job_worker_inward_entry(doc)
             else doc.bill_to_gst_category
         )
 

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -28,6 +28,7 @@ from india_compliance.gst_india.doctype.gst_settings.gst_settings import (
 )
 from india_compliance.gst_india.doctype.gstin.gstin import get_and_validate_gstin_status
 from india_compliance.gst_india.utils import (
+    company_is_bill_to,
     get_all_gst_accounts,
     get_changed_fields,
     get_gst_account_by_item_tax_template,
@@ -39,7 +40,6 @@ from india_compliance.gst_india.utils import (
     has_changed,
     has_gst_taxes,
     is_import_transaction,
-    is_job_worker_inward_entry,
     is_overseas_doc,
     join_list_with_custom_separators,
     validate_gst_category,
@@ -577,11 +577,8 @@ def validate_place_of_supply(doc):
 
 def is_inter_state_supply(doc):
     if doc.doctype == "Stock Entry":
-        # The counterparty is on the bill_from side for returns and inward receipts.
         party_gst_category = (
-            doc.bill_from_gst_category
-            if doc.is_return or is_job_worker_inward_entry(doc)
-            else doc.bill_to_gst_category
+            doc.bill_from_gst_category if company_is_bill_to(doc) else doc.bill_to_gst_category
         )
 
     else:

--- a/india_compliance/gst_india/overrides/transaction.py
+++ b/india_compliance/gst_india/overrides/transaction.py
@@ -39,6 +39,7 @@ from india_compliance.gst_india.utils import (
     has_changed,
     has_gst_taxes,
     is_import_transaction,
+    is_inward_stock_entry,
     is_overseas_doc,
     join_list_with_custom_separators,
     validate_gst_category,
@@ -576,7 +577,12 @@ def validate_place_of_supply(doc):
 
 def is_inter_state_supply(doc):
     if doc.doctype == "Stock Entry":
-        party_gst_category = doc.bill_from_gst_category if doc.is_return else doc.bill_to_gst_category
+        # The counterparty is on the bill_from side for returns and inward receipts.
+        party_gst_category = (
+            doc.bill_from_gst_category
+            if doc.is_return or is_inward_stock_entry(doc)
+            else doc.bill_to_gst_category
+        )
 
     else:
         party_gst_category = doc.gst_category

--- a/india_compliance/gst_india/utils/__init__.py
+++ b/india_compliance/gst_india/utils/__init__.py
@@ -39,6 +39,7 @@ from india_compliance.gst_india.constants import (
     GST_PARTY_TYPES,
     GSTIN_FORMATS,
     IMPORT_GST_CATEGORIES,
+    INWARD_STOCK_ENTRY_PURPOSES,
     PAN_NUMBER,
     PINCODE_FORMAT,
     SALES_DOCTYPES,
@@ -46,6 +47,7 @@ from india_compliance.gst_india.constants import (
     SHIP_TO_GSTIN_APPLICABLE_DATE,
     STATE_NUMBERS,
     STATE_PINCODE_MAPPING,
+    STOCK_ENTRY_TRANSFER_PURPOSES,
     TAX_TYPES,
     TCS,
     TIMEZONE,
@@ -1143,12 +1145,13 @@ def get_periods_between_dates(
 
 
 def is_outward_stock_entry(doc):
-    if (
-        doc.doctype == "Stock Entry"
-        and doc.purpose in ["Material Transfer", "Material Issue"]
-        and not doc.is_return
-    ):
+    if doc.doctype == "Stock Entry" and doc.purpose in STOCK_ENTRY_TRANSFER_PURPOSES and not doc.is_return:
         return True
+
+
+def is_inward_stock_entry(doc):
+    """True when the company physically receives goods and self-generates the e-Waybill."""
+    return doc.doctype == "Stock Entry" and doc.purpose in INWARD_STOCK_ENTRY_PURPOSES
 
 
 def create_notification(message_content, document_type, document_name=None, request_id=None):

--- a/india_compliance/gst_india/utils/__init__.py
+++ b/india_compliance/gst_india/utils/__init__.py
@@ -1155,6 +1155,14 @@ def is_job_worker_inward_entry(doc):
     return doc.doctype == "Stock Entry" and doc.purpose in JOB_WORKER_INWARD_PURPOSES
 
 
+def company_is_bill_to(doc):
+    """True when the company's address/GSTIN is on the bill_to side of a Stock Entry
+    (the counterparty being on bill_from): returns and job-worker inward receipts.
+    Purely positional -- makes no claim about goods direction, since a return can be
+    inward (sales/transfer) or outward (purchase). Stock Entry only."""
+    return doc.doctype == "Stock Entry" and (bool(doc.get("is_return")) or is_job_worker_inward_entry(doc))
+
+
 def create_notification(message_content, document_type, document_name=None, request_id=None):
     # request_id shows failure response
     if request_id and (doc_name := frappe.db.get_value("Integration Request", {"request_id": request_id})):

--- a/india_compliance/gst_india/utils/__init__.py
+++ b/india_compliance/gst_india/utils/__init__.py
@@ -1145,8 +1145,9 @@ def get_periods_between_dates(
 
 
 def is_internal_stock_transfer(doc):
-    if doc.doctype == "Stock Entry" and doc.purpose in INTERNAL_STOCK_TRANSFER_PURPOSES and not doc.is_return:
-        return True
+    return (
+        doc.doctype == "Stock Entry" and doc.purpose in INTERNAL_STOCK_TRANSFER_PURPOSES and not doc.is_return
+    )
 
 
 def is_job_worker_inward_entry(doc):

--- a/india_compliance/gst_india/utils/__init__.py
+++ b/india_compliance/gst_india/utils/__init__.py
@@ -39,7 +39,8 @@ from india_compliance.gst_india.constants import (
     GST_PARTY_TYPES,
     GSTIN_FORMATS,
     IMPORT_GST_CATEGORIES,
-    INWARD_STOCK_ENTRY_PURPOSES,
+    INTERNAL_STOCK_TRANSFER_PURPOSES,
+    JOB_WORKER_INWARD_PURPOSES,
     PAN_NUMBER,
     PINCODE_FORMAT,
     SALES_DOCTYPES,
@@ -47,7 +48,6 @@ from india_compliance.gst_india.constants import (
     SHIP_TO_GSTIN_APPLICABLE_DATE,
     STATE_NUMBERS,
     STATE_PINCODE_MAPPING,
-    STOCK_ENTRY_TRANSFER_PURPOSES,
     TAX_TYPES,
     TCS,
     TIMEZONE,
@@ -1144,14 +1144,15 @@ def get_periods_between_dates(
     return periods
 
 
-def is_outward_stock_entry(doc):
-    if doc.doctype == "Stock Entry" and doc.purpose in STOCK_ENTRY_TRANSFER_PURPOSES and not doc.is_return:
+def is_internal_stock_transfer(doc):
+    if doc.doctype == "Stock Entry" and doc.purpose in INTERNAL_STOCK_TRANSFER_PURPOSES and not doc.is_return:
         return True
 
 
-def is_inward_stock_entry(doc):
-    """True when the company physically receives goods and self-generates the e-Waybill."""
-    return doc.doctype == "Stock Entry" and doc.purpose in INWARD_STOCK_ENTRY_PURPOSES
+def is_job_worker_inward_entry(doc):
+    """True when the company (as job worker) receives goods from the customer and
+    self-generates the e-Waybill."""
+    return doc.doctype == "Stock Entry" and doc.purpose in JOB_WORKER_INWARD_PURPOSES
 
 
 def create_notification(message_content, document_type, document_name=None, request_id=None):

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -56,6 +56,7 @@ from india_compliance.gst_india.utils import (
     handle_server_errors,
     is_api_enabled,
     is_foreign_doc,
+    is_inward_stock_entry,
     is_outward_stock_entry,
     is_ship_to_gstin_applicable,
     load_doc,
@@ -1641,6 +1642,16 @@ class EWaybillData(GSTTransactionData):
         self.transaction_details.update(
             default_supply_types.get((doc.doctype, doc.get("is_return") or 0), {})
         )
+
+        if is_inward_stock_entry(doc):
+            # Direction is by purpose, not is_return: the company is the consignee
+            # and self-generates the e-Waybill, so force an inward supply.
+            self.transaction_details.update(
+                supply_type="I",
+                sub_supply_type=doc.get("_sub_supply_type", ""),
+                sub_supply_desc=doc.get("_sub_supply_desc", ""),
+                document_type="CHL",
+            )
 
         if is_foreign_doc(self.doc):
             self.transaction_details.update(sub_supply_type=3)  # Export

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -1625,6 +1625,7 @@ class EWaybillData(GSTTransactionData):
             ("Stock Entry", 1): {
                 "supply_type": "I",
                 "sub_supply_type": doc.get("_sub_supply_type", ""),
+                "sub_supply_desc": doc.get("_sub_supply_desc", ""),
                 "document_type": "CHL",
             },
             ("Subcontracting Receipt", 0): {

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -56,8 +56,8 @@ from india_compliance.gst_india.utils import (
     handle_server_errors,
     is_api_enabled,
     is_foreign_doc,
-    is_inward_stock_entry,
-    is_outward_stock_entry,
+    is_internal_stock_transfer,
+    is_job_worker_inward_entry,
     is_ship_to_gstin_applicable,
     load_doc,
     parse_datetime,
@@ -1410,7 +1410,7 @@ class EWaybillData(GSTTransactionData):
         if not self.doc.gst_transporter_id:
             self.validate_mode_of_transport()
 
-        if not is_outward_stock_entry(self.doc):
+        if not is_internal_stock_transfer(self.doc):
             self.validate_same_gstin()
 
     def validate_same_gstin(self):
@@ -1643,7 +1643,7 @@ class EWaybillData(GSTTransactionData):
             default_supply_types.get((doc.doctype, doc.get("is_return") or 0), {})
         )
 
-        if is_inward_stock_entry(doc):
+        if is_job_worker_inward_entry(doc):
             # Direction is by purpose, not is_return: the company is the consignee
             # and self-generates the e-Waybill, so force an inward supply.
             self.transaction_details.update(

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -1644,14 +1644,9 @@ class EWaybillData(GSTTransactionData):
         )
 
         if is_job_worker_inward_entry(doc):
-            # Direction is by purpose, not is_return: the company is the consignee
-            # and self-generates the e-Waybill, so force an inward supply.
-            self.transaction_details.update(
-                supply_type="I",
-                sub_supply_type=doc.get("_sub_supply_type", ""),
-                sub_supply_desc=doc.get("_sub_supply_desc", ""),
-                document_type="CHL",
-            )
+            # Inward by purpose (not is_return): the company receives the goods and
+            # self-generates the e-Waybill, so force an inward supply.
+            self.transaction_details.supply_type = "I"
 
         if is_foreign_doc(self.doc):
             self.transaction_details.update(sub_supply_type=3)  # Export
@@ -1719,7 +1714,9 @@ class EWaybillData(GSTTransactionData):
         if self.doc.doctype in BUYING_DOCTYPES:
             to_party, from_party = from_party, to_party
 
-        if self.doc.get("is_return"):
+        # Reverse the party/company sides when the movement is reversed: any return
+        # (runs for all doctypes) or a job-worker inward Stock Entry.
+        if self.doc.get("is_return") or is_job_worker_inward_entry(self.doc):
             to_party, from_party = from_party, to_party
 
         self.bill_to.legal_name = to_party or self.bill_to.address_title
@@ -1799,6 +1796,10 @@ class EWaybillData(GSTTransactionData):
                         ("Stock Entry", 0): (REGISTERED_GSTIN, REGISTERED_GSTIN),
                     }
                 )
+
+            if is_job_worker_inward_entry(self.doc):
+                # Company is on the bill_to side; NIC requires userGstin == toGstin for inward.
+                sandbox_gstin.update({("Stock Entry", 0): (OTHER_GSTIN, REGISTERED_GSTIN)})
 
             def _get_sandbox_gstin(address, key):
                 if address.gstin == "URP":

--- a/india_compliance/gst_india/utils/test_e_waybill.py
+++ b/india_compliance/gst_india/utils/test_e_waybill.py
@@ -52,10 +52,13 @@ from india_compliance.gst_india.utils.tests import (
     append_item,
     create_purchase_invoice,
     create_sales_invoice,
+    create_subcontracting_inward_order,
     create_transaction,
     make_subcontracting_inward_delivery,
     make_subcontracting_inward_rm_return,
     make_subcontracting_stock_entry,
+    manufacture_for_subcontracting_inward,
+    receive_customer_materials,
 )
 
 DATETIME_FORMAT = "%d/%m/%Y %I:%M:%S %p"
@@ -2163,10 +2166,12 @@ class TestEWaybillThreshold(IntegrationTestCase):
 
 
 class TestSubcontractingInwardEWaybill(IntegrationTestCase):
-    """e-Waybill data for Subcontracting Delivery and Return Raw Material to Customer.
+    """e-Waybill data for the four Subcontracting Inward (job worker) legs.
 
-    Both are outward movements (company to customer) on a Delivery Challan with
-    sub supply type "Others" plus a description, and the taxable value includes
+    Outward legs (Subcontracting Delivery, Return Raw Material to Customer): company
+    to customer. Inward legs (Receive from Customer, Subcontracting Return): customer
+    to company, where the company self-generates the e-Waybill. All move on a Delivery
+    Challan with sub supply type "Others" + description, and the taxable value carries
     the customer-provided material value.
     """
 
@@ -2255,3 +2260,53 @@ class TestSubcontractingInwardEWaybill(IntegrationTestCase):
             ewb_taxable,
             sum(flt(item.taxable_value) for item in rm_return.items),
         )
+
+    def _assert_inward_from_customer(self, data, sub_supply_desc, stock_entry):
+        self.assertEqual(data["supplyType"], "I")
+        self.assertEqual(data["subSupplyType"], SUB_SUPPLY_TYPES["Others"])
+        self.assertEqual(data["subSupplyDesc"], sub_supply_desc)
+        self.assertEqual(data["docType"], "CHL")
+        # The company self-generates the e-Waybill, so its GSTIN is on the "to" side and
+        # equals userGstin (regression: sandbox GSTIN table + trade-name swap flip inward).
+        self.assertEqual(data["toGstin"], data["userGstin"])
+        self.assertNotEqual(data["fromGstin"], data["toGstin"])
+        customer_name = frappe.db.get_value(
+            "Subcontracting Inward Order", stock_entry.subcontracting_inward_order, "customer_name"
+        )
+        self.assertEqual(data["fromTrdName"], customer_name)
+        self.assertEqual(data["toTrdName"], stock_entry.company)
+
+    def test_e_waybill_data_for_receive_from_customer(self):
+        scio = create_subcontracting_inward_order()
+        receipt = receive_customer_materials(scio)
+        self._set_transport_details(receipt, "Job Work")
+
+        data = EWaybillData(receipt).get_data()
+
+        self._assert_inward_from_customer(data, "Job Work", receipt)
+
+        # Value is the customer's declared value of the received materials.
+        ewb_taxable = sum(flt(item["taxableAmount"]) for item in data["itemList"])
+        self.assertGreater(ewb_taxable, 0)
+        self.assertEqual(ewb_taxable, sum(flt(item.taxable_value) for item in receipt.items))
+
+    def test_e_waybill_data_for_subcontracting_return(self):
+        scio = create_subcontracting_inward_order()
+        receive_customer_materials(scio)
+        manufacture_for_subcontracting_inward(scio)
+        make_subcontracting_inward_delivery(scio=scio)
+
+        scio.reload()
+        sc_return = frappe.new_doc("Stock Entry").update(scio.make_subcontracting_return())
+        sc_return.save()
+        self._set_transport_details(sc_return, "Return of Finished Goods")
+
+        data = EWaybillData(sc_return).get_data()
+
+        self._assert_inward_from_customer(data, "Return of Finished Goods", sc_return)
+
+        # Returned finished goods carry the customer-material value (Rule 138), so the
+        # e-Waybill total is non-zero even though the FG are zero-valued in own books.
+        ewb_taxable = sum(flt(item["taxableAmount"]) for item in data["itemList"])
+        self.assertGreater(ewb_taxable, 0)
+        self.assertEqual(ewb_taxable, sum(flt(item.taxable_value) for item in sc_return.items))

--- a/india_compliance/patches.txt
+++ b/india_compliance/patches.txt
@@ -5,7 +5,7 @@ execute:from frappe.installer import add_module_defs; add_module_defs("india_com
 
 [post_model_sync]
 india_compliance.patches.v14.set_default_for_overridden_accounts_setting
-execute:from india_compliance.gst_india.setup import create_custom_fields; create_custom_fields() #75
+execute:from india_compliance.gst_india.setup import create_custom_fields; create_custom_fields() #76
 execute:from india_compliance.gst_india.setup import create_property_setters; create_property_setters() #14
 execute:from india_compliance.income_tax_india.setup import create_custom_fields; create_custom_fields() #7
 india_compliance.patches.post_install.remove_old_fields #2

--- a/india_compliance/public/js/transaction.js
+++ b/india_compliance/public/js/transaction.js
@@ -72,7 +72,7 @@ async function update_gst_details(frm, event) {
 
     const same_gstin_stock_entry =
         frm.doc.doctype === "Stock Entry" &&
-        ["Material Transfer", "Material Issue"].includes(frm.doc.purpose) &&
+        india_compliance.STOCK_ENTRY_TRANSFER_PURPOSES.includes(frm.doc.purpose) &&
         !frm.doc.is_return;
 
     if (!(party || same_gstin_stock_entry)) return;

--- a/india_compliance/public/js/transaction.js
+++ b/india_compliance/public/js/transaction.js
@@ -72,7 +72,7 @@ async function update_gst_details(frm, event) {
 
     const same_gstin_stock_entry =
         frm.doc.doctype === "Stock Entry" &&
-        india_compliance.STOCK_ENTRY_TRANSFER_PURPOSES.includes(frm.doc.purpose) &&
+        india_compliance.INTERNAL_STOCK_TRANSFER_PURPOSES.includes(frm.doc.purpose) &&
         !frm.doc.is_return;
 
     if (!(party || same_gstin_stock_entry)) return;

--- a/india_compliance/public/js/utils.js
+++ b/india_compliance/public/js/utils.js
@@ -51,7 +51,7 @@ Object.assign(india_compliance, {
 
     HSN_BIFURCATION_FROM: frappe.datetime.str_to_obj("2025-05-01"),
 
-    // Stock Entry purposes for Subcontracting Inward (company is the job worker)
+    // Inward Order; goods physically move OUT of the company here.
     SUBCONTRACTING_INWARD_PURPOSES: ["Subcontracting Delivery", "Return Raw Material to Customer"],
 
     // Stock Entry purposes where goods move between subcontracting parties
@@ -61,17 +61,35 @@ Object.assign(india_compliance, {
         "Return Raw Material to Customer",
     ],
 
+    // Own-account transfers where the company ships goods out (same-GSTIN allowed)
+    STOCK_ENTRY_TRANSFER_PURPOSES: [
+        "Material Transfer",
+        "Material Transfer for Manufacture",
+        "Material Issue",
+    ],
+
+    // Stock Entry purposes where the company physically RECEIVES goods; the
+    // registered recipient generates the e-Waybill (consignor may be unregistered).
+    INWARD_STOCK_ENTRY_PURPOSES: ["Receive from Customer", "Subcontracting Return"],
+
     // Stock Entry purposes eligible for e-Waybill
     E_WAYBILL_STOCK_ENTRY_PURPOSES: [
         "Material Transfer",
+        "Material Transfer for Manufacture",
         "Material Issue",
         "Send to Subcontractor",
         "Subcontracting Delivery",
         "Return Raw Material to Customer",
+        "Receive from Customer",
+        "Subcontracting Return",
     ],
 
     is_subcontracting_inward_entry(doc) {
         return this.SUBCONTRACTING_INWARD_PURPOSES.includes(doc.purpose);
+    },
+
+    is_inward_stock_entry(doc) {
+        return this.INWARD_STOCK_ENTRY_PURPOSES.includes(doc.purpose);
     },
 
     get_month_year_from_period(period) {

--- a/india_compliance/public/js/utils.js
+++ b/india_compliance/public/js/utils.js
@@ -51,10 +51,13 @@ Object.assign(india_compliance, {
 
     HSN_BIFURCATION_FROM: frappe.datetime.str_to_obj("2025-05-01"),
 
-    // Inward Order; goods physically move OUT of the company here.
-    SUBCONTRACTING_INWARD_PURPOSES: ["Subcontracting Delivery", "Return Raw Material to Customer"],
+    // Company is the JOB WORKER (Subcontracting Inward Order), split by goods direction:
+    //   OUTWARD: job worker sends goods out to the customer
+    //   INWARD:  job worker receives goods in from the customer
+    JOB_WORKER_OUTWARD_PURPOSES: ["Subcontracting Delivery", "Return Raw Material to Customer"],
+    JOB_WORKER_INWARD_PURPOSES: ["Receive from Customer", "Subcontracting Return"],
 
-    // Stock Entry purposes where goods move between subcontracting parties
+    // Purposes facing a subcontracting counterparty (the two GSTINs always differ)
     SUBCONTRACTING_PURPOSES: [
         "Send to Subcontractor",
         "Subcontracting Delivery",
@@ -62,15 +65,11 @@ Object.assign(india_compliance, {
     ],
 
     // Own-account transfers where the company ships goods out (same-GSTIN allowed)
-    STOCK_ENTRY_TRANSFER_PURPOSES: [
+    INTERNAL_STOCK_TRANSFER_PURPOSES: [
         "Material Transfer",
         "Material Transfer for Manufacture",
         "Material Issue",
     ],
-
-    // Stock Entry purposes where the company physically RECEIVES goods; the
-    // registered recipient generates the e-Waybill (consignor may be unregistered).
-    INWARD_STOCK_ENTRY_PURPOSES: ["Receive from Customer", "Subcontracting Return"],
 
     // Stock Entry purposes eligible for e-Waybill
     E_WAYBILL_STOCK_ENTRY_PURPOSES: [
@@ -84,12 +83,12 @@ Object.assign(india_compliance, {
         "Subcontracting Return",
     ],
 
-    is_subcontracting_inward_entry(doc) {
-        return this.SUBCONTRACTING_INWARD_PURPOSES.includes(doc.purpose);
+    is_job_worker_outward_entry(doc) {
+        return this.JOB_WORKER_OUTWARD_PURPOSES.includes(doc.purpose);
     },
 
-    is_inward_stock_entry(doc) {
-        return this.INWARD_STOCK_ENTRY_PURPOSES.includes(doc.purpose);
+    is_job_worker_inward_entry(doc) {
+        return this.JOB_WORKER_INWARD_PURPOSES.includes(doc.purpose);
     },
 
     get_month_year_from_period(period) {

--- a/india_compliance/public/js/utils.js
+++ b/india_compliance/public/js/utils.js
@@ -68,6 +68,8 @@ Object.assign(india_compliance, {
         "Send to Subcontractor",
         "Subcontracting Delivery",
         "Return Raw Material to Customer",
+        "Receive from Customer",
+        "Subcontracting Return",
     ],
 
     // Own-account outward movements; same-GSTIN allowed (unlike subcontracting).

--- a/india_compliance/public/js/utils.js
+++ b/india_compliance/public/js/utils.js
@@ -56,6 +56,12 @@ Object.assign(india_compliance, {
     //   INWARD:  job worker receives goods in from the customer
     JOB_WORKER_OUTWARD_PURPOSES: ["Subcontracting Delivery", "Return Raw Material to Customer"],
     JOB_WORKER_INWARD_PURPOSES: ["Receive from Customer", "Subcontracting Return"],
+    SUBCONTRACTING_AS_JOB_WORKER: [
+        "Subcontracting Delivery",
+        "Return Raw Material to Customer",
+        "Receive from Customer",
+        "Subcontracting Return",
+    ],
 
     // Purposes facing a subcontracting counterparty (the two GSTINs always differ)
     SUBCONTRACTING_PURPOSES: [
@@ -64,7 +70,8 @@ Object.assign(india_compliance, {
         "Return Raw Material to Customer",
     ],
 
-    // Own-account transfers where the company ships goods out (same-GSTIN allowed)
+    // Own-account outward movements; same-GSTIN allowed (unlike subcontracting).
+    // MT / MTfM are warehouse-to-warehouse; Material Issue is an outward issue.
     INTERNAL_STOCK_TRANSFER_PURPOSES: [
         "Material Transfer",
         "Material Transfer for Manufacture",
@@ -89,6 +96,15 @@ Object.assign(india_compliance, {
 
     is_job_worker_inward_entry(doc) {
         return this.JOB_WORKER_INWARD_PURPOSES.includes(doc.purpose);
+    },
+
+    // True when the company's address/GSTIN is on the bill_to side of a Stock Entry
+    // (counterparty on bill_from): returns and job-worker inward receipts. Purely
+    // positional -- no goods-direction claim. Stock Entry only.
+    company_is_bill_to(doc) {
+        return (
+            doc.doctype === "Stock Entry" && (Boolean(doc.is_return) || this.is_job_worker_inward_entry(doc))
+        );
     },
 
     get_month_year_from_period(period) {


### PR DESCRIPTION
Extend e-Waybill functionality to:

- Receive from Customer
- Subcontracting Return
- Material Transfer for Manufacturing

depends on: https://github.com/frappe/erpnext/pull/56912

no-docs