### PR TITLE
fix: pass otp to get_files in TaxpayerBaseAPI

### DIFF
--- a/india_compliance/gst_india/api_classes/taxpayer_base.py
+++ b/india_compliance/gst_india/api_classes/taxpayer_base.py
@@ -468,12 +468,13 @@ class TaxpayerBaseAPI(TaxpayerAuthenticate):
 
         return False
 
-    def get_files(self, return_period, token, action, endpoint):
+    def get_files(self, return_period, token, action, endpoint, otp=None):
         response = self.get(
             action=action,
             return_period=return_period,
             params={"ret_period": return_period, "token": token},
             endpoint=endpoint,
+            otp=otp,
         )
 
         if response.error_type == "queued":


### PR DESCRIPTION
> Explain the details for making this change. What existing problem does the pull request solve?

`EInvoiceAPI.download_files()` forwards `otp` to `super().get_files()`:

```python
def download_files(self, return_period, token, otp=None):
    return super().get_files(return_period, token, action="FILEDETL", endpoint=self.endpoint, otp=otp)
```

But `TaxpayerBaseAPI.get_files()` did not declare an `otp` parameter, so this call raises `TypeError: get_files() got an unexpected keyword argument 'otp'` (the "Extra Keyword argument" flagged by Codacy).

This PR adds the `otp` parameter to `TaxpayerBaseAPI.get_files()` and forwards it to the underlying request (which already accepts `otp`, as used by `get_irn_list`/`get_irn_details`).

> Screenshots/GIFs

N/A — backend-only fix.

closes #4155

---
_Generated by [Claude Code](https://claude.ai/code/session_016TKT8x6x4rcj1nNyCjW8xx)_