### PR TITLE
fix: indent JSON data for report JSON downloads

### DIFF
--- a/india_compliance/gst_india/doctype/gstr_1/gstr_1.js
+++ b/india_compliance/gst_india/doctype/gstr_1/gstr_1.js
@@ -2210,7 +2210,7 @@ class FiledTab extends GSTR1_TabManager {
                     },
                     callback: (r) => {
                         india_compliance.trigger_file_download(
-                            JSON.stringify(r.message.data),
+                            JSON.stringify(r.message.data, null, 2),
                             r.message.filename,
                         );
                         dialog.hide();

--- a/india_compliance/gst_india/report/gst_job_work_stock_movement/gst_job_work_stock_movement.js
+++ b/india_compliance/gst_india/report/gst_job_work_stock_movement/gst_job_work_stock_movement.js
@@ -72,7 +72,7 @@ frappe.query_reports["GST Job Work Stock Movement"] = {
 
     onload: function (query_report) {
         const handle_download = (response) => {
-            india_compliance.trigger_file_download(JSON.stringify(response.data), response.filename);
+            india_compliance.trigger_file_download(JSON.stringify(response.data, null, 2), response.filename);
         };
 
         query_report.page.add_inner_button(__("Export JSON"), function () {


### PR DESCRIPTION
> Explain the details for making this change. What existing problem does the pull request solve?

The **GST Job Work Stock Movement** and **GSTR-1** JSON exports were downloaded as single-line JSON, which is hard to read. This indents those two downloads (2 spaces) at the call site, consistent with the other JSON downloads (HSN summary already indents; e-Waybill is indented server-side).

Per review feedback, `trigger_file_download` itself is left unchanged — each caller decides whether/how to indent based on its data.

> Screenshots/GIFs

N/A — the downloaded `.json` file is now indented instead of single-line.

closes #4496