### PR TITLE
fix: do not show "Not Saved" indicator in PRT and IMS

### DIFF
--- a/india_compliance/gst_india/doctype/gst_invoice_management_system/gst_invoice_management_system.js
+++ b/india_compliance/gst_india/doctype/gst_invoice_management_system/gst_invoice_management_system.js
@@ -23,9 +23,6 @@ frappe.ui.form.on(DOCTYPE, {
     async setup(frm) {
         await frappe.require("ims.bundle.js");
 
-        // Report-like tool; nothing is saved, so never show the "Not Saved" indicator
-        frm.disable_save();
-
         frm.reconciliation_tabs = new IMS(
             frm,
             ["invoice", "match_summary", "action_summary"],
@@ -71,6 +68,9 @@ frappe.ui.form.on(DOCTYPE, {
     period: render_empty_state,
 
     refresh(frm) {
+        frm.disable_save();
+        frm.page.clear_indicator();
+
         show_download_invoices_message(frm);
 
         frm.ims_actions = new IMSAction(frm);

--- a/india_compliance/gst_india/doctype/gst_invoice_management_system/gst_invoice_management_system.js
+++ b/india_compliance/gst_india/doctype/gst_invoice_management_system/gst_invoice_management_system.js
@@ -23,6 +23,9 @@ frappe.ui.form.on(DOCTYPE, {
     async setup(frm) {
         await frappe.require("ims.bundle.js");
 
+        // Report-like tool; nothing is saved, so never show the "Not Saved" indicator
+        frm.disable_save();
+
         frm.reconciliation_tabs = new IMS(
             frm,
             ["invoice", "match_summary", "action_summary"],

--- a/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.js
+++ b/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.js
@@ -73,9 +73,6 @@ frappe.ui.form.on(DOCTYPE, {
 
         await frappe.require("purchase_reconciliation_tool.bundle.js");
 
-        // Report-like tool; nothing is saved, so never show the "Not Saved" indicator
-        frm.disable_save();
-
         frm.doc.company = frappe.defaults.get_user_default("Company");
         frm.trigger("company");
 
@@ -97,6 +94,9 @@ frappe.ui.form.on(DOCTYPE, {
     },
 
     refresh(frm) {
+        frm.disable_save();
+        frm.page.clear_indicator();
+
         frm.reco_tool_actions = new PurchaseReconciliationToolAction(frm);
         frm.reco_tool_actions.setup_actions();
     },

--- a/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.js
+++ b/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.js
@@ -73,6 +73,9 @@ frappe.ui.form.on(DOCTYPE, {
 
         await frappe.require("purchase_reconciliation_tool.bundle.js");
 
+        // Report-like tool; nothing is saved, so never show the "Not Saved" indicator
+        frm.disable_save();
+
         frm.doc.company = frappe.defaults.get_user_default("Company");
         frm.trigger("company");
 


### PR DESCRIPTION
> Explain the details for making this change. What existing problem does the pull request solve?

The Purchase Reconciliation Tool and GST Invoice Management System are report-like tools — the single document is used to drive a report and is never saved. Despite this, the form displayed the orange **Not Saved** pill.

The pill appears because the form is marked dirty when default values are set during `setup` (e.g. `company`/`company_gstin`), which happens *before* `disable_save()` is called (that happened later, in the refresh action setup). Frappe's toolbar suppresses the "Not Saved" indicator only when `save_disabled` is already set at the time the form is dirtied.

This PR calls `frm.disable_save()` early in `setup` — before the form is dirtied — so the indicator never appears, consistent with how GSTR-1 already behaves. The existing `disable_save()` call in the action setup is retained.

Applied to both:
- `purchase_reconciliation_tool.js`
- `gst_invoice_management_system.js`

> Screenshots/GIFs

Before: PRT/IMS show an orange "Not Saved" pill. After: no pill.

closes #4505

---
_Generated by [Claude Code](https://claude.ai/code/session_016TKT8x6x4rcj1nNyCjW8xx)_