### PR TITLE
feat: auto-select State from GSTIN in quick entry dialog

### DIFF
--- a/india_compliance/boot.py
+++ b/india_compliance/boot.py
@@ -30,6 +30,7 @@ def set_bootinfo(bootinfo):
 
     bootinfo["gst_settings"] = gst_settings
     bootinfo["india_state_options"] = list(INDIAN_STATES)
+    bootinfo["gst_state_by_number"] = {number: state for state, number in INDIAN_STATES.items()}
     bootinfo["ic_api_enabled_from_conf"] = bool(frappe.conf.ic_api_secret)
 
     set_indian_registered_companies(bootinfo)

--- a/india_compliance/public/js/quick_entry.js
+++ b/india_compliance/public/js/quick_entry.js
@@ -98,10 +98,6 @@ class GSTQuickEntryForm extends frappe.ui.form.QuickEntryForm {
 
                     india_compliance.check_duplicate_gstin(d.doc._gstin, this.doctype);
 
-                    // Auto-select the State from the GSTIN's state code
-                    const state = india_compliance.get_state_from_gstin(d.doc._gstin);
-                    if (state && d.fields_dict.state) d.set_value("state", state);
-
                     if (["Customer", "Supplier"].includes(this.doctype)) {
                         d.set_value(
                             `${this.doctype.toLowerCase()}_type`,
@@ -110,6 +106,11 @@ class GSTQuickEntryForm extends frappe.ui.form.QuickEntryForm {
                     }
 
                     if (this.api_enabled && !gst_settings.sandbox_mode) return autofill_fields(d);
+
+                    if (d.doc._gstin && d.fields_dict.state) {
+                        const state = india_compliance.get_state_from_gstin(d.doc._gstin);
+                        d.set_value("state", state);
+                    }
 
                     d.set_value(
                         "gst_category",

--- a/india_compliance/public/js/quick_entry.js
+++ b/india_compliance/public/js/quick_entry.js
@@ -98,6 +98,10 @@ class GSTQuickEntryForm extends frappe.ui.form.QuickEntryForm {
 
                     india_compliance.check_duplicate_gstin(d.doc._gstin, this.doctype);
 
+                    // Auto-select the State from the GSTIN's state code
+                    const state = india_compliance.get_state_from_gstin(d.doc._gstin);
+                    if (state && d.fields_dict.state) d.set_value("state", state);
+
                     if (["Customer", "Supplier"].includes(this.doctype)) {
                         d.set_value(
                             `${this.doctype.toLowerCase()}_type`,

--- a/india_compliance/public/js/utils.js
+++ b/india_compliance/public/js/utils.js
@@ -328,6 +328,13 @@ Object.assign(india_compliance, {
         state_field.set_data(frappe.boot.india_state_options || []);
     },
 
+    get_state_from_gstin(gstin) {
+        if (!gstin || gstin.length < 2) return;
+
+        const state_number = gstin.substring(0, 2);
+        return (frappe.boot.gst_state_by_number || {})[state_number];
+    },
+
     can_enable_api(settings) {
         return settings.api_secret || frappe.boot.ic_api_enabled_from_conf;
     },


### PR DESCRIPTION
no-docs — minor UX enhancement that auto-fills an existing field; no dedicated documentation page seems necessary. Happy to add docs or reclassify if you'd prefer.

> Explain the details for making this change. What existing problem does the pull request solve?

When creating an Address (or a Customer/Supplier with address details) through the Quick Entry dialog, the **State** had to be selected manually even though the GSTIN already encodes it (the first two digits are the state code). Picking the wrong State triggers the server-side "First 2 digits of GSTIN should match with State Number" validation.

This PR auto-selects the State from the entered GSTIN's state code:
- `boot.py`: expose the state-name → state-number map as `frappe.boot.gst_state_numbers`.
- `utils.js`: add `india_compliance.get_state_from_gstin(gstin)` helper.
- `quick_entry.js`: on GSTIN change, set the State field from the derived state code (works with or without the autofill API).

This reduces manual entry and prevents the GSTIN/State mismatch error (related to #4348).

> Screenshots/GIFs

Entering a GSTIN starting with `27` now sets State to **Maharashtra** automatically.

closes #4349