### PR TITLE
fix: rename sidebar section "Miscellaneous" to "Account"

### DIFF
--- a/india_compliance/workspace_sidebar/gst_india.json
+++ b/india_compliance/workspace_sidebar/gst_india.json
@@ -102,7 +102,7 @@
    "icon": "layout-list",
    "indent": 1,
    "keep_closed": 1,
-   "label": "Miscellaneous",
+   "label": "Account",
    "link_type": "DocType",
    "show_arrow": 0,
    "type": "Section Break"


### PR DESCRIPTION
> Explain the details for making this change. What existing problem does the pull request solve?

The India Compliance left-nav sidebar had a section labelled **Miscellaneous** that only contains the **India Compliance Account** page. "Miscellaneous" is vague; this renames it to **Account**, which describes its content.

If you'd prefer a different label (e.g. `India Compliance Account` or `Integrations`), it's a one-line change in `workspace_sidebar/gst_india.json` — happy to adjust.

> Screenshots/GIFs

Sidebar section heading changes from "Miscellaneous" to "Account".

closes #4513

---
_Generated by [Claude Code](https://claude.ai/code/session_016TKT8x6x4rcj1nNyCjW8xx)_