### PR TITLE
fix: enforce integer type for distance in e-Waybill calculations

### DIFF
--- a/india_compliance/gst_india/client_scripts/e_waybill_actions.js
+++ b/india_compliance/gst_india/client_scripts/e_waybill_actions.js
@@ -391,7 +391,7 @@ function get_generate_e_waybill_dialog(opts, frm) {
         {
             label: "Distance (in km)",
             fieldname: "distance",
-            fieldtype: "Float",
+            fieldtype: "Int",
             default: frm.doc.distance || 0,
             description: "Set as zero to update distance as per the e-Waybill portal (if available)",
         },
@@ -976,7 +976,7 @@ async function show_extend_validity_dialog(frm) {
             {
                 label: "Remaining Distance (in km)",
                 fieldname: "remaining_distance",
-                fieldtype: "Float",
+                fieldtype: "Int",
                 default: frm.doc.distance,
                 reqd: 1,
             },

--- a/india_compliance/gst_india/overrides/test_transaction_data.py
+++ b/india_compliance/gst_india/overrides/test_transaction_data.py
@@ -236,6 +236,33 @@ class TestTransactionData(IntegrationTestCase):
 
         self.assertEqual(gst_transaction_data.transaction_details["transporter_name"], "A" * 100)
 
+    def test_set_transporter_details_distance_is_coerced_to_int(self):
+        """Distance must reach the e-Waybill portal as a whole number of km.
+
+        Guards against a fractional value (e.g. if the custom field type was
+        modified) and enforces the portal's out-of-range reset to 0.
+        """
+        doc = create_sales_invoice(vehicle_no="GJ07DL9009", do_not_submit=True)
+
+        # Fractional value should truncate to an int
+        doc.distance = 10.9
+        gst_transaction_data = GSTTransactionData(doc)
+        gst_transaction_data.set_transporter_details()
+        self.assertEqual(gst_transaction_data.transaction_details["distance"], 10)
+        self.assertIsInstance(gst_transaction_data.transaction_details["distance"], int)
+
+        # Value at/above the portal limit (4000 km) resets to 0
+        doc.distance = 4000
+        gst_transaction_data = GSTTransactionData(doc)
+        gst_transaction_data.set_transporter_details()
+        self.assertEqual(gst_transaction_data.transaction_details["distance"], 0)
+
+        # Normal integer passes through unchanged
+        doc.distance = 42
+        gst_transaction_data = GSTTransactionData(doc)
+        gst_transaction_data.set_transporter_details()
+        self.assertEqual(gst_transaction_data.transaction_details["distance"], 42)
+
     def test_get_all_item_details(self):
         """Assertion for all Item Details fetched from transaction docs"""
         doc = create_sales_invoice(do_not_submit=True)

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -8,6 +8,7 @@ from frappe.desk.form.load import get_docinfo, run_onload
 from frappe.utils import (
     add_days,
     add_to_date,
+    cint,
     escape_html,
     format_date,
     get_datetime,
@@ -645,7 +646,7 @@ def extend_validity(
     data = EWaybillData(doc).get_extend_validity_data(values)
     result = EWaybillAPI.create(doc).extend_validity(data)
 
-    doc.db_set("distance", values.remaining_distance)
+    doc.db_set("distance", cint(values.remaining_distance))
 
     update_e_waybill_log_for_extention(
         values=values,
@@ -1140,7 +1141,7 @@ def update_transaction(doc, values):
         "transporter_name": transporter_name,
         "gst_transporter_id": values.gst_transporter_id,
         "vehicle_no": values.vehicle_no,
-        "distance": values.distance,
+        "distance": cint(values.distance),
         "lr_no": values.lr_no,
         "lr_date": values.lr_date,
         "mode_of_transport": values.mode_of_transport,
@@ -1339,7 +1340,7 @@ class EWaybillData(GSTTransactionData):
             "fromPlace": self.sanitize_value(values.current_place, regex=3, max_length=50),
             "fromState": STATE_NUMBERS[values.current_state],
             "fromPincode": int(values.current_pincode),
-            "remainingDistance": int(values.remaining_distance),
+            "remainingDistance": cint(values.remaining_distance),
             "transDocNo": self.transaction_details.lr_no,
             "transDocDate": self.transaction_details.lr_date,
             "transMode": self.transaction_details.mode_of_transport,

--- a/india_compliance/gst_india/utils/transaction_data.py
+++ b/india_compliance/gst_india/utils/transaction_data.py
@@ -2,7 +2,7 @@ import re
 
 import frappe
 from frappe import _
-from frappe.utils import format_date, get_link_to_form, getdate, rounded
+from frappe.utils import cint, format_date, get_link_to_form, getdate, rounded
 
 from india_compliance.gst_india.constants import (
     E_INVOICE_MASTER_CODES_URL,
@@ -213,9 +213,10 @@ class GSTTransactionData:
         return True
 
     def set_transporter_details(self):
-        self.transaction_details.distance = (
-            self.doc.distance if self.doc.distance and self.doc.distance < 4000 else 0
-        )
+        # Distance must be a whole number of km for the e-Waybill portal.
+        # cint() guards against a non-Int value (e.g. modified custom field).
+        distance = cint(self.doc.distance)
+        self.transaction_details.distance = distance if distance < 4000 else 0
 
         if self.validate_mode_of_transport(False):
             self.transaction_details.update(


### PR DESCRIPTION
Issue: If the user changes the field type to Float, the e-waybill cannot be generated.