### PR TITLE
fix: correct values for Ineligible As Per Section 17(5)  in GSTR3b

### DIFF
--- a/india_compliance/gst_india/doctype/gstr_3b_report/test_gstr_3b_report.py
+++ b/india_compliance/gst_india/doctype/gstr_3b_report/test_gstr_3b_report.py
@@ -354,6 +354,47 @@ class TestGSTR3BReport(IntegrationTestCase):
         self.assertEqual(net_itc["camt"], 9.0)
         self.assertEqual(net_itc["samt"], 9.0)
 
+    @change_settings(
+        "GST Settings",
+        {"round_off_gst_values": 0},
+    )
+    def test_pos_restricted_pi_with_ineligible_item_is_not_reversed_under_section_17_5(self):
+        """
+        When a Purchase Invoice is PoS-restricted, its ITC is ineligible under the
+        PoS rules (Table 4D) and must NOT ALSO be reported as a Section-17(5) reversal
+        (Table 4B), even if an item carries is_ineligible_for_itc.
+        """
+        pi = create_purchase_invoice(
+            update_stock=1,
+            place_of_supply="27-Maharashtra",
+            is_out_state=1,
+            supplier_address="_Test Registered Supplier-Billing",
+            rate=100,
+            qty=1,
+            do_not_save=True,
+        )
+        pi.items[0].is_ineligible_for_itc = 1
+        pi.save()
+        pi.submit()
+
+        self.assertEqual(pi.ineligibility_reason, "ITC restricted due to PoS rules")
+
+        output = self.get_report_output()
+
+        # Table 4D — itc_inelg OTH: whole invoice reported here (18% IGST on 100 = 18)
+        oth_inelg = next(d for d in output["itc_elg"]["itc_inelg"] if d["ty"] == "OTH")
+        self.assertEqual(oth_inelg["iamt"], 18.0)
+
+        # Table 4B — itc_rev RUL: nothing reversed under Section 17(5)
+        rul_rev = next(d for d in output["itc_elg"]["itc_rev"] if d["ty"] == "RUL")
+        self.assertEqual(rul_rev["camt"], 0.0)
+        self.assertEqual(rul_rev["samt"], 0.0)
+        self.assertEqual(rul_rev["iamt"], 0.0)
+
+        # Not availed either — PoS-restricted ITC never enters Table 4A
+        oth_avl = next(d for d in output["itc_elg"]["itc_avl"] if d["ty"] == "OTH")
+        self.assertEqual(oth_avl["iamt"], 0.0)
+
     def test_itc_reversal_journal_entry_is_included_in_gstr_3b(self):
         journal_entry = create_itc_reversal_journal_entry(tax_amount=9)
 

--- a/india_compliance/gst_india/doctype/gstr_3b_report/test_gstr_3b_report.py
+++ b/india_compliance/gst_india/doctype/gstr_3b_report/test_gstr_3b_report.py
@@ -305,6 +305,55 @@ class TestGSTR3BReport(IntegrationTestCase):
         net_itc = output["itc_elg"]["itc_net"]
         self.assertEqual(net_itc["iamt"], 36.0)
 
+    @change_settings(
+        "GST Settings",
+        {"round_off_gst_values": 0},
+    )
+    def test_mixed_item_section_17_5_pi_reverses_only_ineligible_item(self):
+        """
+        A Purchase Invoice with a mix of eligible and Section-17(5) ineligible items
+        must reverse ONLY the ineligible item's tax, not the whole invoice.
+
+        Two items @ rate=100 (CGST 9 + SGST 9 each); item[1] is ineligible:
+          - Table 4A (itc_avl OTH): both items availed → CGST 18, SGST 18
+          - Table 4B (itc_rev RUL): only ineligible item reversed → CGST 9, SGST 9
+          - Table 4C (itc_net): eligible item retained → CGST 9, SGST 9
+        """
+        pi = create_purchase_invoice(is_in_state=True, rate=100, qty=1, do_not_save=True)
+        append_item(
+            pi,
+            frappe._dict(
+                {
+                    "doctype": "Purchase Invoice",
+                    "item_code": "_Test Trading Goods 1",
+                    "qty": 1,
+                    "rate": 100,
+                }
+            ),
+        )
+        pi.items[1].is_ineligible_for_itc = 1
+        pi.save()
+        pi.submit()
+
+        output = self.get_report_output()
+
+        # Table 4A — itc_avl OTH: both items availed
+        oth_avl = next(d for d in output["itc_elg"]["itc_avl"] if d["ty"] == "OTH")
+        self.assertEqual(oth_avl["camt"], 18.0)
+        self.assertEqual(oth_avl["samt"], 18.0)
+        self.assertEqual(oth_avl["iamt"], 0.0)
+        self.assertEqual(oth_avl["csamt"], 0.0)
+
+        # Table 4B — itc_rev RUL: only the ineligible item reversed
+        rul_rev = next(d for d in output["itc_elg"]["itc_rev"] if d["ty"] == "RUL")
+        self.assertEqual(rul_rev["camt"], 9.0)
+        self.assertEqual(rul_rev["samt"], 9.0)
+
+        # Table 4C — itc_net: eligible item's ITC retained
+        net_itc = output["itc_elg"]["itc_net"]
+        self.assertEqual(net_itc["camt"], 9.0)
+        self.assertEqual(net_itc["samt"], 9.0)
+
     def test_itc_reversal_journal_entry_is_included_in_gstr_3b(self):
         journal_entry = create_itc_reversal_journal_entry(tax_amount=9)
 

--- a/india_compliance/gst_india/utils/gstr3b/gstr3b_inward_data.py
+++ b/india_compliance/gst_india/utils/gstr3b/gstr3b_inward_data.py
@@ -147,11 +147,11 @@ class GSTR3BCategoryConditions:
     def is_itc_available(self, invoice):
         return invoice.ineligibility_reason != "ITC restricted due to PoS rules"
 
-    def is_itc_reversed(self, invoice):
-        return invoice.is_ineligible_for_itc
-
     def is_ineligible_itc(self, invoice):
         return invoice.ineligibility_reason == "ITC restricted due to PoS rules"
+
+    def is_itc_reversed(self, invoice):
+        return invoice.is_ineligible_for_itc and not self.is_ineligible_itc(invoice)
 
     def is_itc_available_for_boe(self, invoice):
         return True

--- a/india_compliance/gst_india/utils/gstr3b/gstr3b_inward_data.py
+++ b/india_compliance/gst_india/utils/gstr3b/gstr3b_inward_data.py
@@ -148,7 +148,7 @@ class GSTR3BCategoryConditions:
         return invoice.ineligibility_reason != "ITC restricted due to PoS rules"
 
     def is_itc_reversed(self, invoice):
-        return invoice.ineligibility_reason == "Ineligible As Per Section 17(5)"
+        return invoice.is_ineligible_for_itc
 
     def is_ineligible_itc(self, invoice):
         return invoice.ineligibility_reason == "ITC restricted due to PoS rules"
@@ -228,6 +228,7 @@ class GSTR3BInwardQuery:
                 self.PI.company_gstin,
                 IfNull(self.PI.supplier_gstin, "").as_("supplier_gstin"),
                 self.PI.is_reverse_charge,
+                self.PI_ITEM.is_ineligible_for_itc,
                 self.PI_ITEM.item_code,
                 IfNull(self.PI_ITEM.gst_treatment, "").as_("gst_treatment"),
                 self.PI_ITEM.gst_hsn_code,


### PR DESCRIPTION
Issue: In a Purchase invoice, if there are mixed ineligible items(Ineligible As Per Section 17(5)), then the whole tax amount was getting reversed in gstr3b.