### PR TITLE
fix: download all categories for gstr 2a

### DIFF
--- a/india_compliance/gst_india/api_classes/taxpayer_returns.py
+++ b/india_compliance/gst_india/api_classes/taxpayer_returns.py
@@ -31,6 +31,7 @@ class ReturnsAPI(TaxpayerBaseAPI):
         # "IMS2B007": "not_applicable", # Either the entered ITC period is incorrect or it has 3B filed
         "IMS2005": "not_needed",  # 2B cannot be generated as there are no changes
         # "IMSSAV0015": # Previous Save or Reset request is already under progress. Please try after some time.
+        "RTNECO-01": "not_applicable",  # Supplies made through E-Commerce Operators is not applicable for the return period.
     }
 
     def download_files(self, return_period, token):

--- a/india_compliance/gst_india/constants/__init__.py
+++ b/india_compliance/gst_india/constants/__init__.py
@@ -1491,6 +1491,10 @@ ORIGINAL_VS_AMENDED = (
         "original": "IMPGSEZ",
         "amended": "",
     },
+    {
+        "original": "ECOM",
+        "amended": "ECOMA",
+    },
 )
 
 E_INVOICE_MASTER_CODES_URL = "https://einvoice1.gst.gov.in/Others/MasterCodes"

--- a/india_compliance/gst_india/data/test_gstr_2a.json
+++ b/india_compliance/gst_india/data/test_gstr_2a.json
@@ -298,7 +298,10 @@
   ],
   "tds": [
     {
+      "gstin_deductor": "24AANFA2543R1ZG",
       "gstin_ded": "01AABCE2207R1Z5",
+      "deductor_name": "Test Deductor",
+      "month": "022020",
       "amt_ded": 10000,
       "iamt": 0,
       "camt": 100,

--- a/india_compliance/gst_india/data/test_gstr_2a.json
+++ b/india_compliance/gst_india/data/test_gstr_2a.json
@@ -228,5 +228,92 @@
       "csamt": 0.5,
       "amd": "N"
     }
+  ],
+  "ecom": [
+    {
+      "ctin": "01AABCE2207R1Z5",
+      "cfs": "Y",
+      "cfs3b": "Y",
+      "fldtr1": "18-Nov-19",
+      "flprdr1": "Nov-19",
+      "inv": [
+        {
+          "inum": "ECO-001",
+          "idt": "24-11-2019",
+          "val": 1180,
+          "pos": "06",
+          "rchrg": "N",
+          "inv_typ": "R",
+          "itms": [
+            {
+              "num": 1,
+              "itm_det": {
+                "rt": 18,
+                "txval": 1000,
+                "iamt": 0,
+                "camt": 90,
+                "samt": 90,
+                "csamt": 0
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "ecoma": [
+    {
+      "ctin": "01AABCE2207R1Z5",
+      "cfs": "Y",
+      "cfs3b": "Y",
+      "fldtr1": "18-Nov-19",
+      "flprdr1": "Nov-19",
+      "inv": [
+        {
+          "inum": "ECO-001-A",
+          "idt": "25-11-2019",
+          "oinum": "ECO-001",
+          "oidt": "24-11-2019",
+          "val": 1180,
+          "pos": "06",
+          "rchrg": "N",
+          "inv_typ": "R",
+          "atyp": "R",
+          "itms": [
+            {
+              "num": 1,
+              "itm_det": {
+                "rt": 18,
+                "txval": 1000,
+                "iamt": 0,
+                "camt": 90,
+                "samt": 90,
+                "csamt": 0
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "tds": [
+    {
+      "gstin_ded": "01AABCE2207R1Z5",
+      "amt_ded": 10000,
+      "iamt": 0,
+      "camt": 100,
+      "samt": 100
+    }
+  ],
+  "tcs": [
+    {
+      "etin": "01AABCE2207R1Z5",
+      "sup_val": 50000,
+      "tx_val": 48000,
+      "iamt": 0,
+      "camt": 240,
+      "samt": 240,
+      "csamt": 0
+    }
   ]
 }

--- a/india_compliance/gst_india/doctype/gst_inward_supply/gst_inward_supply.json
+++ b/india_compliance/gst_india/doctype/gst_inward_supply/gst_inward_supply.json
@@ -152,7 +152,7 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Classification",
-   "options": "\nB2B\nB2BA\nCDNR\nCDNRA\nISD\nISDA\nIMPG\nIMPGSEZ"
+   "options": "\nB2B\nB2BA\nCDNR\nCDNRA\nISD\nISDA\nIMPG\nIMPGSEZ\nECOM\nECOMA\nTDS\nTCS"
   },
   {
    "fieldname": "section_break_16",

--- a/india_compliance/gst_india/doctype/gst_inward_supply/gst_inward_supply.py
+++ b/india_compliance/gst_india/doctype/gst_inward_supply/gst_inward_supply.py
@@ -22,7 +22,11 @@ class GSTInwardSupply(Document):
             self.ims_action = self.previous_ims_action
 
         if self.match_status != "Amended" and (self.other_return_period or self.is_amended):
-            update_docs_for_amendment(self)
+            from india_compliance.gst_india.utils.gstr_2 import NON_RECONCILE_CATEGORY
+
+            # download-only categories are never reconciled: skip amendment linking
+            if self.classification not in NON_RECONCILE_CATEGORY:
+                update_docs_for_amendment(self)
 
     def on_trash(self):
         if self.link_doctype and self.link_name:
@@ -41,6 +45,11 @@ def create_inward_supply(transaction):
         "classification": transaction.classification,
         "supplier_gstin": transaction.supplier_gstin,
     }
+
+    # flat records (TDS/TCS) have no bill no/date; key them by period so a later
+    # period doesn't overwrite an earlier one
+    if not transaction.bill_no:
+        filters["sup_return_period"] = transaction.sup_return_period
 
     if name := frappe.get_value("GST Inward Supply", filters):
         gst_inward_supply = frappe.get_doc("GST Inward Supply", name)

--- a/india_compliance/gst_india/doctype/gst_inward_supply/gst_inward_supply.py
+++ b/india_compliance/gst_india/doctype/gst_inward_supply/gst_inward_supply.py
@@ -22,11 +22,7 @@ class GSTInwardSupply(Document):
             self.ims_action = self.previous_ims_action
 
         if self.match_status != "Amended" and (self.other_return_period or self.is_amended):
-            from india_compliance.gst_india.utils.gstr_2 import NON_RECONCILE_CATEGORY
-
-            # download-only categories are never reconciled: skip amendment linking
-            if self.classification not in NON_RECONCILE_CATEGORY:
-                update_docs_for_amendment(self)
+            update_docs_for_amendment(self)
 
     def on_trash(self):
         if self.link_doctype and self.link_name:

--- a/india_compliance/gst_india/doctype/gst_settings/gst_settings.json
+++ b/india_compliance/gst_india/doctype/gst_settings/gst_settings.json
@@ -74,18 +74,6 @@
   "enable_auto_reconciliation",
   "inward_supply_period",
   "column_break_zlfe",
-  "gst_categories_section",
-  "reconcile_for_b2b",
-  "reconcile_for_b2ba",
-  "column_break_notc",
-  "reconcile_for_cdnr",
-  "reconcile_for_cdnra",
-  "column_break_jpws",
-  "reconcile_for_isd",
-  "reconcile_for_isda",
-  "column_break_brkt",
-  "reconcile_for_impg",
-  "reconcile_for_impgsez",
   "auto_reconciliation_days_section",
   "reconcile_on_monday",
   "reconcile_on_friday",
@@ -457,24 +445,6 @@
    "label": "Inward Supply Period in months"
   },
   {
-   "depends_on": "eval: doc.enable_auto_reconciliation",
-   "fieldname": "gst_categories_section",
-   "fieldtype": "Section Break",
-   "label": "GST Categories"
-  },
-  {
-   "fieldname": "column_break_brkt",
-   "fieldtype": "Column Break"
-  },
-  {
-   "fieldname": "column_break_notc",
-   "fieldtype": "Column Break"
-  },
-  {
-   "fieldname": "column_break_jpws",
-   "fieldtype": "Column Break"
-  },
-  {
    "fieldname": "column_break_koqs",
    "fieldtype": "Column Break"
   },
@@ -523,54 +493,6 @@
    "fieldname": "reconcile_on_thursday",
    "fieldtype": "Check",
    "label": "Thursday"
-  },
-  {
-   "default": "1",
-   "fieldname": "reconcile_for_b2b",
-   "fieldtype": "Check",
-   "label": "B2B"
-  },
-  {
-   "default": "0",
-   "fieldname": "reconcile_for_b2ba",
-   "fieldtype": "Check",
-   "label": "B2BA"
-  },
-  {
-   "default": "1",
-   "fieldname": "reconcile_for_cdnr",
-   "fieldtype": "Check",
-   "label": "CDNR"
-  },
-  {
-   "default": "0",
-   "fieldname": "reconcile_for_cdnra",
-   "fieldtype": "Check",
-   "label": "CDNRA"
-  },
-  {
-   "default": "0",
-   "fieldname": "reconcile_for_isd",
-   "fieldtype": "Check",
-   "label": "ISD"
-  },
-  {
-   "default": "0",
-   "fieldname": "reconcile_for_isda",
-   "fieldtype": "Check",
-   "label": "ISDA"
-  },
-  {
-   "default": "0",
-   "fieldname": "reconcile_for_impg",
-   "fieldtype": "Check",
-   "label": "IMPG"
-  },
-  {
-   "default": "0",
-   "fieldname": "reconcile_for_impgsez",
-   "fieldtype": "Check",
-   "label": "IMPGSEZ"
   },
   {
    "default": "0",

--- a/india_compliance/gst_india/doctype/purchase_reconciliation_tool/__init__.py
+++ b/india_compliance/gst_india/doctype/purchase_reconciliation_tool/__init__.py
@@ -307,7 +307,7 @@ class InwardSupply:
         query = (
             frappe.qb.from_(self.GSTR2)
             .where(IfNull(self.GSTR2.match_status, "") != "Amended")
-            # download-only categories (TDS/TCS/ECOM) are stored but never reconciled
+            # download-only categories (TDS/TCS) are stored but never reconciled
             .where(self.GSTR2.classification.notin(NON_RECONCILE_CATEGORY))
             .select(*fields, ConstantColumn("GST Inward Supply").as_("doctype"))
         )
@@ -393,7 +393,7 @@ class PurchaseInvoice:
                 "Tax Collector",
                 "Input Service Distributor",
             )
-            if category in ("B2B", "CDNR", "ISD")
+            if category in ("B2B", "CDNR", "ISD", "ECOM")
             else ("SEZ", "Overseas", "UIN Holders")
         )
         is_return = 1 if category == "CDNR" else 0

--- a/india_compliance/gst_india/doctype/purchase_reconciliation_tool/__init__.py
+++ b/india_compliance/gst_india/doctype/purchase_reconciliation_tool/__init__.py
@@ -15,7 +15,11 @@ from rapidfuzz import fuzz, process
 
 from india_compliance.gst_india.constants import GST_TAX_TYPES, TAXABLE_GST_TREATMENTS
 from india_compliance.gst_india.utils import get_gstin_list, get_party_for_gstin, get_periods_between_dates
-from india_compliance.gst_india.utils.gstr_2 import IMPORT_CATEGORY, ReturnType
+from india_compliance.gst_india.utils.gstr_2 import (
+    IMPORT_CATEGORY,
+    NON_RECONCILE_CATEGORY,
+    ReturnType,
+)
 from india_compliance.gst_india.utils.itc_claim import (
     SUPPORTED_DOCTYPES,
     set_itc_claim_period_on_match,
@@ -303,6 +307,8 @@ class InwardSupply:
         query = (
             frappe.qb.from_(self.GSTR2)
             .where(IfNull(self.GSTR2.match_status, "") != "Amended")
+            # download-only categories (TDS/TCS/ECOM) are stored but never reconciled
+            .where(self.GSTR2.classification.notin(NON_RECONCILE_CATEGORY))
             .select(*fields, ConstantColumn("GST Inward Supply").as_("doctype"))
         )
 

--- a/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.js
+++ b/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.js
@@ -8,7 +8,6 @@ const tooltip_info = {
 };
 
 const api_enabled = india_compliance.is_api_enabled();
-const GST_CATEGORIES = ["B2B", "B2BA", "CDNR", "CDNRA", "ISD", "IMPG", "IMPGSEZ"];
 const ALERT_HTML = `
     <div class="gstr2b-alert alert alert-primary fade show d-flex align-items-center justify-content-between border-0" role="alert">
         <div>
@@ -28,8 +27,6 @@ const ReturnType = {
     GSTR2A: "GSTR2a",
     GSTR2B: "GSTR2b",
 };
-
-const RECO_2A_CATEGORIES_KEY = "purchase_reco_2a_categories";
 
 const RECO_MODULE =
     "india_compliance.gst_india.doctype.purchase_reconciliation_tool.purchase_reconciliation_tool";
@@ -853,7 +850,6 @@ class ImportDialog {
             title: __("Download Data from GSTN"),
             fields: [
                 ...this.get_gstr_fields(),
-                ...this.get_2a_category_fields(),
                 ...this.get_fields_for_pending_downloads(),
                 ...this.get_fields_for_download_history(),
             ],
@@ -896,23 +892,13 @@ class ImportDialog {
 
     setup_dialog_actions() {
         if (this.for_download) {
-            if (this.return_type === ReturnType.GSTR2A) {
-                this.dialog.set_primary_action(__("Download All"), () => {
-                    this.download_gstr_by_category(false);
-                });
-                this.dialog.set_secondary_action_label(__("Download Missing"));
-                this.dialog.set_secondary_action(() => {
-                    this.download_gstr_by_category(true);
-                });
-            } else if (this.return_type === ReturnType.GSTR2B) {
-                this.dialog.set_primary_action(__("Download All"), () => {
-                    this.download_gstr_by_period(false);
-                });
-                this.dialog.set_secondary_action_label(__("Download Missing"));
-                this.dialog.set_secondary_action(() => {
-                    this.download_gstr_by_period(true);
-                });
-            }
+            this.dialog.set_primary_action(__("Download All"), () => {
+                this.download_gstr_by_period(false);
+            });
+            this.dialog.set_secondary_action_label(__("Download Missing"));
+            this.dialog.set_secondary_action(() => {
+                this.download_gstr_by_period(true);
+            });
         } else {
             this.dialog.set_primary_action(__("Upload"), () => {
                 const file_path = this.dialog.get_value("attach_file");
@@ -926,26 +912,6 @@ class ImportDialog {
                 this.dialog.hide();
             });
         }
-    }
-
-    download_gstr_by_category(only_missing) {
-        const marked_gst_categories = this.dialog.get_value("gst_categories") || [];
-        if (marked_gst_categories.length === 0) {
-            frappe.throw(__("Please select at least one Category to Download"));
-        }
-
-        save_2a_categories(marked_gst_categories);
-
-        download_gstr(
-            this.frm,
-            this.date_range,
-            this.return_type,
-            this.company_gstin,
-            null,
-            only_missing,
-            marked_gst_categories,
-        );
-        this.dialog.hide();
     }
 
     download_gstr_by_period(only_missing) {
@@ -1109,36 +1075,6 @@ class ImportDialog {
         ];
     }
 
-    get_2a_category_fields() {
-        const saved = get_saved_2a_categories();
-        const import_categories = ["IMPG", "IMPGSEZ"];
-        const rare_categories = ["ISD"];
-        const overseas_enabled = gst_settings.enable_overseas_transactions;
-
-        const is_default_checked = (category) => {
-            if (rare_categories.includes(category)) return false;
-            if (import_categories.includes(category) && !overseas_enabled) return false;
-            return true;
-        };
-
-        return [
-            { fieldtype: "Section Break", depends_on: "eval:doc.return_type == 'GSTR2a'" },
-            {
-                fieldname: "gst_categories",
-                fieldtype: "MultiCheck",
-                label: __("Categories"),
-                select_all: true,
-                columns: 4,
-                sort_options: false,
-                options: GST_CATEGORIES.map((category) => ({
-                    label: category,
-                    value: category,
-                    checked: saved ? saved.includes(category) : is_default_checked(category),
-                })),
-            },
-        ];
-    }
-
     get_fields_for_pending_downloads() {
         const label = this.for_download ? "🟠 Pending Download" : "🟠 Pending Upload";
         return [
@@ -1168,7 +1104,6 @@ async function download_gstr(
     company_gstin,
     return_period,
     only_missing = true,
-    gst_categories = null,
 ) {
     let company_gstins;
     if (company_gstin == "All") company_gstins = await india_compliance.get_gstin_options(frm.doc.company);
@@ -1181,7 +1116,6 @@ async function download_gstr(
             date_range,
             return_period,
             force: !only_missing,
-            gst_categories,
         };
         frm.events.show_progress(frm, "download");
         const { message } = await frm.taxpayer_api_call("download_gstr", args);
@@ -1192,21 +1126,6 @@ async function download_gstr(
                 indicator: message?.indicator || "blue",
             });
         }
-    });
-}
-
-function get_saved_2a_categories() {
-    return india_compliance.get_user_default_json(RECO_2A_CATEGORIES_KEY);
-}
-
-function save_2a_categories(categories) {
-    const serialized = JSON.stringify(categories);
-
-    frappe.defaults.set_user_default_local(RECO_2A_CATEGORIES_KEY, serialized);
-
-    frappe.call({
-        method: `${RECO_MODULE}.set_category_preference`,
-        args: { categories: serialized },
     });
 }
 

--- a/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.js
+++ b/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.js
@@ -288,7 +288,7 @@ class PurchaseReconciliationTool extends reconciliation.reconciliation_tabs {
                 label: "Classification",
                 fieldname: "classification",
                 fieldtype: "Select",
-                options: ["B2B", "B2BA", "CDNR", "CDNRA", "ISD", "ISDA", "IMPG", "IMPGSEZ"],
+                options: ["B2B", "B2BA", "CDNR", "CDNRA", "ISD", "ISDA", "IMPG", "IMPGSEZ", "ECOM", "ECOMA"],
             },
             {
                 label: "Is Reverse Charge",

--- a/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.py
+++ b/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.py
@@ -50,7 +50,6 @@ from india_compliance.gst_india.utils.gstin_info import (
     update_gstr_returns_info,
 )
 from india_compliance.gst_india.utils.gstr_2 import (
-    GSTR_2A_ACTIONS,
     IMPORT_CATEGORY,
     ReturnType,
     download_gstr_2a,
@@ -71,10 +70,6 @@ STATUS_MAP = {
     "Pending": "Unreconciled",
     "Ignore": "Ignored",
 }
-
-RECO_2A_CATEGORIES_KEY = "purchase_reco_2a_categories"
-
-VALID_2A_CATEGORIES = {cat.value for cat in GSTR_2A_ACTIONS.values()}
 
 
 class PurchaseReconciliationTool(Document):
@@ -143,7 +138,6 @@ class PurchaseReconciliationTool(Document):
         return_type: str | None = None,
         return_period: str | None = None,
         force: bool = False,
-        gst_categories: str | list | None = None,
     ):
         frappe.has_permission("Purchase Reconciliation Tool", "write", throw=True)
 
@@ -165,7 +159,6 @@ class PurchaseReconciliationTool(Document):
             return_type=return_type,
             return_period=return_period,
             force=force,
-            gst_categories=gst_categories,
             queue="long",
             job_id=job_id,
             now=frappe.flags.in_test,
@@ -389,7 +382,6 @@ def download_gstr(
     return_type,
     return_period=None,
     force=False,
-    gst_categories=None,
 ):
     return_type = ReturnType(return_type)
 
@@ -407,7 +399,7 @@ def download_gstr(
 
     try:
         if return_type == ReturnType.GSTR2A:
-            return download_gstr_2a(company_gstin, periods, gst_categories)
+            return download_gstr_2a(company_gstin, periods)
 
         if return_type == ReturnType.GSTR2B:
             return download_gstr_2b(company_gstin, periods)
@@ -570,20 +562,6 @@ def download_excel_report(
     build_data.export_data()
 
 
-@frappe.whitelist()
-def set_category_preference(categories: str | list | None = None):
-    frappe.has_permission("Purchase Reconciliation Tool", "write", throw=True)
-
-    if isinstance(categories, str):
-        categories = frappe.parse_json(categories) if categories else None
-
-    if not categories:
-        categories = []
-
-    categories = [c for c in categories if c in VALID_2A_CATEGORIES]
-    frappe.defaults.set_user_default(RECO_2A_CATEGORIES_KEY, frappe.as_json(categories))
-
-
 def parse_params(fun):
     def wrapper(*args, **kwargs):
         args = (frappe.parse_json(arg) for arg in args)
@@ -630,8 +608,6 @@ class AutoReconcile:
         if not self.is_reconciliation_enabled():
             return
 
-        # GST Categories for which GSTR 2A is to be downloaded
-        gst_categories = self.get_gst_categories()
         gstins = self.get_gstins_with_valid_credentials()
 
         for gstin in gstins:
@@ -642,16 +618,8 @@ class AutoReconcile:
                         self.today.strftime("%Y-%m-%d"),
                     ],
                     company_gstin=gstin,
-                    gst_categories=gst_categories,
                     return_type=return_type.value,
                 )
-
-    def get_gst_categories(self):
-        return [
-            category.value
-            for category in GSTR_2A_ACTIONS.values()
-            if getattr(self.gst_settings, "reconcile_for_" + category.value.lower())
-        ]
 
     def get_gstins_with_valid_credentials(self):
         valid_gstins = set()

--- a/india_compliance/gst_india/doctype/purchase_reconciliation_tool/test_purchase_reconciliation_tool.py
+++ b/india_compliance/gst_india/doctype/purchase_reconciliation_tool/test_purchase_reconciliation_tool.py
@@ -10,11 +10,6 @@ from frappe.tests.utils import make_test_objects
 from india_compliance.gst_india.doctype.bill_of_entry.bill_of_entry import (
     make_bill_of_entry,
 )
-from india_compliance.gst_india.doctype.purchase_reconciliation_tool.purchase_reconciliation_tool import (
-    RECO_2A_CATEGORIES_KEY,
-    VALID_2A_CATEGORIES,
-    set_category_preference,
-)
 from india_compliance.gst_india.utils.itc_claim import (
     ITC_CLAIM_PERIOD_DEFERRED,
     format_period,
@@ -509,69 +504,6 @@ class TestPurchaseReconciliationTool(IntegrationTestCase):
             link_doctype=None,
         )
         self.assertIsInstance(result, list)
-
-
-class TestCategoryPreference(IntegrationTestCase):
-    """Tests for the GSTR-2A download category user-preference (set_category_preference)."""
-
-    def tearDown(self):
-        # set_category_preference writes a user default; reset it between tests so
-        # one test's stored value cannot leak into another.
-        frappe.defaults.clear_user_default(RECO_2A_CATEGORIES_KEY)
-
-    def get_saved_categories(self):
-        raw = frappe.defaults.get_user_default(RECO_2A_CATEGORIES_KEY)
-        return frappe.parse_json(raw) if raw else None
-
-    def test_stores_valid_categories(self):
-        set_category_preference(["B2B", "ISD"])
-        self.assertEqual(self.get_saved_categories(), ["B2B", "ISD"])
-
-    def test_drops_invalid_categories(self):
-        # "GARBAGE" is not a real category; "ISDA" is a GSTR-2B-only category and so
-        # is not a valid GSTR-2A download category. Both must be filtered out while the
-        # valid entries are kept in the original order.
-        set_category_preference(["B2B", "GARBAGE", "ISD", "ISDA"])
-        self.assertEqual(self.get_saved_categories(), ["B2B", "ISD"])
-
-    def test_accepts_json_string(self):
-        # This is the real call path: the JS client sends a JSON-serialised string.
-        set_category_preference(frappe.as_json(["B2B", "CDNR"]))
-        self.assertEqual(self.get_saved_categories(), ["B2B", "CDNR"])
-
-    def test_accepts_python_list(self):
-        set_category_preference(["B2BA", "CDNRA"])
-        self.assertEqual(self.get_saved_categories(), ["B2BA", "CDNRA"])
-
-    def test_all_valid_categories_round_trip(self):
-        all_categories = sorted(VALID_2A_CATEGORIES)
-        set_category_preference(all_categories)
-        self.assertEqual(sorted(self.get_saved_categories()), all_categories)
-
-    def test_none_stores_empty_list(self):
-        set_category_preference(None)
-        self.assertEqual(self.get_saved_categories(), [])
-
-    def test_empty_string_stores_empty_list(self):
-        set_category_preference("")
-        self.assertEqual(self.get_saved_categories(), [])
-
-    def test_empty_list_stores_empty_list(self):
-        set_category_preference([])
-        self.assertEqual(self.get_saved_categories(), [])
-
-    def test_all_invalid_stores_empty_list(self):
-        set_category_preference(["GARBAGE", "ISDA"])
-        self.assertEqual(self.get_saved_categories(), [])
-
-    def test_overwrites_previous_preference(self):
-        set_category_preference(["B2B", "ISD"])
-        set_category_preference(["CDNR"])
-        self.assertEqual(self.get_saved_categories(), ["CDNR"])
-
-    def test_requires_write_permission(self):
-        with self.set_user("Guest"):
-            self.assertRaises(frappe.PermissionError, set_category_preference, ["B2B"])
 
 
 def create_purchase_invoice(**kwargs):

--- a/india_compliance/gst_india/setup/__init__.py
+++ b/india_compliance/gst_india/setup/__init__.py
@@ -232,8 +232,6 @@ def set_default_gst_settings():
         "inward_supply_period": 2,
         "reconcile_on_tuesday": 1,
         "reconcile_on_friday": 1,
-        "reconcile_for_b2b": 1,
-        "reconcile_for_cdnr": 1,
         # GSTR-1
         "enable_gstr_1_api": 1,
         "compare_unfiled_data": 1,

--- a/india_compliance/gst_india/utils/gstr_2/__init__.py
+++ b/india_compliance/gst_india/utils/gstr_2/__init__.py
@@ -38,7 +38,7 @@ class GSTRCategory(Enum):
     B2BDN = "B2BDN"
     B2BDNA = "B2BDNA"
 
-    # GSTR 2A only (downloaded but not reconciled against purchases)
+    # GSTR 2A only
     ECOM = "ECOM"
     ECOMA = "ECOMA"
     TDS = "TDS"
@@ -77,7 +77,7 @@ GSTR_MODULES = {
 
 IMPORT_CATEGORY = ("IMPG", "IMPGSEZ")
 
-NON_RECONCILE_CATEGORY = ("ECOM", "ECOMA", "TDS", "TCS")
+NON_RECONCILE_CATEGORY = ("TDS", "TCS")
 
 
 def download_gstr_2a(gstin, return_periods):

--- a/india_compliance/gst_india/utils/gstr_2/__init__.py
+++ b/india_compliance/gst_india/utils/gstr_2/__init__.py
@@ -38,6 +38,12 @@ class GSTRCategory(Enum):
     B2BDN = "B2BDN"
     B2BDNA = "B2BDNA"
 
+    # GSTR 2A only (downloaded but not reconciled against purchases)
+    ECOM = "ECOM"
+    ECOMA = "ECOMA"
+    TDS = "TDS"
+    TCS = "TCS"
+
 
 GSTR_2A_ACTIONS = {
     "B2B": GSTRCategory.B2B,
@@ -47,6 +53,10 @@ GSTR_2A_ACTIONS = {
     "ISD": GSTRCategory.ISD,
     "IMPG": GSTRCategory.IMPG,
     "IMPGSEZ": GSTRCategory.IMPGSEZ,
+    "ECOM": GSTRCategory.ECOM,
+    "ECOMA": GSTRCategory.ECOMA,
+    "TDS": GSTRCategory.TDS,
+    "TCS": GSTRCategory.TCS,
 }
 
 IMS_ACTIONS = {
@@ -67,8 +77,10 @@ GSTR_MODULES = {
 
 IMPORT_CATEGORY = ("IMPG", "IMPGSEZ")
 
+NON_RECONCILE_CATEGORY = ("ECOM", "ECOMA", "TDS", "TCS")
 
-def download_gstr_2a(gstin, return_periods, gst_categories=None):
+
+def download_gstr_2a(gstin, return_periods):
     total_expected_requests = len(return_periods) * len(GSTR_2A_ACTIONS)
     requests_made = 0
     queued_message = False
@@ -92,9 +104,6 @@ def download_gstr_2a(gstin, return_periods, gst_categories=None):
                 },
                 user=frappe.session.user,
             )
-
-            if gst_categories and category.value not in gst_categories:
-                continue
 
             response = api.get_data(action, return_period)
 

--- a/india_compliance/gst_india/utils/gstr_2/gstr_2a.py
+++ b/india_compliance/gst_india/utils/gstr_2/gstr_2a.py
@@ -284,8 +284,9 @@ class GSTR2aTDS(GSTR2a):
 
     def get_invoice_details(self, invoice):
         return {
-            "supplier_gstin": invoice.gstin_ded,
-            "sup_return_period": self.return_period,
+            "supplier_gstin": invoice.gstin_deductor,
+            "supplier_name": invoice.deductor_name,
+            "sup_return_period": invoice.month,
             "taxable_value": invoice.amt_ded,
             "igst": invoice.iamt,
             "cgst": invoice.camt,

--- a/india_compliance/gst_india/utils/gstr_2/gstr_2a.py
+++ b/india_compliance/gst_india/utils/gstr_2/gstr_2a.py
@@ -250,3 +250,77 @@ class GSTR2aIMPGSEZ(GSTR2aIMPG):
             }
         )
         return invoice_details
+
+
+# E-commerce operator supplies u/s 9(5). Same structure as B2B/B2BA.
+class GSTR2aECOM(GSTR2aB2B):
+    pass
+
+
+class GSTR2aECOMA(GSTR2aECOM):
+    def get_invoice_details(self, invoice):
+        invoice_details = super().get_invoice_details(invoice)
+        invoice_details.update(
+            {
+                "original_bill_no": invoice.oinum,
+                "original_bill_date": parse_datetime(invoice.oidt, day_first=True),
+            }
+        )
+        return invoice_details
+
+
+class GSTR2aTDS(GSTR2a):
+    """TDS credit received (counterparty files GSTR-7).
+
+    Flat records with no invoice number or line items: each record is one
+    deductor's aggregated deduction for the period.
+    """
+
+    def get_supplier_details(self, supplier):
+        return {}
+
+    def get_supplier_transactions(self, supplier):
+        return [self.get_transaction(frappe._dict(supplier), frappe._dict(supplier))]
+
+    def get_invoice_details(self, invoice):
+        return {
+            "supplier_gstin": invoice.gstin_ded,
+            "sup_return_period": self.return_period,
+            "taxable_value": invoice.amt_ded,
+            "igst": invoice.iamt,
+            "cgst": invoice.camt,
+            "sgst": invoice.samt,
+            "document_value": invoice.amt_ded,
+        }
+
+    def get_transaction_items(self, invoice):
+        pass
+
+
+class GSTR2aTCS(GSTR2a):
+    """TCS credit received (e-commerce operator files GSTR-8).
+
+    Flat records with no invoice number or line items: each record is one
+    e-commerce operator's aggregated collection for the period.
+    """
+
+    def get_supplier_details(self, supplier):
+        return {}
+
+    def get_supplier_transactions(self, supplier):
+        return [self.get_transaction(frappe._dict(supplier), frappe._dict(supplier))]
+
+    def get_invoice_details(self, invoice):
+        return {
+            "supplier_gstin": invoice.etin,
+            "sup_return_period": self.return_period,
+            "taxable_value": invoice.tx_val,
+            "igst": invoice.iamt,
+            "cgst": invoice.camt,
+            "sgst": invoice.samt,
+            "cess": invoice.csamt,
+            "document_value": invoice.sup_val,
+        }
+
+    def get_transaction_items(self, invoice):
+        pass

--- a/india_compliance/gst_india/utils/gstr_2/gstr_2b.py
+++ b/india_compliance/gst_india/utils/gstr_2/gstr_2b.py
@@ -196,6 +196,23 @@ class GSTR2bISDA(GSTR2bISD):
         return invoice_details
 
 
+# E-commerce operator supplies u/s 9(5). Same structure as B2B/B2BA.
+class GSTR2bECOM(GSTR2bB2B):
+    pass
+
+
+class GSTR2bECOMA(GSTR2bECOM):
+    def get_invoice_details(self, invoice):
+        invoice_details = super().get_invoice_details(invoice)
+        invoice_details.update(
+            {
+                "original_bill_no": invoice.oinum,
+                "original_bill_date": parse_datetime(invoice.oidt, day_first=True),
+            }
+        )
+        return invoice_details
+
+
 class GSTR2bIMPGSEZ(GSTR2b):
     def setup(self):
         super().setup()

--- a/india_compliance/gst_india/utils/gstr_2/test_gstr_2a.py
+++ b/india_compliance/gst_india/utils/gstr_2/test_gstr_2a.py
@@ -61,7 +61,7 @@ class TestGSTR2a(TestGSTRMixin, IntegrationTestCase):
     @patch("india_compliance.gst_india.utils.gstr_2.GSTR2aAPI")
     def test_download_gstr_2a(self, mock_gstr_2a_api, mock_save_gstr):
         def mock_get_data(action, return_period):
-            if action in ["B2B", "B2BA", "CDN", "CDNA"]:
+            if action in ["B2B", "B2BA", "CDN", "CDNA", "ECOM", "ECOMA", "TDS", "TCS"]:
                 return frappe._dict({action.lower(): self.test_data[action.lower()]})
             else:
                 return frappe._dict(error_type="no_docs_found")
@@ -73,6 +73,9 @@ class TestGSTR2a(TestGSTRMixin, IntegrationTestCase):
             self.assertTrue("cdnra" in json_data)
             self.assertTrue("isd" not in json_data)
             self.assertListEqual(json_data.cdnr, self.test_data.cdn)
+            for category in ("ecom", "ecoma", "tds", "tcs"):
+                self.assertTrue(category in json_data)
+                self.assertListEqual(json_data[category], self.test_data[category])
 
         mock_gstr_2a_api.return_value = Mock()
         mock_gstr_2a_api.return_value.get_data.side_effect = mock_get_data

--- a/india_compliance/gst_india/utils/gstr_2/test_gstr_2a.py
+++ b/india_compliance/gst_india/utils/gstr_2/test_gstr_2a.py
@@ -375,8 +375,9 @@ class TestGSTR2a(TestGSTRMixin, IntegrationTestCase):
         self.assertImportLog(GSTRCategory.TDS)
         self.assertDocumentEqual(
             {
-                "supplier_gstin": self.gstin,
-                "sup_return_period": self.return_period,
+                "supplier_gstin": "24AANFA2543R1ZG",
+                "supplier_name": "Test Deductor",
+                "sup_return_period": "022020",
                 "taxable_value": 10000,
                 "igst": 0,
                 "cgst": 100,
@@ -409,10 +410,10 @@ class TestGSTR2a(TestGSTRMixin, IntegrationTestCase):
         # TDS/TCS records have no bill number/date. Downloading the same deductor
         # (TDS) / collector (TCS) across multiple periods must yield one distinct
         # record per period, not a single record overwritten by the latest period.
-        deductor = "24AANFA2543R1ZG"
+        deductor = "27AAPFU0939F1ZV"
         periods = ("052020", "062020")
         section_data = {
-            "tds": {"gstin_ded": deductor, "amt_ded": 10000, "iamt": 0, "camt": 100, "samt": 100},
+            "tds": {"gstin_deductor": deductor, "amt_ded": 10000, "iamt": 0, "camt": 100, "samt": 100},
             "tcs": {
                 "etin": deductor,
                 "sup_val": 50000,
@@ -426,6 +427,9 @@ class TestGSTR2a(TestGSTRMixin, IntegrationTestCase):
 
         for section, record in section_data.items():
             for period in periods:
+                if section == "tds":
+                    record["month"] = period
+
                 save_gstr_2a(
                     self.gstin,
                     period,

--- a/india_compliance/gst_india/utils/gstr_2/test_gstr_2a.py
+++ b/india_compliance/gst_india/utils/gstr_2/test_gstr_2a.py
@@ -448,10 +448,9 @@ class TestGSTR2a(TestGSTRMixin, IntegrationTestCase):
                 msg=f"{classification}: expected one record per period, got {stored_periods}",
             )
 
-    def test_gstr2a_ecom_skips_amendment_linking(self):
-        # Download-only categories must not run the reconciliation amendment machinery.
-        # An ECOM invoice that carries an amendment period (aspd) would otherwise be
-        # stamped match_status="Amended"; the guard in before_save must keep it clean.
+    def test_gstr2a_ecom_runs_amendment_linking(self):
+        # ECOM docs now run the amendment machinery: an ECOM invoice carrying an
+        # amendment period (aspd) is stamped match_status="Amended" in before_save.
         save_gstr_2a(
             self.gstin,
             "072020",
@@ -490,4 +489,4 @@ class TestGSTR2a(TestGSTRMixin, IntegrationTestCase):
             {"company_gstin": self.gstin, "classification": "ECOM", "bill_no": "ECO-AMD-001"},
         )
         self.assertEqual(doc.other_return_period, "052020")
-        self.assertNotEqual(doc.match_status, "Amended")
+        self.assertEqual(doc.match_status, "Amended")

--- a/india_compliance/gst_india/utils/gstr_2/test_gstr_2a.py
+++ b/india_compliance/gst_india/utils/gstr_2/test_gstr_2a.py
@@ -312,3 +312,179 @@ class TestGSTR2a(TestGSTRMixin, IntegrationTestCase):
             },
             doc,
         )
+
+    def test_gstr2a_ecom(self):
+        doc = self.get_doc(GSTRCategory.ECOM)
+        self.assertImportLog(GSTRCategory.ECOM)
+        self.assertDocumentEqual(
+            {
+                "bill_no": "ECO-001",
+                "bill_date": date(2019, 11, 24),
+                "doc_type": "Invoice",
+                "supplier_gstin": self.gstin,
+                "supply_type": "Regular",
+                "place_of_supply": "06-Haryana",
+                "document_value": 1180,
+                "taxable_value": 1000,
+                "igst": 0,
+                "cgst": 90,
+                "sgst": 90,
+                "cess": 0,
+                "is_downloaded_from_2a": 1,
+                "items": [
+                    {
+                        "item_number": 1,
+                        "rate": 18,
+                        "taxable_value": 1000,
+                        "igst": 0,
+                        "cgst": 90,
+                        "sgst": 90,
+                        "cess": 0,
+                    }
+                ],
+            },
+            doc,
+        )
+
+    def test_gstr2a_ecoma(self):
+        doc = self.get_doc(GSTRCategory.ECOMA)
+        self.assertImportLog(GSTRCategory.ECOMA)
+        self.assertDocumentEqual(
+            {
+                "bill_no": "ECO-001-A",
+                "bill_date": date(2019, 11, 25),
+                "original_bill_no": "ECO-001",
+                "original_bill_date": date(2019, 11, 24),
+                "doc_type": "Invoice",
+                "supplier_gstin": self.gstin,
+                "amendment_type": "Receiver GSTIN Amended",
+                "document_value": 1180,
+                "taxable_value": 1000,
+                "cgst": 90,
+                "sgst": 90,
+                "is_downloaded_from_2a": 1,
+            },
+            doc,
+        )
+
+    def test_gstr2a_tds(self):
+        doc = self.get_doc(GSTRCategory.TDS)
+        self.assertImportLog(GSTRCategory.TDS)
+        self.assertDocumentEqual(
+            {
+                "supplier_gstin": self.gstin,
+                "sup_return_period": self.return_period,
+                "taxable_value": 10000,
+                "igst": 0,
+                "cgst": 100,
+                "sgst": 100,
+                "document_value": 10000,
+                "is_downloaded_from_2a": 1,
+            },
+            doc,
+        )
+
+    def test_gstr2a_tcs(self):
+        doc = self.get_doc(GSTRCategory.TCS)
+        self.assertImportLog(GSTRCategory.TCS)
+        self.assertDocumentEqual(
+            {
+                "supplier_gstin": self.gstin,
+                "sup_return_period": self.return_period,
+                "taxable_value": 48000,
+                "igst": 0,
+                "cgst": 240,
+                "sgst": 240,
+                "cess": 0,
+                "document_value": 50000,
+                "is_downloaded_from_2a": 1,
+            },
+            doc,
+        )
+
+    def test_gstr2a_tds_tcs_across_periods(self):
+        # TDS/TCS records have no bill number/date. Downloading the same deductor
+        # (TDS) / collector (TCS) across multiple periods must yield one distinct
+        # record per period, not a single record overwritten by the latest period.
+        deductor = "24AANFA2543R1ZG"
+        periods = ("052020", "062020")
+        section_data = {
+            "tds": {"gstin_ded": deductor, "amt_ded": 10000, "iamt": 0, "camt": 100, "samt": 100},
+            "tcs": {
+                "etin": deductor,
+                "sup_val": 50000,
+                "tx_val": 48000,
+                "iamt": 0,
+                "camt": 240,
+                "samt": 240,
+                "csamt": 0,
+            },
+        }
+
+        for section, record in section_data.items():
+            for period in periods:
+                save_gstr_2a(
+                    self.gstin,
+                    period,
+                    frappe._dict({"gstin": self.gstin, "fp": period, section: [record]}),
+                )
+
+            classification = section.upper()
+            stored_periods = frappe.get_all(
+                "GST Inward Supply",
+                filters={
+                    "company_gstin": self.gstin,
+                    "classification": classification,
+                    "supplier_gstin": deductor,
+                },
+                pluck="sup_return_period",
+            )
+            self.assertCountEqual(
+                stored_periods,
+                periods,
+                msg=f"{classification}: expected one record per period, got {stored_periods}",
+            )
+
+    def test_gstr2a_ecom_skips_amendment_linking(self):
+        # Download-only categories must not run the reconciliation amendment machinery.
+        # An ECOM invoice that carries an amendment period (aspd) would otherwise be
+        # stamped match_status="Amended"; the guard in before_save must keep it clean.
+        save_gstr_2a(
+            self.gstin,
+            "072020",
+            frappe._dict(
+                {
+                    "gstin": self.gstin,
+                    "fp": "072020",
+                    "ecom": [
+                        {
+                            "ctin": self.gstin,
+                            "inv": [
+                                {
+                                    "inum": "ECO-AMD-001",
+                                    "idt": "24-07-2020",
+                                    "val": 1180,
+                                    "pos": "06",
+                                    "rchrg": "N",
+                                    "inv_typ": "R",
+                                    "aspd": "May-20",
+                                    "itms": [
+                                        {
+                                            "num": 1,
+                                            "itm_det": {"rt": 18, "txval": 1000, "camt": 90, "samt": 90},
+                                        }
+                                    ],
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ),
+        )
+
+        doc = frappe.get_doc(
+            "GST Inward Supply",
+            {"company_gstin": self.gstin, "classification": "ECOM", "bill_no": "ECO-AMD-001"},
+        )
+        self.assertEqual(doc.other_return_period, "052020")
+        self.assertNotEqual(doc.match_status, "Amended")

--- a/india_compliance/gst_india/utils/gstr_2/test_gstr_2b_v4_0.py
+++ b/india_compliance/gst_india/utils/gstr_2/test_gstr_2b_v4_0.py
@@ -101,6 +101,67 @@ class TestGSTR2b(TestGSTRMixin, IntegrationTestCase):
             doc,
         )
 
+    def test_gstr2b_ecom(self):
+        doc = self.get_doc(GSTRCategory.ECOM)
+        self.assertDocumentEqual(
+            {
+                "supplier_gstin": "07USERR0205A1ZS",
+                "supplier_name": "GSTN",
+                "gstr_1_filing_date": date(2023, 8, 26),
+                "sup_return_period": "052023",
+                "bill_no": "E123",
+                "supply_type": "Regular",
+                "bill_date": date(2023, 5, 1),
+                "document_value": 234324234,
+                "place_of_supply": "23-Madhya Pradesh",
+                "is_reverse_charge": 0,
+                "itc_availability": "Yes",
+                "diffprcnt": "1",
+                "irn_source": "e-Invoice",
+                "irn_number": ("897ADG56RTY78956HYUG90BNHHIJK453GFTD99845672FDHHHSHGFH4567FG56TR"),
+                "irn_gen_date": date(2019, 12, 24),
+                "doc_type": "Invoice",
+                "taxable_value": 12200,
+                "igst": 183,
+                "cgst": 0,
+                "sgst": 0,
+                "cess": 0,
+                "is_downloaded_from_2b": 1,
+                "is_supplier_return_filed": 1,
+            },
+            doc,
+        )
+
+    def test_gstr2b_ecoma(self):
+        doc = self.get_doc(GSTRCategory.ECOMA)
+        self.assertDocumentEqual(
+            {
+                "supplier_gstin": "07USERR0205A1ZS",
+                "supplier_name": "GSTN",
+                "gstr_1_filing_date": date(2023, 8, 26),
+                "sup_return_period": "052023",
+                "bill_no": "E123",
+                "supply_type": "Regular",
+                "bill_date": date(2023, 5, 1),
+                "document_value": 234324234,
+                "place_of_supply": "23-Madhya Pradesh",
+                "is_reverse_charge": 0,
+                "itc_availability": "Yes",
+                "diffprcnt": "1",
+                "original_bill_no": None,
+                "original_bill_date": None,
+                "doc_type": "Invoice",
+                "taxable_value": 12200,
+                "igst": 183,
+                "cgst": 0,
+                "sgst": 0,
+                "cess": 0,
+                "is_downloaded_from_2b": 1,
+                "is_supplier_return_filed": 1,
+            },
+            doc,
+        )
+
     def test_gstr2b_cdnr(self):
         doc = self.get_doc(GSTRCategory.CDNR)
         self.assertDocumentEqual(

--- a/india_compliance/patches.txt
+++ b/india_compliance/patches.txt
@@ -89,4 +89,5 @@ india_compliance.patches.v16.update_tds_section_display_name
 execute:import frappe; frappe.db.set_single_value("GST Settings", "nil_exempt_e_invoice_treatment", "Do Not Generate")
 india_compliance.patches.post_install.set_india_compliance_default_tax_category
 india_compliance.patches.post_install.remove_tax_category_gst_state
+india_compliance.patches.v16.remove_gstr_2a_category_preferences
 

--- a/india_compliance/patches/v14/update_default_auto_reconciliation_settings.py
+++ b/india_compliance/patches/v14/update_default_auto_reconciliation_settings.py
@@ -8,7 +8,5 @@ def execute():
             "inward_supply_period": 2,
             "reconcile_on_tuesday": 1,
             "reconcile_on_friday": 1,
-            "reconcile_for_b2b": 1,
-            "reconcile_for_cdnr": 1,
         },
     )

--- a/india_compliance/patches/v16/remove_gstr_2a_category_preferences.py
+++ b/india_compliance/patches/v16/remove_gstr_2a_category_preferences.py
@@ -1,0 +1,32 @@
+import frappe
+
+
+def execute():
+    """GSTR-2A now always downloads all sections.
+
+    Clean up the obsolete per-category preferences:
+    - the `reconcile_for_*` fields in GST Settings (auto reconciliation)
+    - the `purchase_reco_2a_categories` user default (download dialog)
+    """
+    frappe.db.delete(
+        "Singles",
+        {
+            "doctype": "GST Settings",
+            "field": (
+                "in",
+                (
+                    "reconcile_for_b2b",
+                    "reconcile_for_b2ba",
+                    "reconcile_for_cdnr",
+                    "reconcile_for_cdnra",
+                    "reconcile_for_isd",
+                    "reconcile_for_isda",
+                    "reconcile_for_impg",
+                    "reconcile_for_impgsez",
+                ),
+            ),
+        },
+    )
+
+    frappe.db.delete("DefaultValue", {"defkey": "purchase_reco_2a_categories"})
+    frappe.clear_cache()


### PR DESCRIPTION
## Purpose
GSTR-2A now always downloads every section (no per-category selection), and adds the previously-missing ECOM, ECOMA, TDS, and TCS sections so that e-commerce supplies and TDS/TCS credits are captured in GST Inward Supply.

### What changed 

- Added ECOM, ECOMA, TDS, TCS to GSTRCategory / GSTR_2A_ACTIONS and added their parsers in gstr_2a.py (verified against the GSP schema).
- Added the four values to the GST Inward Supply classification options.
- Excluded these categories from reconciliation (inward-supply query) and from amendment-linking (before_save) — they're stored for reference/export but never matched.
- TDS/TCS flat records (no bill no/date) are keyed by return period so a later period can't overwrite an earlier one.
Always download all sections

- Removed the category-selection UI from the download dialog; 2A and 2B now share the same period-based download flow.
- Removed the per-category reconcile_for_* toggles from GST Settings and the auto-reconciliation category filter.
- Removed the set_category_preference endpoint and the stored user preference.
Migration & cleanup

- New patch v16.remove_gstr_2a_category_preferences deletes the obsolete reconcile_for_* Single fields and the purchase_reco_2a_categories user default.
- Dropped the removed defaults from setup and the auto-reconciliation patch.

### Tests

Added parser tests + fixtures for ECOM/ECOMA/TDS/TCS, plus cross-period uniqueness and the amendment-skip guard.
Removed the now-obsolete TestCategoryPreference suite.