### PR TITLE
fix: add company level permission checks

### DIFF
--- a/india_compliance/gst_india/doctype/gst_invoice_management_system/gst_invoice_management_system.py
+++ b/india_compliance/gst_india/doctype/gst_invoice_management_system/gst_invoice_management_system.py
@@ -39,6 +39,7 @@ from india_compliance.gst_india.doctype.purchase_reconciliation_tool.purchase_re
 from india_compliance.gst_india.doctype.purchase_reconciliation_tool.purchase_reconciliation_utils import (
     unlink_documents as _unlink_documents,
 )
+from india_compliance.gst_india.utils import validate_gstin_permission
 from india_compliance.gst_india.utils.exporter import ExcelExporter
 from india_compliance.gst_india.utils.gstin_info import (
     get_latest_3b_filed_period,
@@ -250,6 +251,7 @@ class GSTInvoiceManagementSystem(Document):
 
 
 @frappe.whitelist()
+@validate_gstin_permission
 @otp_handler
 def download_invoices(company_gstin: str):
     frappe.has_permission("GST Invoice Management System", "write", throw=True)
@@ -273,6 +275,7 @@ def download_invoices(company_gstin: str):
 
 
 @frappe.whitelist()
+@validate_gstin_permission
 @otp_handler
 def save_invoices(company_gstin: str):
     frappe.has_permission("GST Invoice Management System", "write", throw=True)
@@ -282,6 +285,7 @@ def save_invoices(company_gstin: str):
 
 
 @frappe.whitelist()
+@validate_gstin_permission
 @otp_handler
 def reset_invoices(company_gstin: str):
     frappe.has_permission("GST Invoice Management System", "write", throw=True)
@@ -291,6 +295,7 @@ def reset_invoices(company_gstin: str):
 
 
 @frappe.whitelist()
+@validate_gstin_permission
 @otp_handler
 def sync_with_gstn_and_reupload(company_gstin: str):
     frappe.has_permission("GST Invoice Management System", "write", throw=True)
@@ -306,6 +311,7 @@ def sync_with_gstn_and_reupload(company_gstin: str):
 
 
 @frappe.whitelist()
+@validate_gstin_permission(doctype="GST Return Log")
 @otp_handler
 def check_action_status(company_gstin: str, action: str):
     frappe.has_permission("GST Return Log", "write", throw=True)
@@ -327,6 +333,7 @@ def download_excel_report(data: str | list, doc: str | dict | frappe._dict):
 
 
 @frappe.whitelist()
+@validate_gstin_permission
 def get_period_options(company: str, company_gstin: str):
     def format_period(period):
         return period[2:] + period[:2]

--- a/india_compliance/gst_india/doctype/gstr_1/gstr_1.py
+++ b/india_compliance/gst_india/doctype/gstr_1/gstr_1.py
@@ -22,6 +22,7 @@ from india_compliance.gst_india.utils import (
     MONTHS,
     get_gst_accounts_by_type,
     get_period,
+    validate_gstin_permission,
 )
 from india_compliance.gst_india.utils.gstin_info import get_gstr_1_return_status
 
@@ -183,6 +184,7 @@ class GSTR1(Document):
 
 
 @frappe.whitelist()
+@validate_gstin_permission(doctype="GST Return Log")
 @otp_handler
 def perform_gstr1_action(
     action: str,
@@ -216,6 +218,7 @@ def perform_gstr1_action(
 
 
 @frappe.whitelist()
+@validate_gstin_permission(doctype="GST Return Log")
 @otp_handler
 def check_action_status(month_or_quarter: str, year: str, company_gstin: str, action: str):
     frappe.has_permission("GST Return Log", "write", throw=True)
@@ -355,6 +358,7 @@ def get_gst_and_round_off_accounts(month_or_quarter: str, year: str, company: st
 
 
 @frappe.whitelist()
+@validate_gstin_permission(doctype="GST Return Log")
 def make_journal_entry(
     company: str,
     company_gstin: str,
@@ -394,6 +398,7 @@ def make_journal_entry(
 
 
 @frappe.whitelist()
+@validate_gstin_permission(doctype="GST Return Log")
 def get_net_gst_liability(
     company: str,
     company_gstin: str,
@@ -463,6 +468,7 @@ def get_gstr_1_from_and_to_date(month_or_quarter: str, year: str, filing_prefere
 
 
 @frappe.whitelist()
+@validate_gstin_permission(doctype="GST Return Log")
 def get_filing_preference_from_log(month_or_quarter: str, year: str, company_gstin: str):
     frappe.has_permission("GSTR-1", throw=True)
 

--- a/india_compliance/gst_india/doctype/gstr_1/gstr_1_export.py
+++ b/india_compliance/gst_india/doctype/gstr_1/gstr_1_export.py
@@ -11,7 +11,11 @@ import frappe
 from frappe import _
 from frappe.utils import getdate
 
-from india_compliance.gst_india.utils import get_data_file_path, get_period
+from india_compliance.gst_india.utils import (
+    get_data_file_path,
+    get_period,
+    validate_gstin_permission,
+)
 from india_compliance.gst_india.utils.exporter import ExcelExporter
 from india_compliance.gst_india.utils.gstr_1 import (
     HSN_BIFURCATION_FROM,
@@ -2196,6 +2200,7 @@ def set_section_preference(sections: str | list[str] | None = None):
 
 
 @frappe.whitelist()
+@validate_gstin_permission(doctype="GST Return Log")
 def download_filed_as_excel(
     company_gstin: str, month_or_quarter: str, year: str, sections: str | list[str] | None = None
 ):
@@ -2206,6 +2211,7 @@ def download_filed_as_excel(
 
 
 @frappe.whitelist()
+@validate_gstin_permission(doctype="GST Return Log")
 def download_books_as_excel(company_gstin: str, month_or_quarter: str, year: str):
     frappe.has_permission("GSTR-1", "export", throw=True)
 
@@ -2214,6 +2220,7 @@ def download_books_as_excel(company_gstin: str, month_or_quarter: str, year: str
 
 
 @frappe.whitelist()
+@validate_gstin_permission(doctype="GST Return Log")
 def download_reconcile_as_excel(company_gstin: str, month_or_quarter: str, year: str):
     frappe.has_permission("GSTR-1", "export", throw=True)
 
@@ -2222,6 +2229,7 @@ def download_reconcile_as_excel(company_gstin: str, month_or_quarter: str, year:
 
 
 @frappe.whitelist()
+@validate_gstin_permission(doctype="GST Return Log")
 def get_gstr_1_json(
     company_gstin: str,
     year: str,

--- a/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.py
+++ b/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.py
@@ -42,6 +42,7 @@ from india_compliance.gst_india.utils import (
     get_party_for_gstin,
     get_timespan_date_range,
     is_api_enabled,
+    validate_gstin_permission,
 )
 from india_compliance.gst_india.utils.exporter import ExcelExporter
 from india_compliance.gst_india.utils.gstin_info import (
@@ -135,6 +136,7 @@ class PurchaseReconciliationTool(Document):
             return save_gstr_2b(self.company_gstin, period, json_data)
 
     @frappe.whitelist()
+    @validate_gstin_permission
     @otp_handler
     def download_gstr(
         self,
@@ -174,6 +176,7 @@ class PurchaseReconciliationTool(Document):
         )
 
     @frappe.whitelist()
+    @validate_gstin_permission
     def get_import_history(
         self,
         company_gstin: str,

--- a/india_compliance/gst_india/utils/__init__.py
+++ b/india_compliance/gst_india/utils/__init__.py
@@ -1,6 +1,7 @@
 import copy
 import datetime
 import functools
+import inspect
 import io
 import tarfile
 
@@ -153,6 +154,73 @@ def get_party_for_gstin(gstin: str, party_type: str = "Supplier"):
     )
     if party:
         return party[0][0]
+
+
+def validate_company_access(company, doctype="GST Inward Supply"):
+    """Throw unless the user may read doctype data for company."""
+    if not company:
+        return
+
+    reference = frappe.new_doc(doctype)
+    reference.company = company
+    if not frappe.has_permission(doctype, "read", doc=reference):
+        frappe.throw(
+            _("You are not permitted to access data for Company {0}.").format(company),
+            frappe.PermissionError,
+        )
+
+
+def validate_company_gstin_access(company_gstin, doctype="GST Inward Supply"):
+    """Throw unless the user may read doctype data for company_gstin's Company."""
+    if not company_gstin or company_gstin == "All":
+        return
+
+    company = get_party_for_gstin(company_gstin, "Company")
+    if not company:
+        frappe.throw(
+            _("GSTIN {0} is not linked to any Company.").format(company_gstin),
+            frappe.PermissionError,
+        )
+
+    validate_company_access(company, doctype)
+
+
+def validate_gstin_permission(fn=None, *, doctype=None):
+    """Whitelist decorator gating a method on its company_gstin / gstin argument.
+    Place below @frappe.whitelist() and above @otp_handler.
+    """
+    if fn is None:
+        return functools.partial(validate_gstin_permission, doctype=doctype)
+
+    signature = inspect.signature(fn)
+    if "company_gstin" in signature.parameters:
+        field = "company_gstin"
+    elif "gstin" in signature.parameters:
+        field = "gstin"
+    else:
+        raise ValueError(
+            f"validate_gstin_permission requires '{fn.__name__}' to declare a "
+            "'company_gstin' or 'gstin' parameter."
+        )
+
+    doctype_from_arg = doctype is None and "doctype" in signature.parameters
+
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        bound = signature.bind_partial(*args, **kwargs)
+        resolved_doctype = (
+            bound.arguments.get("doctype") if doctype_from_arg else doctype
+        ) or "GST Inward Supply"
+
+        company_gstin = bound.arguments.get(field)
+        if company_gstin == "All":
+            validate_company_access(bound.arguments.get("company"), resolved_doctype)
+        else:
+            validate_company_gstin_access(company_gstin, resolved_doctype)
+
+        return fn(*args, **kwargs)
+
+    return wrapper
 
 
 @frappe.whitelist()

--- a/india_compliance/gst_india/utils/__init__.py
+++ b/india_compliance/gst_india/utils/__init__.py
@@ -179,7 +179,7 @@ def validate_company_gstin_access(company_gstin, doctype="GST Inward Supply"):
     if not company:
         frappe.throw(
             _("GSTIN {0} is not linked to any Company.").format(company_gstin),
-            frappe.PermissionError,
+            frappe.ValidationError,
         )
 
     validate_company_access(company, doctype)
@@ -214,7 +214,13 @@ def validate_gstin_permission(fn=None, *, doctype=None):
 
         company_gstin = bound.arguments.get(field)
         if company_gstin == "All":
-            validate_company_access(bound.arguments.get("company"), resolved_doctype)
+            company = bound.arguments.get("company") or getattr(bound.arguments.get("self"), "company", None)
+            if not company:
+                frappe.throw(
+                    _("Company is required to validate access for all GSTINs."),
+                    frappe.PermissionError,
+                )
+            validate_company_access(company, resolved_doctype)
         else:
             validate_company_gstin_access(company_gstin, resolved_doctype)
 

--- a/india_compliance/gst_india/utils/__init__.py
+++ b/india_compliance/gst_india/utils/__init__.py
@@ -203,16 +203,13 @@ def validate_gstin_permission(fn=None, *, doctype=None):
             "'company_gstin' or 'gstin' parameter."
         )
 
-    doctype_from_arg = doctype is None and "doctype" in signature.parameters
+    resolved_doctype = doctype or "GST Inward Supply"
 
     @functools.wraps(fn)
     def wrapper(*args, **kwargs):
         bound = signature.bind_partial(*args, **kwargs)
-        resolved_doctype = (
-            bound.arguments.get("doctype") if doctype_from_arg else doctype
-        ) or "GST Inward Supply"
-
         company_gstin = bound.arguments.get(field)
+
         if company_gstin == "All":
             company = bound.arguments.get("company") or getattr(bound.arguments.get("self"), "company", None)
             if not company:

--- a/india_compliance/gst_india/utils/gstin_info.py
+++ b/india_compliance/gst_india/utils/gstin_info.py
@@ -17,7 +17,12 @@ from india_compliance.gst_india.api_classes.taxpayer_base import (
     otp_handler,
 )
 from india_compliance.gst_india.api_classes.taxpayer_returns import GSTR1API
-from india_compliance.gst_india.utils import parse_datetime, titlecase, validate_gstin
+from india_compliance.gst_india.utils import (
+    parse_datetime,
+    titlecase,
+    validate_gstin,
+    validate_gstin_permission,
+)
 
 GST_CATEGORIES = {
     "Regular": "Registered Regular",
@@ -382,6 +387,7 @@ def get_latest_3b_filed_period(company, company_gstin):
 
 
 @frappe.whitelist()
+@validate_gstin_permission(doctype="GST Return Log")
 @otp_handler
 def get_and_update_filing_preference(gstin: str, period: str):
     frappe.has_permission("GST Return Log", throw=True)

--- a/india_compliance/gst_india/utils/gstr_2/__init__.py
+++ b/india_compliance/gst_india/utils/gstr_2/__init__.py
@@ -449,7 +449,7 @@ def end_transaction_progress(return_period):
 
 
 @frappe.whitelist()
-@validate_gstin_permission
+@validate_gstin_permission(doctype="GST Inward Supply")
 @otp_handler
 def regenerate_gstr_2b(gstin: str, return_period: str, doctype: str):
     frappe.has_permission(doctype, throw=True)
@@ -464,7 +464,7 @@ def regenerate_gstr_2b(gstin: str, return_period: str, doctype: str):
 
 
 @frappe.whitelist()
-@validate_gstin_permission
+@validate_gstin_permission(doctype="GST Inward Supply")
 def check_regenerate_status(gstin: str, reference_id: str, doctype: str):
     frappe.has_permission(doctype, throw=True)
 

--- a/india_compliance/gst_india/utils/gstr_2/__init__.py
+++ b/india_compliance/gst_india/utils/gstr_2/__init__.py
@@ -17,7 +17,7 @@ from india_compliance.gst_india.doctype.gst_return_log.gst_return_log import (
 from india_compliance.gst_india.doctype.gstr_import_log.gstr_import_log import (
     create_import_log,
 )
-from india_compliance.gst_india.utils import get_party_for_gstin
+from india_compliance.gst_india.utils import get_party_for_gstin, validate_gstin_permission
 from india_compliance.gst_india.utils.gstr_2 import gstr_2a, gstr_2b, ims
 from india_compliance.gst_india.utils.gstr_utils import ReturnType
 
@@ -449,6 +449,7 @@ def end_transaction_progress(return_period):
 
 
 @frappe.whitelist()
+@validate_gstin_permission
 @otp_handler
 def regenerate_gstr_2b(gstin: str, return_period: str, doctype: str):
     frappe.has_permission(doctype, throw=True)
@@ -463,6 +464,7 @@ def regenerate_gstr_2b(gstin: str, return_period: str, doctype: str):
 
 
 @frappe.whitelist()
+@validate_gstin_permission
 def check_regenerate_status(gstin: str, reference_id: str, doctype: str):
     frappe.has_permission(doctype, throw=True)
 

--- a/india_compliance/gst_india/utils/gstr_utils.py
+++ b/india_compliance/gst_india/utils/gstr_utils.py
@@ -11,7 +11,7 @@ from india_compliance.gst_india.doctype.gstr_import_log.gstr_import_log import (
     create_import_log,
     toggle_scheduled_jobs,
 )
-from india_compliance.gst_india.utils import create_notification
+from india_compliance.gst_india.utils import create_notification, validate_gstin_permission
 from india_compliance.gst_india.utils.gstr_1.gstr_1_download import (
     save_gstr_1_filed_data,
     save_gstr_1_unfiled_data,
@@ -27,6 +27,7 @@ class ReturnType(Enum):
 
 
 @frappe.whitelist()
+@validate_gstin_permission
 @otp_handler
 def request_otp(company_gstin: str):
     frappe.has_permission("GST Settings", throw=True)
@@ -35,6 +36,7 @@ def request_otp(company_gstin: str):
 
 
 @frappe.whitelist()
+@validate_gstin_permission
 @otp_handler
 def authenticate_otp(company_gstin: str, otp: str):
     frappe.has_permission("GST Settings", throw=True)
@@ -46,6 +48,7 @@ def authenticate_otp(company_gstin: str, otp: str):
 
 
 @frappe.whitelist()
+@validate_gstin_permission(doctype="GST Return Log")
 @otp_handler
 def generate_evc_otp(company_gstin: str, pan: str, request_type: str):
     frappe.has_permission("GSTR-1", "write", throw=True)

--- a/india_compliance/gst_india/utils/itc_claim.py
+++ b/india_compliance/gst_india/utils/itc_claim.py
@@ -21,7 +21,11 @@ from frappe.utils import (
 )
 
 from india_compliance.gst_india.overrides.transaction import validate_mandatory_fields
-from india_compliance.gst_india.utils import get_period, get_periods_between_dates
+from india_compliance.gst_india.utils import (
+    get_period,
+    get_periods_between_dates,
+    validate_gstin_permission,
+)
 
 SUPPORTED_DOCTYPES = frozenset(("Purchase Invoice", "Bill of Entry"))
 SUPPORTED_TABLE_NAMES = frozenset(get_table_name(dt) for dt in SUPPORTED_DOCTYPES)
@@ -114,6 +118,7 @@ def set_itc_claim_period_on_ims_action(
 
 
 @frappe.whitelist()
+@validate_gstin_permission(doctype="GST Return Log")
 def get_itc_period_options(company_gstin: str | None = None, posting_date: str | None = None) -> list[str]:
     if not company_gstin or not posting_date:
         return []
@@ -142,6 +147,7 @@ def get_itc_period_options(company_gstin: str | None = None, posting_date: str |
 
 
 @frappe.whitelist()
+@validate_gstin_permission(doctype="GST Return Log")
 def update_gstr3b_filing_status(
     company_gstin: str, month_or_quarter: str, year: int | str, status: str
 ) -> None:

--- a/india_compliance/gst_india/utils/test_gstin_permission.py
+++ b/india_compliance/gst_india/utils/test_gstin_permission.py
@@ -1,0 +1,111 @@
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from india_compliance.gst_india.utils import (
+    validate_company_gstin_access,
+    validate_gstin_permission,
+)
+
+OWN_GSTIN = "24AAQCA8719H1ZC"  # _Test Indian Registered Company (user is permitted)
+OTHER_GSTIN = "29AAQCA8719H1Z1"  # another company (user is not permitted)
+TEST_USER = "gstin-perm-test@example.com"
+
+
+class TestGstinPermission(IntegrationTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.other_company = "_Test IC Perm Company B"
+        if not frappe.db.exists("Company", cls.other_company):
+            frappe.get_doc(
+                {
+                    "doctype": "Company",
+                    "company_name": cls.other_company,
+                    "abbr": "TICPCB",
+                    "default_currency": "INR",
+                    "country": "India",
+                }
+            ).insert(ignore_permissions=True, ignore_if_duplicate=True)
+
+        frappe.db.set_value("Company", "_Test Indian Registered Company", "gstin", OWN_GSTIN)
+        frappe.db.set_value("Company", cls.other_company, "gstin", OTHER_GSTIN)
+
+        if not frappe.db.exists("User", TEST_USER):
+            frappe.get_doc(
+                {
+                    "doctype": "User",
+                    "email": TEST_USER,
+                    "first_name": "Perm",
+                    "roles": [{"role": "Accounts Manager"}, {"role": "Accounts User"}],
+                }
+            ).insert(ignore_permissions=True)
+
+    def tearDown(self):
+        frappe.db.delete("User Permission", {"user": TEST_USER})
+        frappe.clear_cache(user=TEST_USER)
+
+    def restrict_user_to_own_company(self, applicable_for=None):
+        permission = {
+            "doctype": "User Permission",
+            "user": TEST_USER,
+            "allow": "Company",
+            "for_value": "_Test Indian Registered Company",
+        }
+        if applicable_for:
+            permission["applicable_for"] = applicable_for
+        frappe.get_doc(permission).insert(ignore_permissions=True)
+        frappe.clear_cache(user=TEST_USER)
+
+    def test_restricted_user_scoped_to_own_company(self):
+        self.restrict_user_to_own_company()
+        with self.set_user(TEST_USER):
+            validate_company_gstin_access(OWN_GSTIN)
+            with self.assertRaises(frappe.PermissionError):
+                validate_company_gstin_access(OTHER_GSTIN)
+
+    def test_applicable_for_scopes_check_to_its_doctype(self):
+        self.restrict_user_to_own_company(applicable_for="GST Inward Supply")
+        with self.set_user(TEST_USER):
+            with self.assertRaises(frappe.PermissionError):
+                validate_company_gstin_access(OTHER_GSTIN, "GST Inward Supply")
+            validate_company_gstin_access(OTHER_GSTIN, "GST Return Log")
+
+    def test_decorator_gates_the_method(self):
+        @validate_gstin_permission
+        def action(company_gstin):
+            return "ran"
+
+        self.restrict_user_to_own_company()
+        with self.set_user(TEST_USER):
+            self.assertEqual(action(company_gstin=OWN_GSTIN), "ran")
+            with self.assertRaises(frappe.PermissionError):
+                action(company_gstin=OTHER_GSTIN)
+
+    def test_decorator_honours_doctype_override(self):
+        # Restriction scoped to GST Inward Supply must not gate a GST Return Log check.
+        @validate_gstin_permission(doctype="GST Return Log")
+        def action(company_gstin):
+            return "ran"
+
+        self.restrict_user_to_own_company(applicable_for="GST Inward Supply")
+        with self.set_user(TEST_USER):
+            self.assertEqual(action(company_gstin=OTHER_GSTIN), "ran")
+
+    def test_all_sentinel_validates_company_argument(self):
+        @validate_gstin_permission
+        def action(company_gstin, company):
+            return "ran"
+
+        self.restrict_user_to_own_company()
+        with self.set_user(TEST_USER):
+            self.assertEqual(action(company_gstin="All", company="_Test Indian Registered Company"), "ran")
+            with self.assertRaises(frappe.PermissionError):
+                action(company_gstin="All", company=self.other_company)
+
+    def test_decorator_requires_gstin_parameter(self):
+        with self.assertRaises(ValueError):
+
+            @validate_gstin_permission
+            def action(period):
+                return "ran"

--- a/india_compliance/gst_india/utils/test_gstin_permission.py
+++ b/india_compliance/gst_india/utils/test_gstin_permission.py
@@ -103,6 +103,31 @@ class TestGstinPermission(IntegrationTestCase):
             with self.assertRaises(frappe.PermissionError):
                 action(company_gstin="All", company=self.other_company)
 
+    def test_all_sentinel_resolves_company_from_bound_method(self):
+        class Tool:
+            def __init__(self, company):
+                self.company = company
+
+            @validate_gstin_permission
+            def action(self, company_gstin):
+                return "ran"
+
+        self.restrict_user_to_own_company()
+        with self.set_user(TEST_USER):
+            self.assertEqual(Tool("_Test Indian Registered Company").action(company_gstin="All"), "ran")
+            with self.assertRaises(frappe.PermissionError):
+                Tool(self.other_company).action(company_gstin="All")
+
+    def test_all_sentinel_fails_closed_without_company(self):
+        @validate_gstin_permission
+        def action(company_gstin):
+            return "ran"
+
+        self.restrict_user_to_own_company()
+        with self.set_user(TEST_USER):
+            with self.assertRaises(frappe.PermissionError):
+                action(company_gstin="All")
+
     def test_decorator_requires_gstin_parameter(self):
         with self.assertRaises(ValueError):
 


### PR DESCRIPTION
## Description
Whitelisted endpoints that take a `company_gstin/gstin` only checked doctype-level permission, so any user with role access could pull or export another company's GST data by passing its GSTIN.

Adds `@validate_gstin_permission` decorator that maps the GSTIN to its Company and verifies the user has read access to that company's data (via User Permissions) before the method runs. Applied across GSTR-1, IMS, Purchase Reconciliation, GSTR-2, ITC and OTP endpoints.

### Notes
- Decorator sits below `@frappe.whitelist()` and above `@otp_handler` — permission checked before any OTP is triggered.
- Doctype scoped by data domain: GST Return Log for outward/GSTR-1, GST Inward Supply for inward/2A/2B/IMS.
- "All" GSTIN selector falls back to validating the company argument.
- Tests in `test_gstin_permission.py` cover own-vs-other company, doctype override, the "All" branch, and missing-param guard.