### PR TITLE
fix: show Supplier GSTIN in purchase reconciliation detail view

### DIFF
--- a/india_compliance/gst_india/doctype/purchase_reconciliation_tool/invoice_detail_comparison.html
+++ b/india_compliance/gst_india/doctype/purchase_reconciliation_tool/invoice_detail_comparison.html
@@ -14,6 +14,15 @@
 				<td data-label="company_gstin">{{ purchase.company_gstin || '-' }}</td>
 			</tr>
 			<tr>
+				<th>Supplier GSTIN</th>
+				<td data-label="supplier_gstin">
+					{{ inward_supply.supplier_gstin || '-' }}
+				</td>
+				<td data-label="supplier_gstin">
+					{{ purchase.supplier_gstin || '-' }}
+				</td>
+			</tr>
+			<tr>
 				<th>Document Links</td>
 					{% if inward_supply.name %}
 				<td data-label="name">{{ frappe.utils.get_form_link("GST Inward Supply",

--- a/india_compliance/public/js/reconciliation_components/tabs.js
+++ b/india_compliance/public/js/reconciliation_components/tabs.js
@@ -463,12 +463,7 @@ reconciliation.detail_view_dialog = class DetailViewDialog {
     _set_value_color(wrapper) {
         if (!this.row.purchase_invoice_name || !this.row.inward_supply_name) return;
 
-        [
-            "supplier_gstin",
-            "company_gstin",
-            "place_of_supply",
-            "is_reverse_charge",
-        ].forEach((field) => {
+        ["supplier_gstin", "company_gstin", "place_of_supply", "is_reverse_charge"].forEach((field) => {
             if (this.data._purchase_invoice[field] == this.data._inward_supply[field]) return;
 
             wrapper.find(`[data-label='${field}'], [data-label='${field}']`).addClass("not-matched");

--- a/india_compliance/public/js/reconciliation_components/tabs.js
+++ b/india_compliance/public/js/reconciliation_components/tabs.js
@@ -463,7 +463,12 @@ reconciliation.detail_view_dialog = class DetailViewDialog {
     _set_value_color(wrapper) {
         if (!this.row.purchase_invoice_name || !this.row.inward_supply_name) return;
 
-        ["place_of_supply", "is_reverse_charge"].forEach((field) => {
+        [
+            "supplier_gstin",
+            "company_gstin",
+            "place_of_supply",
+            "is_reverse_charge",
+        ].forEach((field) => {
             if (this.data._purchase_invoice[field] == this.data._inward_supply[field]) return;
 
             wrapper.find(`[data-label='${field}'], [data-label='${field}']`).addClass("not-matched");


### PR DESCRIPTION
## Summary
- Add Supplier GSTIN row to the purchase reconciliation detail comparison table so users can compare 2A/2B vs Purchase Invoice values when Differences shows `SUPPLIER_GSTIN`
- Highlight mismatched `supplier_gstin` and `company_gstin` cells in the detail view (same as place of supply / reverse charge)

Fixes #4581

## Test plan
- [ ] Create/identify a Purchase Invoice whose Supplier GSTIN differs from the matching GST Inward Supply
- [ ] Open Purchase Reconciliation Tool and run reconciliation
- [ ] Confirm the Differences column shows `SUPPLIER_GSTIN`
- [ ] Open the row detail (eye) view and verify both Supplier GSTIN values are shown and highlighted when they differ