### PR TITLE
fix: manual commits after each company patch to avoid `TooManyWritesError`

### DIFF
--- a/india_compliance/patches/post_install/update_company_fixtures.py
+++ b/india_compliance/patches/post_install/update_company_fixtures.py
@@ -27,6 +27,8 @@ def execute():
         make_default_customs_accounts(company)
         make_default_gst_expense_accounts(company)
 
+        frappe.db.commit()  # nosemgrep — reset transaction_writes between companies
+
 
 def update_root_for_rcm(company):
     # Root type for RCM had been updated to "Liability".

--- a/india_compliance/patches/v14/update_tax_withholding_categories.py
+++ b/india_compliance/patches/v14/update_tax_withholding_categories.py
@@ -10,3 +10,4 @@ def execute():
 
     for company in company_list:
         create_or_update_tax_withholding_category(company)
+        frappe.db.commit()  # nosemgrep — for multiple companies, commit after each to avoid long transactions


### PR DESCRIPTION
Issue: User has 55 companies in a single site, causing TooManyWritesError on updating patch.
```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 114, in <module>
    main()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 20, in main
    click.Group(commands=commands)(prog_name="bench")
  File "/home/frappe/frappe-bench/env/lib/python3.11/site-packages/click/core.py", line 1442, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/frappe/frappe-bench/env/lib/python3.11/site-packages/click/core.py", line 1363, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/home/frappe/frappe-bench/env/lib/python3.11/site-packages/click/core.py", line 1830, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/frappe/frappe-bench/env/lib/python3.11/site-packages/click/core.py", line 1830, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/frappe/frappe-bench/env/lib/python3.11/site-packages/click/core.py", line 1226, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/frappe/frappe-bench/env/lib/python3.11/site-packages/click/core.py", line 794, in invoke
    return callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/frappe/frappe-bench/env/lib/python3.11/site-packages/click/decorators.py", line 34, in new_func
    return f(get_current_context(), *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/frappe/frappe-bench/apps/frappe/frappe/commands/__init__.py", line 29, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/frappe/frappe-bench/apps/frappe/frappe/commands/site.py", line 694, in migrate
    ).run(site=site)
      ^^^^^^^^^^^^^^
  File "/home/frappe/frappe-bench/apps/frappe/frappe/migrate.py", line 193, in run
    self.run_schema_updates()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/migrate.py", line 54, in wrapper
    raise e
  File "/home/frappe/frappe-bench/apps/frappe/frappe/migrate.py", line 46, in wrapper
    ret = method(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/frappe/frappe-bench/apps/frappe/frappe/migrate.py", line 124, in run_schema_updates
    frappe.modules.patch_handler.run_all(
  File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 76, in run_all
    run_patch(patch)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 62, in run_patch
    if not run_single(patchmodule=patch):
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 152, in run_single
    return execute_patch(patchmodule, method, methodargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 188, in execute_patch
    _patch()
  File "/home/frappe/frappe-bench/apps/india_compliance/india_compliance/patches/v14/update_tax_withholding_categories.py", line 12, in execute
    create_or_update_tax_withholding_category(company)
  File "/home/frappe/frappe-bench/apps/india_compliance/india_compliance/income_tax_india/overrides/company.py", line 56, in create_or_update_tax_withholding_category
    update_existing_tax_withholding_category(category_doc, category_name, company)
  File "/home/frappe/frappe-bench/apps/india_compliance/india_compliance/income_tax_india/overrides/company.py", line 91, in update_existing_tax_withholding_category
    doc.save()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 378, in save
    return self._save(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 430, in _save
    self.update_children()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 469, in update_children
    self.update_child_table(df.fieldname, df)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 501, in update_child_table
    d.db_update()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/base_document.py", line 635, in db_update
    frappe.db.sql(
  File "/home/frappe/frappe-bench/apps/frappe/frappe/database/database.py", line 210, in sql
    self.check_transaction_status(query)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/database/database.py", line 434, in check_transaction_status
    raise frappe.TooManyWritesError(msg)
frappe.exceptions.TooManyWritesError: <br><br>Too many changes to database in single action.<br>The changes have been reverted.<br>
```