### PR TITLE
refactor: add --skip-assets option to ci for test

### DIFF
--- a/.github/helper/install.sh
+++ b/.github/helper/install.sh
@@ -77,7 +77,7 @@ ERPNEXT_REMOTE=${ERPNEXT_REMOTE:-https://github.com/frappe/erpnext.git}
 ERPNEXT_BRANCH=${ERPNEXT_BRANCH:-$BRANCH_TO_CLONE}
 
 bench get-app "$ERPNEXT_REMOTE" --branch "$ERPNEXT_BRANCH" --resolve-deps
-bench get-app india_compliance "${GITHUB_WORKSPACE}"
+bench get-app india_compliance "${GITHUB_WORKSPACE}" --skip-assets
 bench setup requirements --dev
 
 wait $wkpid


### PR DESCRIPTION
- Related PR: https://github.com/resilient-tech/india-compliance/pull/4603

<img width="512" height="176" alt="image" src="https://github.com/user-attachments/assets/c8b596a1-2ea9-448a-8173-cca5aa63997e" />

---

- CI installs `india_compliance` from a local path (`bench get-app <local-folder>`), which triggers bench's cached-app path and **skips `yarn install`**.
- `vue-router`/`vuex` were recently dropped from frappe's own `node_modules` and are now declared in our `package.json`, so they were never installed in CI.
- This caused the esbuild step for the `india_compliance_account` Vue app to fail during CI setup.
- Fix: add `--skip-assets` to the `bench get-app` step — server (Python) tests don't need the JS bundle.
- Regular users are unaffected — installing from a Git URL runs `yarn install` normally.
