### PR TITLE
Fix e-Invoice print log fallback

### DIFF
--- a/india_compliance/gst_india/print_format/e_invoice/e_invoice.html
+++ b/india_compliance/gst_india/print_format/e_invoice/e_invoice.html
@@ -4,22 +4,24 @@
 
 {%- from "templates/print_formats/standard_macros.html" import add_header, render_field, print_value -%}
 
-{% if not doc.irn %}
-
-<div class="text-center no-preview-available">
-	Please generate an e-Invoice to preview it.
-</div>
-
-{% else %}
-
 {% set e_invoice_log = frappe.db.get_value(
 	"e-Invoice Log", doc.irn, ("invoice_data", "signed_qr_code"), as_dict=True
-) %}
+) if doc.irn else None %}
+
+{% if not e_invoice_log %}
+	{% set e_invoice_log = frappe.db.get_value(
+		"e-Invoice Log",
+		{"sales_invoice": doc.name, "is_cancelled": 0},
+		("invoice_data", "signed_qr_code"),
+		order_by="modified desc",
+		as_dict=True,
+	) %}
+{% endif %}
 
 {% if not e_invoice_log %}
 
 <div class="text-center no-preview-available">
-	The e-Invoice Log linked to this Sales Invoice could not be found.
+	Please generate an e-Invoice to preview it.
 </div>
 
 {% else %}
@@ -204,6 +206,5 @@
 </div>
 </div>
 
-{% endif %}
 {% endif %}
 {% endif %}


### PR DESCRIPTION
## Summary
- update the e-Invoice print format to resolve the e-Invoice Log by doc.irn when available
- fall back to the latest active e-Invoice Log linked by sales_invoice when doc.irn is blank or stale
- keep the existing no-preview message when no active e-Invoice Log is available

## Root Cause
Sales Invoice print preview could show no IRN details when the print format relied only on doc.irn, even though an active e-Invoice Log existed for the Sales Invoice.

## Validation
- Cherry-picked the code-only fix from the closed stable-branch PR onto upstream/develop.
- Ran git diff --check upstream/develop..HEAD.