### PR TITLE
fix: implement company deletion logic to clear related GST settings and single DocTypes fields

### DIFF
--- a/india_compliance/gst_india/overrides/company.py
+++ b/india_compliance/gst_india/overrides/company.py
@@ -7,15 +7,13 @@ from frappe.utils import flt
 
 from india_compliance.gst_india.utils import get_data_file_path
 
-# Single DocTypes where the company is stored as a filter in `tabSingles`
-SINGLES_WITH_COMPANY = (
+SINGLE_DOCTYPES_WITH_COMPANY_FIELD = (
     "GST Invoice Management System",
     "GSTR-1",
     "Purchase Reconciliation Tool",
 )
 
-# Child tables of GST Settings with a company
-GST_SETTINGS_COMPANY_TABLES = (
+GST_SETTINGS_CHILD_TABLES_WITH_COMPANY = (
     "gst_accounts",
     "credentials",
     "e_invoice_applicable_companies",
@@ -26,11 +24,11 @@ def on_trash(doc, method=None):
     if doc.country != "India":
         return
 
-    reset_company_in_singles(doc.name)
-    delete_gst_settings_for_company(doc.name)
+    clear_company_from_single_doctypes(doc.name)
+    remove_gst_settings_for_company(doc.name)
 
 
-def reset_company_in_singles(company):
+def clear_company_from_single_doctypes(company):
     """Clear the deleted company from Single DocTypes, since these aren't cleared on delete."""
     singles = frappe.qb.DocType("Singles")
 
@@ -38,7 +36,7 @@ def reset_company_in_singles(company):
         frappe.qb.from_(singles)
         .select(singles["doctype"])
         .where(
-            singles["doctype"].isin(SINGLES_WITH_COMPANY)
+            singles["doctype"].isin(SINGLE_DOCTYPES_WITH_COMPANY_FIELD)
             & (singles.field == "company")
             & (singles.value == company)
         )
@@ -57,10 +55,10 @@ def reset_company_in_singles(company):
         frappe.clear_document_cache(doctype, doctype)
 
 
-def delete_gst_settings_for_company(company):
+def remove_gst_settings_for_company(company):
     gst_settings = frappe.get_doc("GST Settings")
 
-    for fieldname in GST_SETTINGS_COMPANY_TABLES:
+    for fieldname in GST_SETTINGS_CHILD_TABLES_WITH_COMPANY:
         gst_settings.set(
             fieldname, [row for row in gst_settings.get(fieldname, []) if row.company != company]
         )

--- a/india_compliance/gst_india/overrides/company.py
+++ b/india_compliance/gst_india/overrides/company.py
@@ -7,16 +7,63 @@ from frappe.utils import flt
 
 from india_compliance.gst_india.utils import get_data_file_path
 
+# Single DocTypes where the company is stored as a filter in `tabSingles`
+SINGLES_WITH_COMPANY = (
+    "GST Invoice Management System",
+    "GSTR-1",
+    "Purchase Reconciliation Tool",
+)
 
-def delete_gst_settings_for_company(doc, method=None):
+# Child tables of GST Settings with a company
+GST_SETTINGS_COMPANY_TABLES = (
+    "gst_accounts",
+    "credentials",
+    "e_invoice_applicable_companies",
+)
+
+
+def on_trash(doc, method=None):
     if doc.country != "India":
         return
 
+    reset_company_in_singles(doc.name)
+    delete_gst_settings_for_company(doc.name)
+
+
+def reset_company_in_singles(company):
+    """Clear the deleted company from Single DocTypes, since these aren't cleared on delete."""
+    singles = frappe.qb.DocType("Singles")
+
+    doctypes = (
+        frappe.qb.from_(singles)
+        .select(singles["doctype"])
+        .where(
+            singles["doctype"].isin(SINGLES_WITH_COMPANY)
+            & (singles.field == "company")
+            & (singles.value == company)
+        )
+    ).run(pluck=True)
+
+    if not doctypes:
+        return
+
+    (
+        frappe.qb.update(singles)
+        .set(singles.value, "")
+        .where(singles["doctype"].isin(doctypes) & singles.field.isin(("company", "company_gstin")))
+    ).run()
+
+    for doctype in doctypes:
+        frappe.clear_document_cache(doctype, doctype)
+
+
+def delete_gst_settings_for_company(company):
     gst_settings = frappe.get_doc("GST Settings")
 
-    gst_settings.gst_accounts = [
-        row for row in gst_settings.get("gst_accounts", []) if row.company != doc.name
-    ]
+    for fieldname in GST_SETTINGS_COMPANY_TABLES:
+        gst_settings.set(
+            fieldname, [row for row in gst_settings.get(fieldname, []) if row.company != company]
+        )
 
     gst_settings.flags.ignore_mandatory = True
     gst_settings.save()

--- a/india_compliance/gst_india/overrides/test_company.py
+++ b/india_compliance/gst_india/overrides/test_company.py
@@ -59,27 +59,16 @@ class TestCompanyFixtures(IntegrationTestCase):
 
 class TestCompanyOnTrash(IntegrationTestCase):
     def test_company_is_cleared_from_singles(self):
-        company = frappe.get_doc(
-            {
-                "doctype": "Company",
-                "abbr": "_TTC",
-                "company_name": "_Test Trash Company",
-                "country": "India",
-                "default_currency": "INR",
-                "chart_of_accounts": "Standard",
-                "gstin": "24AAQCA8719H1ZC",
-                "gst_category": "Registered Regular",
-            }
-        ).insert()
+        company = self.create_company("_Test Trash Company", "_TTC")
+        other_company = frappe.get_cached_doc("Company", "_Test Indian Registered Company")
 
-        # company is set as a filter on each tool
+        gst_settings = self.setup_gst_settings(company, other_company)
         for doctype in SINGLE_DOCTYPES_WITH_COMPANY_FIELD:
             frappe.db.set_single_value(doctype, {"company": company.name, "company_gstin": company.gstin})
 
-        gst_settings = self.setup_gst_settings(company)
-
         for fieldname in GST_SETTINGS_CHILD_TABLES_WITH_COMPANY:
             self.assertTrue(self.get_gst_settings_rows(gst_settings, fieldname, company.name))
+            self.assertTrue(self.get_gst_settings_rows(gst_settings, fieldname, other_company.name))
 
         company.delete()
 
@@ -91,24 +80,45 @@ class TestCompanyOnTrash(IntegrationTestCase):
 
         for fieldname in GST_SETTINGS_CHILD_TABLES_WITH_COMPANY:
             self.assertFalse(self.get_gst_settings_rows(gst_settings, fieldname, company.name))
+            self.assertTrue(self.get_gst_settings_rows(gst_settings, fieldname, other_company.name))
 
-    def setup_gst_settings(self, company):
+    def create_company(self, company_name, abbr):
+        return frappe.get_doc(
+            {
+                "doctype": "Company",
+                "abbr": abbr,
+                "company_name": company_name,
+                "country": "India",
+                "default_currency": "INR",
+                "chart_of_accounts": "Standard",
+                "gstin": "24AAQCA8719H1ZC",
+                "gst_category": "Registered Regular",
+            }
+        ).insert()
+
+    def setup_gst_settings(self, *companies):
         """gst_accounts are added by company fixtures, add the remaining tables"""
         gst_settings = frappe.get_doc("GST Settings")
-        gst_settings.append(
-            "credentials",
-            {
-                "company": company.name,
-                "service": "e-Waybill / e-Invoice",
-                "gstin": company.gstin,
-                "username": "test_username",
-                "password": "test_password",
-            },
-        )
-        gst_settings.append(
-            "e_invoice_applicable_companies",
-            {"company": company.name, "applicable_from": "2021-04-01"},
-        )
+
+        for company in companies:
+            for service in ("e-Waybill / e-Invoice", "Returns"):
+                gst_settings.append(
+                    "credentials",
+                    {
+                        "company": company.name,
+                        "service": service,
+                        "gstin": company.gstin,
+                        "username": "test_username",
+                        "password": "test_password",
+                    },
+                )
+
+            if not self.get_gst_settings_rows(gst_settings, "e_invoice_applicable_companies", company.name):
+                gst_settings.append(
+                    "e_invoice_applicable_companies",
+                    {"company": company.name, "applicable_from": "2021-04-01"},
+                )
+
         gst_settings.save()
 
         return gst_settings

--- a/india_compliance/gst_india/overrides/test_company.py
+++ b/india_compliance/gst_india/overrides/test_company.py
@@ -2,8 +2,8 @@ import frappe
 from frappe.tests import IntegrationTestCase
 
 from india_compliance.gst_india.overrides.company import (
-    GST_SETTINGS_COMPANY_TABLES,
-    SINGLES_WITH_COMPANY,
+    GST_SETTINGS_CHILD_TABLES_WITH_COMPANY,
+    SINGLE_DOCTYPES_WITH_COMPANY_FIELD,
     get_tax_defaults,
 )
 
@@ -73,23 +73,23 @@ class TestCompanyOnTrash(IntegrationTestCase):
         ).insert()
 
         # company is set as a filter on each tool
-        for doctype in SINGLES_WITH_COMPANY:
+        for doctype in SINGLE_DOCTYPES_WITH_COMPANY_FIELD:
             frappe.db.set_single_value(doctype, {"company": company.name, "company_gstin": company.gstin})
 
         gst_settings = self.setup_gst_settings(company)
 
-        for fieldname in GST_SETTINGS_COMPANY_TABLES:
+        for fieldname in GST_SETTINGS_CHILD_TABLES_WITH_COMPANY:
             self.assertTrue(self.get_gst_settings_rows(gst_settings, fieldname, company.name))
 
         company.delete()
 
-        for doctype in SINGLES_WITH_COMPANY:
+        for doctype in SINGLE_DOCTYPES_WITH_COMPANY_FIELD:
             self.assertFalse(frappe.db.get_single_value(doctype, "company"))
             self.assertFalse(frappe.db.get_single_value(doctype, "company_gstin"))
 
         gst_settings = frappe.get_doc("GST Settings")
 
-        for fieldname in GST_SETTINGS_COMPANY_TABLES:
+        for fieldname in GST_SETTINGS_CHILD_TABLES_WITH_COMPANY:
             self.assertFalse(self.get_gst_settings_rows(gst_settings, fieldname, company.name))
 
     def setup_gst_settings(self, company):

--- a/india_compliance/gst_india/overrides/test_company.py
+++ b/india_compliance/gst_india/overrides/test_company.py
@@ -1,7 +1,11 @@
 import frappe
 from frappe.tests import IntegrationTestCase
 
-from india_compliance.gst_india.overrides.company import get_tax_defaults
+from india_compliance.gst_india.overrides.company import (
+    GST_SETTINGS_COMPANY_TABLES,
+    SINGLES_WITH_COMPANY,
+    get_tax_defaults,
+)
 
 
 class TestCompanyFixtures(IntegrationTestCase):
@@ -51,3 +55,63 @@ class TestCompanyFixtures(IntegrationTestCase):
                         gst_rate if "IGST" in row["account_head"]["account_name"] else gst_rate / 2
                     )
                     self.assertEqual(row["account_head"]["tax_rate"], expected_rate)
+
+
+class TestCompanyOnTrash(IntegrationTestCase):
+    def test_company_is_cleared_from_singles(self):
+        company = frappe.get_doc(
+            {
+                "doctype": "Company",
+                "abbr": "_TTC",
+                "company_name": "_Test Trash Company",
+                "country": "India",
+                "default_currency": "INR",
+                "chart_of_accounts": "Standard",
+                "gstin": "24AAQCA8719H1ZC",
+                "gst_category": "Registered Regular",
+            }
+        ).insert()
+
+        # company is set as a filter on each tool
+        for doctype in SINGLES_WITH_COMPANY:
+            frappe.db.set_single_value(doctype, {"company": company.name, "company_gstin": company.gstin})
+
+        gst_settings = self.setup_gst_settings(company)
+
+        for fieldname in GST_SETTINGS_COMPANY_TABLES:
+            self.assertTrue(self.get_gst_settings_rows(gst_settings, fieldname, company.name))
+
+        company.delete()
+
+        for doctype in SINGLES_WITH_COMPANY:
+            self.assertFalse(frappe.db.get_single_value(doctype, "company"))
+            self.assertFalse(frappe.db.get_single_value(doctype, "company_gstin"))
+
+        gst_settings = frappe.get_doc("GST Settings")
+
+        for fieldname in GST_SETTINGS_COMPANY_TABLES:
+            self.assertFalse(self.get_gst_settings_rows(gst_settings, fieldname, company.name))
+
+    def setup_gst_settings(self, company):
+        """gst_accounts are added by company fixtures, add the remaining tables"""
+        gst_settings = frappe.get_doc("GST Settings")
+        gst_settings.append(
+            "credentials",
+            {
+                "company": company.name,
+                "service": "e-Waybill / e-Invoice",
+                "gstin": company.gstin,
+                "username": "test_username",
+                "password": "test_password",
+            },
+        )
+        gst_settings.append(
+            "e_invoice_applicable_companies",
+            {"company": company.name, "applicable_from": "2021-04-01"},
+        )
+        gst_settings.save()
+
+        return gst_settings
+
+    def get_gst_settings_rows(self, gst_settings, fieldname, company):
+        return [row for row in gst_settings.get(fieldname) if row.company == company]

--- a/india_compliance/hooks.py
+++ b/india_compliance/hooks.py
@@ -141,7 +141,7 @@ doc_events = {
         "on_update": ["india_compliance.gst_india.overrides.address.update_party_gstin_and_gst_category"],
     },
     "Company": {
-        "on_trash": "india_compliance.gst_india.overrides.company.delete_gst_settings_for_company",
+        "on_trash": "india_compliance.gst_india.overrides.company.on_trash",
         "on_update": [
             "india_compliance.income_tax_india.overrides.company.make_company_fixtures",
             "india_compliance.gst_india.overrides.company.make_company_fixtures",


### PR DESCRIPTION
Issue: Company deletion was restricted because a few doctype has company name set.
