### PR TITLE
refactor: de-deuplicate shared excel engine

### DIFF
--- a/india_compliance/gst_india/doctype/gstr_1/gstr_1_export.py
+++ b/india_compliance/gst_india/doctype/gstr_1/gstr_1_export.py
@@ -4,7 +4,6 @@ Export GSTR-1 data to excel or json
 
 from collections import defaultdict
 from datetime import datetime
-from enum import Enum
 from typing import ClassVar
 
 import frappe
@@ -16,7 +15,14 @@ from india_compliance.gst_india.utils import (
     get_period,
     validate_gstin_permission,
 )
-from india_compliance.gst_india.utils.exporter import ExcelExporter
+from india_compliance.gst_india.utils.exporter import (
+    AMOUNT_FORMAT,
+    COLOR_PALLATE,
+    DATE_FORMAT,
+    PERCENT_FORMAT,
+    ExcelExporter,
+    ExcelWidth,
+)
 from india_compliance.gst_india.utils.gstr_1 import (
     HSN_BIFURCATION_FROM,
     JSON_CATEGORY_EXCEL_CATEGORY_MAPPING,
@@ -36,15 +42,6 @@ from india_compliance.gst_india.utils.gstr_1.gstr_1_json_map import (
 
 # Used for storing user preferences for GSTR-1 download sections.
 GSTR1_SECTIONS_DEFAULT_KEY = "gstr1_download_sections"
-
-
-class ExcelWidth(Enum):
-    XS = 10
-    SM = 15
-    MD = 20  # Default
-    LG = 25
-    XL = 30
-    XXL = 35
 
 
 CATEGORIES_WITH_ITEMS = {
@@ -147,9 +144,9 @@ class GovExcel(DataProcessor):
     Returns Offline Tool download link - https://www.gst.gov.in/download/returns
     """
 
-    AMOUNT_FORMAT = "#,##0.00"
-    DATE_FORMAT = "dd-mmm-yy"
-    PERCENT_FORMAT = "0.00"
+    AMOUNT_FORMAT = AMOUNT_FORMAT
+    DATE_FORMAT = DATE_FORMAT
+    PERCENT_FORMAT = PERCENT_FORMAT
 
     FIELD_TRANSFORMATIONS: ClassVar[dict] = {
         inv_f.DIFF_PERCENTAGE: lambda value: value * 100 if value != 0 else None,
@@ -1285,21 +1282,10 @@ class BooksExcel(DataProcessor):
 
 
 class ReconcileExcel:
-    AMOUNT_FORMAT = "#,##0.00"
-    DATE_FORMAT = "dd-mmm-yy"
+    AMOUNT_FORMAT = AMOUNT_FORMAT
+    DATE_FORMAT = DATE_FORMAT
 
-    COLOR_PALLATE = frappe._dict(
-        {
-            "dark_gray": "d9d9d9",
-            "light_gray": "f2f2f2",
-            "dark_pink": "e6b9b8",
-            "light_pink": "f2dcdb",
-            "sky_blue": "c6d9f1",
-            "light_blue": "dce6f2",
-            "green": "d7e4bd",
-            "light_green": "ebf1de",
-        }
-    )
+    COLOR_PALLATE = COLOR_PALLATE
 
     DEFAULT_HEADER_FORMAT: ClassVar[dict] = {"bg_color": COLOR_PALLATE.dark_gray}
     DEFAULT_DATA_FORMAT: ClassVar[dict] = {"bg_color": COLOR_PALLATE.light_gray}

--- a/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.py
+++ b/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.py
@@ -44,7 +44,7 @@ from india_compliance.gst_india.utils import (
     is_api_enabled,
     validate_gstin_permission,
 )
-from india_compliance.gst_india.utils.exporter import ExcelExporter
+from india_compliance.gst_india.utils.exporter import COLOR_PALLATE, ExcelExporter
 from india_compliance.gst_india.utils.gstin_info import (
     get_fy,
     get_latest_3b_filed_period,
@@ -700,18 +700,7 @@ def auto_reconcile():
 
 
 class BuildExcel:
-    COLOR_PALLATE = frappe._dict(
-        {
-            "dark_gray": "d9d9d9",
-            "light_gray": "f2f2f2",
-            "dark_pink": "e6b9b8",
-            "light_pink": "f2dcdb",
-            "sky_blue": "c6d9f1",
-            "light_blue": "dce6f2",
-            "green": "d7e4bd",
-            "light_green": "ebf1de",
-        }
-    )
+    COLOR_PALLATE = COLOR_PALLATE
 
     @parse_params
     def __init__(self, doc, data, is_supplier_specific=False, email=False):

--- a/india_compliance/gst_india/utils/exporter.py
+++ b/india_compliance/gst_india/utils/exporter.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from io import BytesIO
 
 import frappe
@@ -6,6 +7,34 @@ from frappe.desk.utils import provide_binary_file
 from openpyxl.formatting.rule import FormulaRule
 from openpyxl.styles import Alignment, Font, PatternFill
 from openpyxl.utils import get_column_letter
+
+# Shared cell-fill palette for every GST-returns Excel export.
+COLOR_PALLATE = frappe._dict(
+    {
+        "dark_gray": "d9d9d9",
+        "light_gray": "f2f2f2",
+        "dark_pink": "e6b9b8",
+        "light_pink": "f2dcdb",
+        "sky_blue": "c6d9f1",
+        "light_blue": "dce6f2",
+        "green": "d7e4bd",
+        "light_green": "ebf1de",
+    }
+)
+
+# Shared number formats for GST-returns Excel exports.
+AMOUNT_FORMAT = "#,##0.00"
+DATE_FORMAT = "dd-mmm-yy"
+PERCENT_FORMAT = "0.00"
+
+
+class ExcelWidth(Enum):
+    XS = 10
+    SM = 15
+    MD = 20  # Default
+    LG = 25
+    XL = 30
+    XXL = 35
 
 
 class ExcelExporter:
@@ -172,7 +201,7 @@ class Worksheet:
                 if transform:
                     value = transform(value, row)
 
-                sheet.cell(row=i, column=j, value=value or "")
+                sheet.cell(row=i, column=j, value="" if value is None else value)
 
     def add_data(self, data, **kwargs):
         if not data:

--- a/india_compliance/gst_india/utils/gstr_utils.py
+++ b/india_compliance/gst_india/utils/gstr_utils.py
@@ -23,6 +23,7 @@ class ReturnType(Enum):
     GSTR2B = "GSTR2b"
     GSTR1 = "GSTR1"
     UnfiledGSTR1 = "Unfiled GSTR1"
+    GSTR3B = "GSTR3B"
     IMS = "IMS"
 
 

--- a/india_compliance/gst_india/utils/test_exporter.py
+++ b/india_compliance/gst_india/utils/test_exporter.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2024, Resilient Tech and Contributors
+# See license.txt
+
+from frappe.tests import IntegrationTestCase
+
+from india_compliance.gst_india.utils.exporter import ExcelExporter
+
+
+class TestExcelExporter(IntegrationTestCase):
+    def test_insert_data_keeps_zero(self):
+        """insert_data must write a numeric 0, not blank it out (regression: `value or ""`)."""
+        excel = ExcelExporter()
+        excel.wb.create_sheet("data")
+        excel.insert_data(
+            sheet_name="data",
+            headers=[{"fieldname": "amount"}],
+            data=[{"amount": 0}, {"amount": 100}],
+        )
+
+        ws = excel.wb["data"]
+        self.assertEqual(ws.cell(row=1, column=1).value, 0)
+        self.assertEqual(ws.cell(row=2, column=1).value, 100)


### PR DESCRIPTION
## What

First PR of the GST-returns refactor. Fixes a zero-blanking bug in the shared Excel engine and refactor duplicated engine constants.

## Changes

- **Fix:** `Worksheet.insert_data` used `value or ""`, so a numeric `0` (e.g. taxable value, cess) exported as a blank cell. Now `"" if value is None else value` — real zeros survive, genuinely-empty cells stay blank.
- **Dedup:** `COLOR_PALLATE` (byte-identical copy in `BuildExcel` and `ReconcileExcel`) plus `AMOUNT_FORMAT` / `DATE_FORMAT` / `PERCENT_FORMAT` and `ExcelWidth` now live once in `exporter.py`. Consumers alias them — no call-site churn.
- **Enum:** `GSTR3B` added to `ReturnType`; the return log already writes `"GSTR3B"`.
- **Test:** engine-level regression test (`utils/test_exporter.py`) — asserts `insert_data` writes `0`, not blank. Verified: reverting the fix fails it (`'' != 0`).

`PR-1 of refactor series`