### PR TITLE
fix(ims): show action summary on load, and let its divider reach the edges

### DIFF
--- a/india_compliance/gst_india/doctype/gst_invoice_management_system/gst_invoice_management_system.js
+++ b/india_compliance/gst_india/doctype/gst_invoice_management_system/gst_invoice_management_system.js
@@ -82,6 +82,7 @@ class IMS extends reconciliation.reconciliation_tabs {
     render_data(data) {
         this.process_data(data);
         super.render_data(data);
+        this.set_actions_summary();
     }
 
     refresh(data) {
@@ -520,7 +521,7 @@ class IMS extends reconciliation.reconciliation_tabs {
             .join("");
 
         const action_performed_html = `
-            <div class="action-performed-summary mt-3 mb-3 w-100 d-flex justify-content-around align-items-center" style="border-bottom: 1px solid var(--border-color);">
+            <div class="action-performed-summary mt-3 mb-3 d-flex justify-content-around align-items-center">
                 ${action_performed_cards}
             </div>
        `;

--- a/india_compliance/public/scss/_return_tool.scss
+++ b/india_compliance/public/scss/_return_tool.scss
@@ -26,8 +26,9 @@
         padding: 0;
     }
 
-    // net GST liability cards above the tabs
-    .gst-ledger-difference {
+    // the count strips above the tabs: net GST liability, actions performed
+    .gst-ledger-difference,
+    .action-performed-summary {
         @include full-bleed-divider;
     }
 }


### PR DESCRIPTION
## What

- Counts strip (No Action / Accepted / Pending / Rejected) did not show after **Show Invoices**. Only turned up after acting on a row.
- Line under that strip stopped short of both edges.

## How

- Draw the strip when invoices first load, not only on refresh.
- Drop the fixed width so the shared full-width divider rule applies.

## Note

- First one is old, not from #4672. The strip was only ever drawn on refresh.
- Second one shows up next to #4672, which made the other dividers reach the edges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Screenshots

<img width="516" height="328" alt="image" src="https://github.com/user-attachments/assets/70aded5f-cf76-463e-a948-18f419e5620a" />

