### PR TITLE
refactor(ui): rebuild the view group as a segmented control

### DIFF
--- a/india_compliance/public/js/components/view_group.js
+++ b/india_compliance/public/js/components/view_group.js
@@ -8,21 +8,14 @@ india_compliance.ViewGroup = class ViewGroup {
     }
 
     render() {
-        $(this.$wrapper).append(
-            `
-            <div class= "view-group">
-                <div class="view-switch"></div>
-            </div>
-            `,
-        );
-
+        // frappe's segmented control: a rail with one pressed pill
         this.view_group_container = $(`
-            <ul
-                class= "nav custom-tabs rounded-sm border d-inline-flex"
-                id = "custom-tabs"
-                role = "tablist"
-            ></ul>
-        `).appendTo(this.$wrapper.find(`.view-switch`));
+            <div
+                class="view-group es-tab-buttons"
+                role="radiogroup"
+                aria-label="${__("Change view")}"
+            ></div>
+        `).appendTo(this.$wrapper);
 
         this.make_views();
         this.setup_events();
@@ -30,39 +23,41 @@ india_compliance.ViewGroup = class ViewGroup {
 
     set_active_view(view) {
         this.active_view = view;
-        this.views[`${view}_view`].children().tab("show");
+
+        Object.entries(this.views).forEach(([name, $pill]) => {
+            const active = name === `${view}_view`;
+            $pill.attr("data-state", active ? "active" : "inactive").attr("aria-checked", active);
+        });
     }
 
     make_views() {
         this.view_names.forEach((view) => {
-            this.views[`${view}_view`] = $(
-                `
-                <li class="nav-item show">
-                    <a
-                        class="nav-link ${this.active_view === view ? "active" : ""}"
-                        id = "gstr-1-__${view}-view"
-                        data-toggle="tab"
-                        data-fieldname="${view}"
-                        href="#gstr-1-__${view}-view"
-                        role="tab"
-                        aria-controls="gstr-1-__${view}-view"
-                        aria-selected="true"
-            >
-            ${frappe.unscrub(view)}
-                    </a>
-                </li>
-            `,
-            ).appendTo(this.view_group_container);
+            const active = this.active_view === view;
+
+            this.views[`${view}_view`] = $(`
+                <button
+                    class="es-pill"
+                    role="radio"
+                    data-fieldname="${view}"
+                    data-state="${active ? "active" : "inactive"}"
+                    aria-checked="${active}"
+                >
+                    ${frappe.unscrub(view)}
+                </button>
+            `).appendTo(this.view_group_container);
         });
     }
 
     setup_events() {
-        this.view_group_container.off("click").on("click", ".nav-link", (e) => {
+        this.view_group_container.off("click").on("click", ".es-pill", (e) => {
             e.preventDefault();
             e.stopImmediatePropagation();
 
-            this.target = $(e.currentTarget);
-            const target_view = this.target.attr("data-fieldname");
+            const $pill = $(e.currentTarget);
+            // guard here, not pointer-events: covers the keyboard, keeps the title
+            if ($pill.is("[data-disabled]")) return;
+
+            const target_view = $pill.attr("data-fieldname");
 
             this.set_active_view(target_view);
             this.callback && this.callback(target_view);
@@ -70,12 +65,17 @@ india_compliance.ViewGroup = class ViewGroup {
     }
 
     disable_view(view, title) {
-        this.views[`${view}_view`].attr("title", title);
-        this.views[`${view}_view`].find(".nav-link").addClass("disabled");
+        this.views[`${view}_view`].attr({
+            title,
+            "data-disabled": "",
+            "aria-disabled": "true",
+        });
     }
 
     enable_view(view) {
-        this.views[`${view}_view`].removeAttr("title");
-        this.views[`${view}_view`].find(".nav-link").removeClass("disabled");
+        this.views[`${view}_view`]
+            .removeAttr("title")
+            .removeAttr("data-disabled")
+            .removeAttr("aria-disabled");
     }
 };

--- a/india_compliance/public/scss/components/_view_group.scss
+++ b/india_compliance/public/scss/components/_view_group.scss
@@ -1,27 +1,60 @@
-// styles js/components/view_group.js
-// frappe v16 ships no segmented control, so this is our own pill rail
+// js/components/view_group.js
+// frappe's segmented control, look rebuilt on v16 vars. scoped to .view-group,
+// so dropping this file is all it takes once v16 ships the component.
 
-.view-group .custom-tabs {
-    > .nav-item > .nav-link {
-        // 29px, to sit level with the filter and Actions buttons beside it
-        padding: 3px 8px;
+.view-group.es-tab-buttons {
+    display: inline-flex;
+    align-items: center;
+    gap: 1px;
+    // frame, so the rail shows around the pill
+    padding: 1px;
+    background: var(--control-bg);
+    // rail radius = pill radius + the frame
+    border-radius: 8px;
+
+    .es-pill {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        flex-shrink: 0;
+        border: 0;
+        background: transparent;
+        border-radius: 7px;
+        // adds up to 29px, level with the buttons beside it
+        padding: 5px 8px;
+        font-size: var(--text-sm);
+        line-height: 17px;
+        color: var(--text-muted);
+        white-space: nowrap;
+        user-select: none;
+        cursor: pointer;
+        transition:
+            background-color 150ms ease-out,
+            color 150ms ease-out,
+            box-shadow 150ms ease-out;
+    }
+
+    // one step darker than the rail
+    .es-pill:hover:not([data-state="active"], [data-disabled]) {
+        background: var(--control-bg-on-gray);
         color: var(--text-color);
     }
 
-    > .nav-item:first-child > .nav-link {
-        border-radius: 0.4rem 0 0 0.4rem;
+    // the pressed pill rises out of the rail
+    .es-pill[data-state="active"] {
+        background: var(--card-bg);
+        box-shadow: var(--btn-shadow);
+        color: var(--text-color);
     }
 
-    > .nav-item:last-child > .nav-link {
-        border-radius: 0 0.4rem 0.4rem 0;
+    .es-pill:focus-visible {
+        outline: 1px solid var(--gray-500);
+        outline-offset: 0;
     }
 
-    > .nav-item:not(:has(.disabled)):hover > .nav-link:not(.active) {
-        background-color: var(--btn-default-hover-bg);
-    }
-
-    > .nav-item > .nav-link.active {
-        background-color: var(--control-bg);
-        color: var(--primary);
+    // no pointer-events: none, or the title never shows. handler blocks it.
+    .es-pill[data-disabled] {
+        opacity: 0.6;
+        cursor: default;
     }
 }


### PR DESCRIPTION
Follow-up to #4673. That one left the Summary/Detailed switch alone. This fixes it.

## What

- Switch looked flat and homemade. Now one proper control.
- Switch vanished in dark mode. Shows up now.
- Greyed out "Detailed" could still be picked. Blocked now.
- Screen readers had nothing to announce. Labelled now.

## How

- Same buttons develop uses, so ours drops out when v16 catches up.
- Colours come from the theme instead of being written in.
- Hovering a greyed out view still says why it is off.

## Note

- Same height as the Filter and Actions buttons, as before.
- Only GSTR-1 uses this switch.
- Comments across the shared styles trimmed to one-liners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
