### PR TITLE
refactor: gst return package skeleton and helpers

### DIFF
--- a/india_compliance/gst_returns/__init__.py
+++ b/india_compliance/gst_returns/__init__.py
@@ -1,0 +1,5 @@
+"""Pure GST-returns logic. No frappe (guard: test_frappe_free.py). Import within relatively.
+
+Fast suite, no site:
+    python -m unittest discover -s <path>/gst_returns -t <path>/apps/india_compliance
+"""

--- a/india_compliance/gst_returns/enrich.py
+++ b/india_compliance/gst_returns/enrich.py
@@ -1,0 +1,1 @@
+"""Enrich: totals / sign-flips / classification."""

--- a/india_compliance/gst_returns/excel/__init__.py
+++ b/india_compliance/gst_returns/excel/__init__.py
@@ -1,0 +1,1 @@
+"""Excel column layouts + writer."""

--- a/india_compliance/gst_returns/fields/__init__.py
+++ b/india_compliance/gst_returns/fields/__init__.py
@@ -1,0 +1,1 @@
+"""Field constants per return."""

--- a/india_compliance/gst_returns/helpers.py
+++ b/india_compliance/gst_returns/helpers.py
@@ -17,6 +17,8 @@ def parse_date(value, fmt="%Y-%m-%d"):
     """str -> date"""
     if not value:
         return None
+    if isinstance(value, datetime):
+        return value.date()
     if isinstance(value, date):
         return value
     return datetime.strptime(value, fmt).date()

--- a/india_compliance/gst_returns/helpers.py
+++ b/india_compliance/gst_returns/helpers.py
@@ -1,0 +1,29 @@
+import math
+from datetime import date, datetime
+
+
+def round2(value):
+    """2 decimal places round. Not naive (2.675 -> 2.68)."""
+    if value is None:
+        return 0.0
+
+    scaled = round(float(value) * 100, 8)
+    floor = math.floor(scaled)
+    scaled = floor + 1 if scaled - floor == 0.5 else round(scaled)
+    return scaled / 100
+
+
+def parse_date(value, fmt="%Y-%m-%d"):
+    """str -> date"""
+    if not value:
+        return None
+    if isinstance(value, date):
+        return value
+    return datetime.strptime(value, fmt).date()
+
+
+def format_date(value, fmt="%Y-%m-%d"):
+    """date -> str"""
+    if value is None:
+        return None
+    return value.strftime(fmt)

--- a/india_compliance/gst_returns/rename.py
+++ b/india_compliance/gst_returns/rename.py
@@ -1,0 +1,1 @@
+"""Rename: raw keys <-> canonical names."""

--- a/india_compliance/gst_returns/reshape.py
+++ b/india_compliance/gst_returns/reshape.py
@@ -1,0 +1,1 @@
+"""Reshape: declared nesting + row keys."""

--- a/india_compliance/gst_returns/roundtrip.py
+++ b/india_compliance/gst_returns/roundtrip.py
@@ -2,14 +2,14 @@ _MISSING = object()
 
 
 def _clean(value, precision):
-    if isinstance(value, bool):
-        return value
-    if isinstance(value, (int, float)):
-        return round(float(value), precision)
+    if isinstance(value, float):
+        return round(value, precision)
     if isinstance(value, dict):
-        return {k: _clean(v, precision) for k, v in value.items() if not _is_empty(v)}
+        cleaned = ((k, _clean(v, precision)) for k, v in value.items())
+        return {k: v for k, v in cleaned if not _is_empty(v)}
     if isinstance(value, (list, tuple)):
-        return [_clean(v, precision) for v in value]
+        cleaned = (_clean(v, precision) for v in value)
+        return [v for v in cleaned if not _is_empty(v)]
     return value
 
 

--- a/india_compliance/gst_returns/roundtrip.py
+++ b/india_compliance/gst_returns/roundtrip.py
@@ -1,0 +1,55 @@
+_MISSING = object()
+
+
+def _clean(value, precision):
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return round(float(value), precision)
+    if isinstance(value, dict):
+        return {k: _clean(v, precision) for k, v in value.items() if not _is_empty(v)}
+    if isinstance(value, (list, tuple)):
+        return [_clean(v, precision) for v in value]
+    return value
+
+
+def _is_empty(value):
+    # drop falsy, keep 0 and False
+    return not (value or value == 0)
+
+
+def _is_number(value):
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def _first_diff(a, b, path="root"):
+    """Return first difference between a and b, or None if equal"""
+    if type(a) is not type(b) and not (_is_number(a) and _is_number(b)):
+        return (path, a, b)
+
+    if isinstance(a, dict):
+        for key in a.keys() | b.keys():
+            av, bv = a.get(key, _MISSING), b.get(key, _MISSING)
+            if av is _MISSING or bv is _MISSING:
+                return (f"{path}.{key}", av, bv)
+            if diff := _first_diff(av, bv, f"{path}.{key}"):
+                return diff
+        return None
+
+    if isinstance(a, list):
+        if len(a) != len(b):
+            return (f"{path}[len]", len(a), len(b))
+        for i, (av, bv) in enumerate(zip(a, b, strict=True)):
+            if diff := _first_diff(av, bv, f"{path}[{i}]"):
+                return diff
+        return None
+
+    return None if a == b else (path, a, b)
+
+
+def assert_roundtrip(original, roundtripped, precision=2):
+    """Raise if roundtrip lost data. Path in message."""
+    diff = _first_diff(_clean(original, precision), _clean(roundtripped, precision))
+    if diff:
+        path, a, b = diff
+        raise AssertionError(f"round-trip mismatch at {path}: {a!r} != {b!r}")

--- a/india_compliance/gst_returns/summary.py
+++ b/india_compliance/gst_returns/summary.py
@@ -1,0 +1,1 @@
+"""One summary shape."""

--- a/india_compliance/gst_returns/test_frappe_free.py
+++ b/india_compliance/gst_returns/test_frappe_free.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2024, Resilient Tech and Contributors
+# See license.txt
+
+"""Guard: no frappe imports in gst_returns. Site-less.
+
+AST, not sys.modules (package import pulls frappe via india_compliance/__init__).
+"""
+
+import ast
+import unittest
+from pathlib import Path
+
+PACKAGE_DIR = Path(__file__).resolve().parent
+
+FORBIDDEN_ROOTS = {"frappe", "erpnext", "india_compliance"}
+
+
+def _imported_modules(tree):
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                yield alias.name
+        elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+            yield node.module
+
+
+def _is_forbidden(module):
+    return module.split(".")[0] in FORBIDDEN_ROOTS
+
+
+class TestPackageIsFrappeFree(unittest.TestCase):
+    def test_no_frappe_world_imports(self):
+        offenders = [
+            f"{path.relative_to(PACKAGE_DIR)}: imports {module}"
+            for path in PACKAGE_DIR.rglob("*.py")
+            for module in _imported_modules(ast.parse(path.read_text(), filename=str(path)))
+            if _is_forbidden(module)
+        ]
+        self.assertEqual(offenders, [], "gst_returns must stay frappe-free:\n" + "\n".join(offenders))
+
+
+class TestForbiddenPredicate(unittest.TestCase):
+    def test_classification(self):
+        for mod in (
+            "frappe",
+            "frappe.utils",
+            "erpnext",
+            "india_compliance",
+            "india_compliance.gst_india.utils.exporter",
+            "india_compliance.gst_returns.helpers",
+        ):
+            self.assertTrue(_is_forbidden(mod), mod)
+        for mod in ("math", "openpyxl", "datetime"):
+            self.assertFalse(_is_forbidden(mod), mod)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/india_compliance/gst_returns/test_helpers.py
+++ b/india_compliance/gst_returns/test_helpers.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2024, Resilient Tech and Contributors
+# See license.txt
+
+"""Pure self-tests for helpers. Site-less. round2 expectations = frappe.flt(x, 2)."""
+
+import unittest
+from datetime import date
+
+from .helpers import format_date, parse_date, round2
+
+
+class TestRound2(unittest.TestCase):
+    def test_none_and_zero(self):
+        self.assertEqual(round2(None), 0.0)
+        self.assertEqual(round2(0), 0.0)
+        self.assertEqual(round2(0.0), 0.0)
+
+    def test_epsilon_corrected_halves(self):
+        self.assertEqual(round2(2.675), 2.68)
+        self.assertEqual(round2(-50.005), -50.0)
+        self.assertEqual(round2(10.005), 10.01)
+        self.assertEqual(round2(99.995), 100.0)
+        self.assertEqual(round2(1234.565), 1234.57)
+
+    def test_plain_values(self):
+        self.assertEqual(round2(100), 100.0)
+        self.assertEqual(round2(33.333333), 33.33)
+        self.assertEqual(round2(0.1 + 0.2), 0.3)
+
+
+class TestDateHelpers(unittest.TestCase):
+    def test_parse_iso_and_custom_fmt(self):
+        self.assertEqual(parse_date("2024-03-15"), date(2024, 3, 15))
+        self.assertEqual(parse_date("15-03-2024", "%d-%m-%Y"), date(2024, 3, 15))
+
+    def test_parse_empty(self):
+        self.assertIsNone(parse_date(None))
+        self.assertIsNone(parse_date(""))
+
+    def test_parse_passthrough_date(self):
+        self.assertEqual(parse_date(date(2024, 3, 15)), date(2024, 3, 15))
+
+    def test_format_iso_and_custom_fmt(self):
+        self.assertEqual(format_date(date(2024, 3, 15)), "2024-03-15")
+        self.assertEqual(format_date(date(2024, 3, 15), "%d-%m-%Y"), "15-03-2024")
+        self.assertIsNone(format_date(None))
+
+    def test_roundtrip(self):
+        self.assertEqual(parse_date(format_date(date(2024, 3, 15))), date(2024, 3, 15))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/india_compliance/gst_returns/test_helpers.py
+++ b/india_compliance/gst_returns/test_helpers.py
@@ -4,7 +4,7 @@
 """Pure self-tests for helpers. Site-less. round2 expectations = frappe.flt(x, 2)."""
 
 import unittest
-from datetime import date
+from datetime import date, datetime
 
 from .helpers import format_date, parse_date, round2
 
@@ -39,6 +39,11 @@ class TestDateHelpers(unittest.TestCase):
 
     def test_parse_passthrough_date(self):
         self.assertEqual(parse_date(date(2024, 3, 15)), date(2024, 3, 15))
+
+    def test_parse_datetime_drops_time(self):
+        parsed = parse_date(datetime(2024, 3, 15, 13, 45, 6))
+        self.assertEqual(parsed, date(2024, 3, 15))
+        self.assertNotIsInstance(parsed, datetime)
 
     def test_format_iso_and_custom_fmt(self):
         self.assertEqual(format_date(date(2024, 3, 15)), "2024-03-15")

--- a/india_compliance/gst_returns/test_roundtrip.py
+++ b/india_compliance/gst_returns/test_roundtrip.py
@@ -40,6 +40,16 @@ class TestAssertRoundtrip(unittest.TestCase):
     def test_int_float_equal(self):
         assert_roundtrip({"n": 5}, {"n": 5.0})
 
+    def test_big_int_not_flattened(self):
+        with self.assertRaises(AssertionError):
+            assert_roundtrip({"n": 9007199254740992}, {"n": 9007199254740993})
+
+    def test_nested_empty_dict_vs_absent(self):
+        assert_roundtrip({"a": {"b": ""}}, {})
+
+    def test_empty_list_record_vs_absent(self):
+        assert_roundtrip({"rows": [{"a": 1}, {"b": ""}]}, {"rows": [{"a": 1}]})
+
     def test_nested_mismatch_reports_path(self):
         a = {"b2b": [{"items": [{"txval": 10.0}]}]}
         b = {"b2b": [{"items": [{"txval": 11.0}]}]}

--- a/india_compliance/gst_returns/test_roundtrip.py
+++ b/india_compliance/gst_returns/test_roundtrip.py
@@ -1,0 +1,61 @@
+# Copyright (c) 2024, Resilient Tech and Contributors
+# See license.txt
+
+"""Self-tests for the losslessness harness. Site-less."""
+
+import unittest
+
+from .roundtrip import assert_roundtrip
+
+
+class TestAssertRoundtrip(unittest.TestCase):
+    def test_identical_passes(self):
+        data = {"b2b": [{"ctin": "24AAQCA8719H1ZC", "txval": 100.0}]}
+        assert_roundtrip(data, data)
+
+    def test_empty_vs_absent_passes(self):
+        # empty drops out
+        assert_roundtrip({"a": 1, "b": "", "c": None}, {"a": 1})
+        assert_roundtrip({"a": 1}, {"a": 1, "b": "", "c": None})
+
+    def test_zero_is_not_empty(self):
+        # 0 not empty
+        assert_roundtrip({"txval": 0}, {"txval": 0.0})
+        with self.assertRaises(AssertionError):
+            assert_roundtrip({"txval": 0}, {})
+
+    def test_false_is_not_empty(self):
+        with self.assertRaises(AssertionError):
+            assert_roundtrip({"flag": False}, {})
+
+    def test_empty_container_drops(self):
+        # {} and [] vanish through format_data
+        assert_roundtrip({"a": 1, "b": {}, "c": []}, {"a": 1})
+
+    def test_float_precision_tolerance(self):
+        assert_roundtrip({"txval": 10.501}, {"txval": 10.5})
+        with self.assertRaises(AssertionError):
+            assert_roundtrip({"txval": 10.5}, {"txval": 10.6})
+
+    def test_int_float_equal(self):
+        assert_roundtrip({"n": 5}, {"n": 5.0})
+
+    def test_nested_mismatch_reports_path(self):
+        a = {"b2b": [{"items": [{"txval": 10.0}]}]}
+        b = {"b2b": [{"items": [{"txval": 11.0}]}]}
+        with self.assertRaises(AssertionError) as cm:
+            assert_roundtrip(a, b)
+        self.assertIn("b2b", str(cm.exception))
+        self.assertIn("txval", str(cm.exception))
+
+    def test_list_length_mismatch_fails(self):
+        with self.assertRaises(AssertionError):
+            assert_roundtrip({"rows": [1, 2]}, {"rows": [1, 2, 3]})
+
+    def test_extra_key_fails(self):
+        with self.assertRaises(AssertionError):
+            assert_roundtrip({"a": 1}, {"a": 1, "b": 2})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/india_compliance/gst_returns/validate.py
+++ b/india_compliance/gst_returns/validate.py
@@ -1,0 +1,1 @@
+"""Payload validation."""


### PR DESCRIPTION
## What

-  New package for GST-returns logic, kept free of framework code.
- Test that blocks framework into it.
- Money-rounding + date helpers.
- Round-trip checker — proves a data conversion loses nothing.

### Note

- Runs without a site, fast.
- Empty module placeholders filled by later PRs.

`PR-2 of refactor series`