### PR TITLE
fix: persist raw 2a and 2b token in gst return log

### DIFF
--- a/india_compliance/gst_india/doctype/gst_return_log/gst_return_log.json
+++ b/india_compliance/gst_india/doctype/gst_return_log/gst_return_log.json
@@ -22,6 +22,7 @@
   "section_break_oisv",
   "unfiled",
   "filed",
+  "raw_gov_data",
   "upload_error",
   "column_break_hxfu",
   "unfiled_summary",
@@ -114,6 +115,12 @@
    "fieldname": "filed",
    "fieldtype": "Attach",
    "label": "Filed Data",
+   "read_only": 1
+  },
+  {
+   "fieldname": "raw_gov_data",
+   "fieldtype": "Attach",
+   "label": "Raw Gov Data",
    "read_only": 1
   },
   {

--- a/india_compliance/gst_india/doctype/gst_return_log/gst_return_log.py
+++ b/india_compliance/gst_india/doctype/gst_return_log/gst_return_log.py
@@ -25,6 +25,8 @@ from india_compliance.gst_india.utils import get_party_for_gstin
 
 DOCTYPE = "GST Return Log"
 
+RAW_FIELD = "raw_gov_data"
+
 
 class GSTReturnLog(GenerateGSTR1, FileGSTR1, Document):
     @property
@@ -327,10 +329,10 @@ def get_decompressed_data(content):
 
 
 def store_raw_return_data(gstin, return_type, return_period, json_data):
-    """Keep the portal payload (gzipped) in the period's log `filed` field."""
+    """Keep the portal payload (gzipped) in the period's log `raw_gov_data` field."""
     name = f"{return_type}-{return_period}-{gstin}"
     with filelock(frappe.scrub(f"raw_return_{name}")):
-        get_gst_return_log(name).update_json_for("filed", json_data)
+        get_gst_return_log(name).update_json_for(RAW_FIELD, json_data)
 
 
 def get_raw_return_data(gstin, return_type, return_period):
@@ -339,7 +341,8 @@ def get_raw_return_data(gstin, return_type, return_period):
     if not frappe.db.exists(DOCTYPE, name):
         return None
 
-    return get_gst_return_log(name).get_json_for("filed")
+    with filelock(frappe.scrub(f"raw_return_{name}")):
+        return get_gst_return_log(name).get_json_for(RAW_FIELD)
 
 
 def create_ims_return_log(company_gstin):

--- a/india_compliance/gst_india/doctype/gst_return_log/gst_return_log.py
+++ b/india_compliance/gst_india/doctype/gst_return_log/gst_return_log.py
@@ -15,6 +15,7 @@ from frappe.utils import (
     getdate,
 )
 from frappe.utils.response import json_handler
+from frappe.utils.synchronization import filelock
 
 from india_compliance.gst_india.doctype.gst_return_log.generate_gstr_1 import (
     FileGSTR1,
@@ -323,6 +324,22 @@ def get_compressed_data(json_data):
 
 def get_decompressed_data(content):
     return frappe.parse_json(frappe.safe_decode(gzip.decompress(content)))
+
+
+def store_raw_return_data(gstin, return_type, return_period, json_data):
+    """Keep the portal payload (gzipped) in the period's log `filed` field."""
+    name = f"{return_type}-{return_period}-{gstin}"
+    with filelock(frappe.scrub(f"raw_return_{name}")):
+        get_gst_return_log(name).update_json_for("filed", json_data)
+
+
+def get_raw_return_data(gstin, return_type, return_period):
+    """Stored portal payload, or None."""
+    name = f"{return_type}-{return_period}-{gstin}"
+    if not frappe.db.exists(DOCTYPE, name):
+        return None
+
+    return get_gst_return_log(name).get_json_for("filed")
 
 
 def create_ims_return_log(company_gstin):

--- a/india_compliance/gst_india/doctype/gst_return_log/test_gst_return_log.py
+++ b/india_compliance/gst_india/doctype/gst_return_log/test_gst_return_log.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024, Resilient Tech and Contributors
 # See license.txt
 
+import copy
 from unittest.mock import Mock, patch
 
 import frappe
@@ -10,6 +11,8 @@ from frappe.utils import getdate
 from india_compliance.gst_india.doctype.gst_return_log.gst_return_log import (
     add_comment_to_gst_return_log,
     get_gst_return_log,
+    get_raw_return_data,
+    store_raw_return_data,
 )
 from india_compliance.gst_india.utils.gstr_1.gstr_1_download import download_gstr1_json_data
 
@@ -50,6 +53,22 @@ class TestGSTReturnLog(IntegrationTestCase):
         )
         self.assertTrue(comment)
         self.assertIn("has been submitted by", comment.content)
+
+    def test_portal_data_roundtrip(self):
+        payload = {
+            "gstin": self.GSTIN,
+            "b2b": [{"ctin": "24AABCR6898M1ZN", "txval": 100.0, "iamt": 0}],
+            "itcsumm": {"itcavl": []},
+        }
+        original = copy.deepcopy(payload)
+
+        self.assertIsNone(get_raw_return_data(self.GSTIN, "GSTR2b", "052099"))
+
+        store_raw_return_data(self.GSTIN, "GSTR2b", "052099", payload)
+        got = get_raw_return_data(self.GSTIN, "GSTR2b", "052099")
+
+        got.pop("creation", None)
+        self.assertEqual(got, original)
 
     @patch("india_compliance.gst_india.utils.gstr_1.gstr_1_download.GSTR1API")
     def test_download_gstr1_json_data(self, mock_api):

--- a/india_compliance/gst_india/utils/gstr_2/__init__.py
+++ b/india_compliance/gst_india/utils/gstr_2/__init__.py
@@ -13,11 +13,16 @@ from india_compliance.gst_india.api_classes.taxpayer_returns import (
 )
 from india_compliance.gst_india.doctype.gst_return_log.gst_return_log import (
     create_ims_return_log,
+    store_raw_return_data,
 )
 from india_compliance.gst_india.doctype.gstr_import_log.gstr_import_log import (
     create_import_log,
 )
-from india_compliance.gst_india.utils import get_party_for_gstin, validate_gstin_permission
+from india_compliance.gst_india.utils import (
+    get_party_for_gstin,
+    merge_dicts,
+    validate_gstin_permission,
+)
 from india_compliance.gst_india.utils.gstr_2 import gstr_2a, gstr_2b, ims
 from india_compliance.gst_india.utils.gstr_utils import ReturnType
 
@@ -216,9 +221,14 @@ def download_gstr_2b(gstin, return_periods):
 
         # Handle multiple files for GSTR2B
         if response.data and (file_count := response.data.get("fc")):
+            combined = {}
             for file_num in range(1, file_count + 1):
                 r = api.get_data(return_period, file_num=file_num)
-                save_gstr_2b(gstin, return_period, r)
+                merge_dicts(combined, r.data or {})
+                save_gstr_2b(gstin, return_period, r, store_raw=False)
+
+            if combined:
+                store_raw_return_data(gstin, ReturnType.GSTR2B.value, return_period, combined)
 
             continue  # skip first response if file_count is greater than 1
 
@@ -307,10 +317,11 @@ def save_gstr_2a(gstin, return_period, json_data):
         # making consistent with GSTR2b
         json_data[category.value.lower()] = json_data.pop(action.lower())
 
+    store_raw_return_data(gstin, return_type.value, return_period, json_data)
     save_gstr(gstin, return_type, return_period, json_data)
 
 
-def save_gstr_2b(gstin, return_period, json_data):
+def save_gstr_2b(gstin, return_period, json_data, *, store_raw=True):
     json_data = json_data.data
     return_type = ReturnType.GSTR2B
     if not json_data or json_data.get("gstin") != gstin:
@@ -321,6 +332,9 @@ def save_gstr_2b(gstin, return_period, json_data):
             ),
             title=_("Invalid Response Received."),
         )
+
+    if store_raw:
+        store_raw_return_data(gstin, return_type.value, return_period, dict(json_data))
 
     create_import_log(gstin, return_type.value, return_period)
     save_gstr(

--- a/india_compliance/gst_india/utils/gstr_2/__init__.py
+++ b/india_compliance/gst_india/utils/gstr_2/__init__.py
@@ -308,6 +308,8 @@ def save_gstr_2a(gstin, return_period, json_data):
             title=_("Invalid Response Received."),
         )
 
+    raw_data = dict(json_data)
+
     for action, category in GSTR_2A_ACTIONS.items():
         if action.lower() not in json_data:
             continue
@@ -317,7 +319,7 @@ def save_gstr_2a(gstin, return_period, json_data):
         # making consistent with GSTR2b
         json_data[category.value.lower()] = json_data.pop(action.lower())
 
-    store_raw_return_data(gstin, return_type.value, return_period, json_data)
+    store_raw_return_data(gstin, return_type.value, return_period, raw_data)
     save_gstr(gstin, return_type, return_period, json_data)
 
 

--- a/india_compliance/gst_india/utils/gstr_2/test_gstr_2a.py
+++ b/india_compliance/gst_india/utils/gstr_2/test_gstr_2a.py
@@ -6,6 +6,9 @@ from frappe import parse_json, read_file
 from frappe.tests import IntegrationTestCase
 from frappe.utils import get_datetime
 
+from india_compliance.gst_india.doctype.gst_return_log.gst_return_log import (
+    get_raw_return_data,
+)
 from india_compliance.gst_india.utils import get_data_file_path
 from india_compliance.gst_india.utils.gstr_2 import (
     GSTRCategory,
@@ -81,6 +84,12 @@ class TestGSTR2a(TestGSTRMixin, IntegrationTestCase):
         mock_gstr_2a_api.return_value.get_data.side_effect = mock_get_data
         mock_save_gstr.side_effect = mock_save_gstr_func
         download_gstr_2a(self.gstin, (self.return_period,))
+
+    def test_raw_stored_before_rename(self):
+        raw = get_raw_return_data(self.gstin, ReturnType.GSTR2A.value, self.return_period)
+        self.assertIn("cdn", raw)
+        self.assertNotIn("cdnr", raw)
+        self.assertListEqual(raw["cdn"], self.test_data.cdn)
 
     def test_gstr2a_b2b(self):
         doc = self.get_doc(GSTRCategory.B2B)

--- a/india_compliance/gst_india/utils/gstr_2/test_gstr_2b_v4_0.py
+++ b/india_compliance/gst_india/utils/gstr_2/test_gstr_2b_v4_0.py
@@ -357,10 +357,10 @@ class TestMultiFileRawMerge(IntegrationTestCase):
     def test_docs_concat_summary_not_doubled(self):
         combined = {}
         file1 = {"itcsumm": {"itcavl": 100}, "docdata": {"b2b": [{"inum": "1"}]}}
-        file2 = {"itcsumm": {"itcavl": 100}, "docdata": {"b2b": [{"inum": "2"}], "cdnr": [{"nt": "9"}]}}
+        file2 = {"itcsumm": {"itcavl": 150}, "docdata": {"b2b": [{"inum": "2"}], "cdnr": [{"nt": "9"}]}}
         merge_dicts(combined, file1)
         merge_dicts(combined, file2)
 
         self.assertEqual(combined["docdata"]["b2b"], [{"inum": "1"}, {"inum": "2"}])
         self.assertEqual(combined["docdata"]["cdnr"], [{"nt": "9"}])
-        self.assertEqual(combined["itcsumm"]["itcavl"], 100)  # newer-wins, NOT 200
+        self.assertEqual(combined["itcsumm"]["itcavl"], 150)

--- a/india_compliance/gst_india/utils/gstr_2/test_gstr_2b_v4_0.py
+++ b/india_compliance/gst_india/utils/gstr_2/test_gstr_2b_v4_0.py
@@ -4,7 +4,7 @@ import frappe
 from frappe import parse_json, read_file
 from frappe.tests import IntegrationTestCase
 
-from india_compliance.gst_india.utils import get_data_file_path
+from india_compliance.gst_india.utils import get_data_file_path, merge_dicts
 from india_compliance.gst_india.utils.gstr_2 import GSTRCategory, save_gstr_2b
 from india_compliance.gst_india.utils.gstr_2.gstr import get_unique_key
 from india_compliance.gst_india.utils.gstr_2.test_gstr_2a import TestGSTRMixin
@@ -351,3 +351,16 @@ class TestGetUniqueKey(IntegrationTestCase):
     def test_normal_gstin(self):
         t = frappe._dict(supplier_gstin="01AABCE2207R1Z5", bill_no="INV-1")
         self.assertEqual(get_unique_key(t), "01AABCE2207R1Z5-INV-1")
+
+
+class TestMultiFileRawMerge(IntegrationTestCase):
+    def test_docs_concat_summary_not_doubled(self):
+        combined = {}
+        file1 = {"itcsumm": {"itcavl": 100}, "docdata": {"b2b": [{"inum": "1"}]}}
+        file2 = {"itcsumm": {"itcavl": 100}, "docdata": {"b2b": [{"inum": "2"}], "cdnr": [{"nt": "9"}]}}
+        merge_dicts(combined, file1)
+        merge_dicts(combined, file2)
+
+        self.assertEqual(combined["docdata"]["b2b"], [{"inum": "1"}, {"inum": "2"}])
+        self.assertEqual(combined["docdata"]["cdnr"], [{"nt": "9"}])
+        self.assertEqual(combined["itcsumm"]["itcavl"], 100)  # newer-wins, NOT 200


### PR DESCRIPTION
## What
- Keep the raw 2A/2B portal data instead of throwing it away after mapping.

## How
- Store the gzipped payload in the period's return log.
- Big 2B downloads arrive split across files — merge them back into one payload (reuse existing `merge_dicts`).

## Why
- Rebuild our data from the stored copy on a mapping bug, no re-download (portal download is OTP-gated + rate-limited).
- Foundation for the canonical + export work coming next.

`PR-4 of refactor series`