### PR TITLE
fix: move return field names into the package

### DIFF
--- a/india_compliance/gst_india/utils/gstr_1/__init__.py
+++ b/india_compliance/gst_india/utils/gstr_1/__init__.py
@@ -1,382 +1,43 @@
-from enum import Enum
-
 from frappe.utils import getdate
 
-
-class GSTR1_Category(Enum):
-    """
-    Overview Page of GSTR-1
-    """
-
-    # Invoice Items Bifurcation
-    B2B = "B2B, SEZ, DE"
-    EXP = "Exports"
-    B2CL = "B2C (Large)"
-    B2CS = "B2C (Others)"
-    NIL_EXEMPT = "Nil-Rated, Exempted, Non-GST"
-    CDNR = "Credit/Debit Notes (Registered)"
-    CDNUR = "Credit/Debit Notes (Unregistered)"
-
-    # Other Categories
-    AT = "Advances Received"
-    TXP = "Advances Adjusted"
-    HSN = "HSN Summary"
-    DOC_ISSUE = "Document Issued"
-    SUPECOM = "Supplies made through E-commerce Operators"
-    ECOM_RCM = "Supplies through E-commerce Operators u/s 9(5)"
-
-
-class GSTR1_SubCategory(Enum):
-    """
-    Summary Page of GSTR-1
-    """
-
-    # Invoice Items Bifurcation
-    B2B_REGULAR = "B2B Regular"
-    B2B_REVERSE_CHARGE = "B2B Reverse Charge"
-    SEZWP = "SEZ With Payment of Tax"
-    SEZWOP = "SEZ Without Payment of Tax"
-    DE = "Deemed Exports"
-    EXPWP = "Export With Payment of Tax"
-    EXPWOP = "Export Without Payment of Tax"
-    B2CL = "B2C (Large)"
-    B2CS = "B2C (Others)"
-    NIL_EXEMPT = "Nil-Rated, Exempted, Non-GST"
-    CDNR = "Credit/Debit Notes (Registered)"
-    CDNUR = "Credit/Debit Notes (Unregistered)"
-
-    # Other Sub-Categories
-    AT = "Advances Received"
-    TXP = "Advances Adjusted"
-    HSN = "HSN Summary"  # Backwards Compatibility
-    HSN_B2B = "HSN Summary - B2B"
-    HSN_B2C = "HSN Summary - B2C"
-    DOC_ISSUE = "Document Issued"
-
-    # E-Commerce
-    SUPECOM_52 = "Liable to collect tax u/s 52(TCS)"
-    SUPECOM_9_5 = "Liable to pay tax u/s 9(5)"
-
-
-class SUPECOM(Enum):
-    US_9_5 = "Liable to pay tax u/s 9(5)"
-    US_52 = "Liable to collect tax u/s 52(TCS)"
-
-
-QUARTERLY_KEYS = (
-    "already_included_docs_for_quarterly",
-    "excluded_docs_for_quarterly",
+from india_compliance.gst_returns.fields.gstr1 import (  # noqa: F401
+    CATEGORY_SUB_CATEGORY_MAPPING,
+    JSON_CATEGORY_EXCEL_CATEGORY_MAPPING,
+    PREVIOUS_VERSION,
+    QUARTERLY_KEYS,
+    SUB_CATEGORY_GOV_CATEGORY_MAPPING,
+    SUBCATEGORIES_NOT_CONSIDERED_IN_TOTAL_TAX,
+    SUBCATEGORIES_NOT_CONSIDERED_IN_TOTAL_TAXABLE_VALUE,
+    SUPECOM,
+    HSNKey,
 )
-
-
-CATEGORY_SUB_CATEGORY_MAPPING = {
-    GSTR1_Category.B2B: (
-        GSTR1_SubCategory.B2B_REGULAR,
-        GSTR1_SubCategory.B2B_REVERSE_CHARGE,
-        GSTR1_SubCategory.SEZWP,
-        GSTR1_SubCategory.SEZWOP,
-        GSTR1_SubCategory.DE,
-    ),
-    GSTR1_Category.B2CL: (GSTR1_SubCategory.B2CL,),
-    GSTR1_Category.EXP: (GSTR1_SubCategory.EXPWP, GSTR1_SubCategory.EXPWOP),
-    GSTR1_Category.B2CS: (GSTR1_SubCategory.B2CS,),
-    GSTR1_Category.NIL_EXEMPT: (GSTR1_SubCategory.NIL_EXEMPT,),
-    GSTR1_Category.CDNR: (GSTR1_SubCategory.CDNR,),
-    GSTR1_Category.CDNUR: (GSTR1_SubCategory.CDNUR,),
-    GSTR1_Category.AT: (GSTR1_SubCategory.AT,),
-    GSTR1_Category.TXP: (GSTR1_SubCategory.TXP,),
-    GSTR1_Category.DOC_ISSUE: (GSTR1_SubCategory.DOC_ISSUE,),
-    GSTR1_Category.HSN: (
-        GSTR1_SubCategory.HSN_B2B,
-        GSTR1_SubCategory.HSN_B2C,
-    ),
-    GSTR1_Category.SUPECOM: (
-        GSTR1_SubCategory.SUPECOM_52,
-        GSTR1_SubCategory.SUPECOM_9_5,
-    ),
-}
-
-# Backwards compatibility
-PREVIOUS_VERSION = {
-    GSTR1_Category.HSN.value: (GSTR1_SubCategory.HSN,),
-}
-
-
-class GSTR1_DataField:
-    TRANSACTION_TYPE = "transaction_type"
-    CUST_GSTIN = "customer_gstin"
-    ECOMMERCE_GSTIN = "ecommerce_gstin"
-    ECOMMERCE_OPERATOR_NAME = "ecommerce_operator_name"
-    CUST_NAME = "customer_name"
-    DOC_DATE = "document_date"
-    DOC_NUMBER = "document_number"
-    DOC_TYPE = "document_type"
-    DOC_VALUE = "document_value"
-    POS = "place_of_supply"
-    DIFF_PERCENTAGE = "diff_percentage"
-    REVERSE_CHARGE = "reverse_charge"
-    TAXABLE_VALUE = "total_taxable_value"
-    ITEMS = "items"
-    IGST = "total_igst_amount"
-    CGST = "total_cgst_amount"
-    SGST = "total_sgst_amount"
-    CESS = "total_cess_amount"
-    TAX_RATE = "tax_rate"
-
-    SHIPPING_BILL_NUMBER = "shipping_bill_number"
-    SHIPPING_BILL_DATE = "shipping_bill_date"
-    SHIPPING_PORT_CODE = "shipping_port_code"
-
-    EXEMPTED_AMOUNT = "exempted_amount"
-    NIL_RATED_AMOUNT = "nil_rated_amount"
-    NON_GST_AMOUNT = "non_gst_amount"
-
-    HSN_CODE = "hsn_code"
-    DESCRIPTION = "description"
-    UOM = "uom"
-    QUANTITY = "quantity"
-
-    FROM_SR = "from_sr_no"
-    TO_SR = "to_sr_no"
-    TOTAL_COUNT = "total_count"
-    DRAFT_COUNT = "draft_count"
-    CANCELLED_COUNT = "cancelled_count"
-    NET_ISSUE = "net_issue"
-    UPLOAD_STATUS = "upload_status"
-
-    ERROR_CD = "error_code"
-    ERROR_MSG = "error_message"
-
-
-class GSTR1_ItemField:
-    INDEX = "idx"
-    TAXABLE_VALUE = "taxable_value"
-    IGST = "igst_amount"
-    CGST = "cgst_amount"
-    SGST = "sgst_amount"
-    CESS = "cess_amount"
-    TAX_RATE = "tax_rate"
-    ITEM_DETAILS = "item_details"
-    ADDITIONAL_AMOUNT = "additional_amount"
-
-
-class GovDataField:
-    CUST_GSTIN = "ctin"
-    ECOMMERCE_GSTIN = "etin"
-    DOC_DATE = "idt"
-    DOC_NUMBER = "inum"
-    DOC_VALUE = "val"
-    POS = "pos"
-    DIFF_PERCENTAGE = "diff_percent"
-    REVERSE_CHARGE = "rchrg"
-    TAXABLE_VALUE = "txval"
-    ITEMS = "itms"
-    IGST = "iamt"
-    CGST = "camt"
-    SGST = "samt"
-    CESS = "csamt"
-    TAX_RATE = "rt"
-    ITEM_DETAILS = "itm_det"
-    SHIPPING_BILL_NUMBER = "sbnum"
-    SHIPPING_BILL_DATE = "sbdt"
-    SHIPPING_PORT_CODE = "sbpcode"
-    SUPPLY_TYPE = "sply_ty"
-    NET_TAXABLE_VALUE = "suppval"
-
-    EXEMPTED_AMOUNT = "expt_amt"
-    NIL_RATED_AMOUNT = "nil_amt"
-    NON_GST_AMOUNT = "ngsup_amt"
-
-    HSN_DATA = "data"  # Backwards compatibility
-    HSN_CODE = "hsn_sc"
-    DESCRIPTION = "desc"
-    UOM = "uqc"
-    QUANTITY = "qty"
-    ADVANCE_AMOUNT = "ad_amt"
-
-    INDEX = "num"
-    FROM_SR = "from"
-    TO_SR = "to"
-    TOTAL_COUNT = "totnum"
-    CANCELLED_COUNT = "cancel"
-    DOC_ISSUE_DETAILS = "doc_det"
-    DOC_ISSUE_NUMBER = "doc_num"
-    DOC_ISSUE_LIST = "docs"
-    NET_ISSUE = "net_issue"
-
-    INVOICE_TYPE = "inv_typ"
-    INVOICES = "inv"
-    EXPORT_TYPE = "exp_typ"
-    TYPE = "typ"
-
-    NOTE_TYPE = "ntty"
-    NOTE_NUMBER = "nt_num"
-    NOTE_DATE = "nt_dt"
-    NOTE_DETAILS = "nt"
-
-    SUPECOM_52 = "clttx"
-    SUPECOM_9_5 = "paytx"
-
-    HSN_B2B = "hsn_b2b"
-    HSN_B2C = "hsn_b2c"
-
-    ERROR_CD = "error_cd"
-    ERROR_MSG = "error_msg"
-
-    FLAG = "flag"
-    CHECKSUM = "chksum"
-
-
-class GovExcelField:
-    CUST_GSTIN = "GSTIN/UIN of Recipient"
-    CUST_NAME = "Receiver Name"
-    INVOICE_NUMBER = "Invoice Number"
-    INVOICE_DATE = "Invoice date"
-    INVOICE_VALUE = "Invoice Value"
-    POS = "Place Of Supply"
-    REVERSE_CHARGE = "Reverse Charge"
-    DIFF_PERCENTAGE = "Applicable % of Tax Rate"
-    INVOICE_TYPE = "Invoice Type"
-    TAXABLE_VALUE = "Taxable Value"
-    ECOMMERCE_GSTIN = "E-Commerce GSTIN"
-    TAX_RATE = "Rate"
-    IGST = "Integrated Tax Amount"
-    CGST = "Central Tax Amount"
-    SGST = "State/UT Tax Amount"
-    CESS = "Cess Amount"
-
-    NOTE_NO = "Note Number"
-    NOTE_DATE = "Note Date"
-    NOTE_TYPE = "Note Type"
-    NOTE_VALUE = "Note Value"
-
-    PORT_CODE = "Port Code"
-    SHIPPING_BILL_NO = "Shipping Bill Number"
-    SHIPPING_BILL_DATE = "Shipping Bill Date"
-
-    DESCRIPTION = "Description"
-    # NIL_RATED = "Nil Rated Supplies"
-    # EXEMPTED = "Exempted (other than nil rated/non-GST supplies)"
-    # NON_GST = "Non-GST Supplies"
-
-    HSN_CODE = "HSN"
-    UOM = "UQC"
-    QUANTITY = "Total Quantity"
-    TOTAL_VALUE = "Total Value"
-
-
-class GovJsonKey(Enum):
-    """
-    Categories / Keys as per Govt JSON file
-    """
-
-    B2B = "b2b"
-    EXP = "exp"
-    B2CL = "b2cl"
-    B2CS = "b2cs"
-    NIL_EXEMPT = "nil"
-    CDNR = "cdnr"
-    CDNUR = "cdnur"
-    AT = "at"
-    TXP = "txpd"
-    HSN = "hsn"
-    DOC_ISSUE = "doc_issue"
-    SUPECOM = "supeco"
-    RET_SUM = "sec_sum"
-
-
-# only for excel
-class HSNKey(Enum):
-    HSN = "hsn"
-    HSN_B2B = "hsn_b2b"
-    HSN_B2C = "hsn_b2c"
-
-
-class GovExcelSheetName(Enum):
-    """
-    Categories / Worksheets as per Gov Excel file
-    """
-
-    B2B = "b2b,sez,de"
-    EXP = "exp"
-    B2CL = "b2cl"
-    B2CS = "b2cs"
-    NIL_EXEMPT = "exemp"
-    CDNR = "cdnr"
-    CDNUR = "cdnur"
-    AT = "at"
-    TXP = "atadj"
-    HSN = "hsn"
-    HSN_B2B = "hsn(b2b)"
-    HSN_B2C = "hsn(b2c)"
-    DOC_ISSUE = "docs"
-    SUPECOM = "eco"
-    MASTER = "master"
-
-
-SUB_CATEGORY_GOV_CATEGORY_MAPPING = {
-    GSTR1_SubCategory.B2B_REGULAR: GovJsonKey.B2B,
-    GSTR1_SubCategory.B2B_REVERSE_CHARGE: GovJsonKey.B2B,
-    GSTR1_SubCategory.SEZWP: GovJsonKey.B2B,
-    GSTR1_SubCategory.SEZWOP: GovJsonKey.B2B,
-    GSTR1_SubCategory.DE: GovJsonKey.B2B,
-    GSTR1_SubCategory.B2CL: GovJsonKey.B2CL,
-    GSTR1_SubCategory.EXPWP: GovJsonKey.EXP,
-    GSTR1_SubCategory.EXPWOP: GovJsonKey.EXP,
-    GSTR1_SubCategory.B2CS: GovJsonKey.B2CS,
-    GSTR1_SubCategory.NIL_EXEMPT: GovJsonKey.NIL_EXEMPT,
-    GSTR1_SubCategory.CDNR: GovJsonKey.CDNR,
-    GSTR1_SubCategory.CDNUR: GovJsonKey.CDNUR,
-    GSTR1_SubCategory.AT: GovJsonKey.AT,
-    GSTR1_SubCategory.TXP: GovJsonKey.TXP,
-    GSTR1_SubCategory.DOC_ISSUE: GovJsonKey.DOC_ISSUE,
-    GSTR1_SubCategory.HSN: GovJsonKey.HSN,  # Backwards Compatibility
-    GSTR1_SubCategory.HSN_B2B: GovJsonKey.HSN,
-    GSTR1_SubCategory.HSN_B2C: GovJsonKey.HSN,
-    GSTR1_SubCategory.SUPECOM_52: GovJsonKey.SUPECOM,
-    GSTR1_SubCategory.SUPECOM_9_5: GovJsonKey.SUPECOM,
-}
-
-JSON_CATEGORY_EXCEL_CATEGORY_MAPPING = {
-    GovJsonKey.B2B.value: GovExcelSheetName.B2B.value,
-    GovJsonKey.EXP.value: GovExcelSheetName.EXP.value,
-    GovJsonKey.B2CL.value: GovExcelSheetName.B2CL.value,
-    GovJsonKey.B2CS.value: GovExcelSheetName.B2CS.value,
-    GovJsonKey.NIL_EXEMPT.value: GovExcelSheetName.NIL_EXEMPT.value,
-    GovJsonKey.CDNR.value: GovExcelSheetName.CDNR.value,
-    GovJsonKey.CDNUR.value: GovExcelSheetName.CDNUR.value,
-    GovJsonKey.AT.value: GovExcelSheetName.AT.value,
-    GovJsonKey.TXP.value: GovExcelSheetName.TXP.value,
-    GovJsonKey.HSN.value: GovExcelSheetName.HSN.value,
-    GovJsonKey.DOC_ISSUE.value: GovExcelSheetName.DOC_ISSUE.value,
-    GovJsonKey.SUPECOM.value: GovExcelSheetName.SUPECOM.value,
-    # only for excel
-    HSNKey.HSN_B2B.value: GovExcelSheetName.HSN_B2B.value,
-    HSNKey.HSN_B2C.value: GovExcelSheetName.HSN_B2C.value,
-}
-
-
-class GSTR1_B2B_InvoiceType(Enum):
-    R = "Regular B2B"
-    SEWP = "SEZ supplies with payment"
-    SEWOP = "SEZ supplies without payment"
-    DE = "Deemed Exp"
-
-
-SUBCATEGORIES_NOT_CONSIDERED_IN_TOTAL_TAXABLE_VALUE = [
-    GSTR1_SubCategory.HSN.value,  # Backwards Compatibility
-    GSTR1_SubCategory.HSN_B2B.value,
-    GSTR1_SubCategory.HSN_B2C.value,
-    GSTR1_SubCategory.DOC_ISSUE.value,
-    GSTR1_SubCategory.SUPECOM_52.value,
-]
-
-SUBCATEGORIES_NOT_CONSIDERED_IN_TOTAL_TAX = [
-    GSTR1_SubCategory.B2B_REVERSE_CHARGE.value,
-    GSTR1_SubCategory.SUPECOM_9_5.value,
-    *SUBCATEGORIES_NOT_CONSIDERED_IN_TOTAL_TAXABLE_VALUE,
-]
-
+from india_compliance.gst_returns.fields.gstr1 import (  # noqa: F401
+    B2BInvoiceType as GSTR1_B2B_InvoiceType,
+)
+from india_compliance.gst_returns.fields.gstr1 import (  # noqa: F401
+    Category as GSTR1_Category,
+)
+from india_compliance.gst_returns.fields.gstr1 import (  # noqa: F401
+    DocField as GSTR1_DataField,
+)
+from india_compliance.gst_returns.fields.gstr1 import (  # noqa: F401
+    ExcelLabel as GovExcelField,
+)
+from india_compliance.gst_returns.fields.gstr1 import (  # noqa: F401
+    ItemField as GSTR1_ItemField,
+)
+from india_compliance.gst_returns.fields.gstr1 import (  # noqa: F401
+    JsonKey as GovJsonKey,
+)
+from india_compliance.gst_returns.fields.gstr1 import (  # noqa: F401
+    RawField as GovDataField,
+)
+from india_compliance.gst_returns.fields.gstr1 import (  # noqa: F401
+    SheetName as GovExcelSheetName,
+)
+from india_compliance.gst_returns.fields.gstr1 import (  # noqa: F401
+    SubCategory as GSTR1_SubCategory,
+)
 
 HSN_BIFURCATION_FROM = getdate("2025-05-01")
 

--- a/india_compliance/gst_india/utils/gstr_2/__init__.py
+++ b/india_compliance/gst_india/utils/gstr_2/__init__.py
@@ -1,5 +1,3 @@
-from enum import Enum
-
 import frappe
 from frappe import _
 from frappe.query_builder.terms import Criterion
@@ -25,30 +23,7 @@ from india_compliance.gst_india.utils import (
 )
 from india_compliance.gst_india.utils.gstr_2 import gstr_2a, gstr_2b, ims
 from india_compliance.gst_india.utils.gstr_utils import ReturnType
-
-
-class GSTRCategory(Enum):
-    B2B = "B2B"
-    B2BA = "B2BA"
-    CDNR = "CDNR"
-    CDNRA = "CDNRA"
-    ISD = "ISD"
-    ISDA = "ISDA"  # for GSTR 2B only
-    IMPG = "IMPG"
-    IMPGSEZ = "IMPGSEZ"
-
-    # IMS
-    B2BCN = "B2BCN"
-    B2BCNA = "B2BCNA"
-    B2BDN = "B2BDN"
-    B2BDNA = "B2BDNA"
-
-    # GSTR 2A only
-    ECOM = "ECOM"
-    ECOMA = "ECOMA"
-    TDS = "TDS"
-    TCS = "TCS"
-
+from india_compliance.gst_returns.fields.gstr2 import Category as GSTRCategory
 
 GSTR_2A_ACTIONS = {
     "B2B": GSTRCategory.B2B,

--- a/india_compliance/gst_india/utils/itc_04/__init__.py
+++ b/india_compliance/gst_india/utils/itc_04/__init__.py
@@ -1,79 +1,19 @@
-from enum import Enum
-
-
-class GovJsonKey(Enum):
-    """
-    Categories / Keys as per Govt JSON file
-    """
-
-    FG_RECEIVED = "table5A"
-    RM_SENT = "m2jw"
-
-
-class ITC04JsonKey(Enum):
-    """
-    Categories / Keys as per Internal JSON file
-    """
-
-    FG_RECEIVED = "FG Received"
-    RM_SENT = "RM Sent"
-
-
-class GovDataField(Enum):
-    JOB_WORKER_GSTIN = "ctin"
-    JOB_WORKER_STATE_CODE = "jw_stcd"
-    ITEMS = "items"
-    ORIGINAL_CHALLAN_NUMBER = "o_chnum"
-    ORIGINAL_CHALLAN_DATE = "o_chdt"
-    JOB_WORK_CHALLAN_NUMBER = "jw2_chnum"
-    JOB_WORK_CHALLAN_DATE = "jw2_chdt"
-    NATURE_OF_JOB = "nat_jw"
-    UOM = "uqc"
-    QUANTITY = "qty"
-    DESCRIPTION = "desc"
-    TAXABLE_VALUE = "txval"
-    GOODS_TYPE = "goods_ty"
-    IGST = "tx_i"
-    CGST = "tx_c"
-    SGST = "tx_s"
-    CESS_AMOUNT = "tx_cs"
-    FLAG = "flag"
-    LOST_QUANTITY = "lwqty"
-    LOST_UOM = "lwuqc"
-
-
-class GovDataField_SE(Enum):
-    ITEMS = "itms"
-    ORIGINAL_CHALLAN_NUMBER = "chnum"
-    ORIGINAL_CHALLAN_DATE = "chdt"
-
-
-class ITC04_DataField(Enum):
-    JOB_WORKER_GSTIN = "supplier_gstin"
-    JOB_WORKER_STATE_CODE = "jw_state_code"
-    ITEMS = "items"
-    ORIGINAL_CHALLAN_NUMBER = "original_challan_number"
-    ORIGINAL_CHALLAN_DATE = "original_challan_date"
-    JOB_WORK_CHALLAN_NUMBER = "jw_challan_number"
-    JOB_WORK_CHALLAN_DATE = "jw_challan_date"
-    TAXABLE_VALUE = "total_taxable_value"
-    IGST = "total_igst_rate"
-    CGST = "total_cgst_rate"
-    SGST = "total_sgst_rate"
-    CESS_AMOUNT = "total_cess_amount"
-    FLAG = "flag"
-
-
-class ITC04_ItemField(Enum):
-    NATURE_OF_JOB = "nature_of_job"
-    UOM = "uom"
-    QUANTITY = "qty"
-    DESCRIPTION = "desc"
-    TAXABLE_VALUE = "taxable_value"
-    GOODS_TYPE = "goods_type"
-    IGST = "igst_rate"
-    CGST = "cgst_rate"
-    SGST = "sgst_rate"
-    CESS_AMOUNT = "cess_amount"
-    LOST_QUANTITY = "lost_qty"
-    LOST_UOM = "lost_uom"
+# Constants moved to the pure package; re-exported here under legacy names.
+from india_compliance.gst_returns.fields.itc04 import (  # noqa: F401
+    Category as ITC04JsonKey,
+)
+from india_compliance.gst_returns.fields.itc04 import (  # noqa: F401
+    DocField as ITC04_DataField,
+)
+from india_compliance.gst_returns.fields.itc04 import (  # noqa: F401
+    ItemField as ITC04_ItemField,
+)
+from india_compliance.gst_returns.fields.itc04 import (  # noqa: F401
+    JsonKey as GovJsonKey,
+)
+from india_compliance.gst_returns.fields.itc04 import (  # noqa: F401
+    RawField as GovDataField,
+)
+from india_compliance.gst_returns.fields.itc04 import (  # noqa: F401
+    RawFieldSE as GovDataField_SE,
+)

--- a/india_compliance/gst_returns/fields/gstr1.py
+++ b/india_compliance/gst_returns/fields/gstr1.py
@@ -1,0 +1,346 @@
+"""GSTR-1 constants. Pure, no frappe."""
+
+from enum import Enum
+
+
+class Category(Enum):
+    # overview page
+    B2B = "B2B, SEZ, DE"
+    EXP = "Exports"
+    B2CL = "B2C (Large)"
+    B2CS = "B2C (Others)"
+    NIL_EXEMPT = "Nil-Rated, Exempted, Non-GST"
+    CDNR = "Credit/Debit Notes (Registered)"
+    CDNUR = "Credit/Debit Notes (Unregistered)"
+    AT = "Advances Received"
+    TXP = "Advances Adjusted"
+    HSN = "HSN Summary"
+    DOC_ISSUE = "Document Issued"
+    SUPECOM = "Supplies made through E-commerce Operators"
+    ECOM_RCM = "Supplies through E-commerce Operators u/s 9(5)"
+
+
+class SubCategory(Enum):
+    # summary page
+    B2B_REGULAR = "B2B Regular"
+    B2B_REVERSE_CHARGE = "B2B Reverse Charge"
+    SEZWP = "SEZ With Payment of Tax"
+    SEZWOP = "SEZ Without Payment of Tax"
+    DE = "Deemed Exports"
+    EXPWP = "Export With Payment of Tax"
+    EXPWOP = "Export Without Payment of Tax"
+    B2CL = "B2C (Large)"
+    B2CS = "B2C (Others)"
+    NIL_EXEMPT = "Nil-Rated, Exempted, Non-GST"
+    CDNR = "Credit/Debit Notes (Registered)"
+    CDNUR = "Credit/Debit Notes (Unregistered)"
+    AT = "Advances Received"
+    TXP = "Advances Adjusted"
+    HSN = "HSN Summary"  # back-compat
+    HSN_B2B = "HSN Summary - B2B"
+    HSN_B2C = "HSN Summary - B2C"
+    DOC_ISSUE = "Document Issued"
+    SUPECOM_52 = "Liable to collect tax u/s 52(TCS)"
+    SUPECOM_9_5 = "Liable to pay tax u/s 9(5)"
+
+
+class SUPECOM(Enum):
+    US_9_5 = "Liable to pay tax u/s 9(5)"
+    US_52 = "Liable to collect tax u/s 52(TCS)"
+
+
+class DocField:
+    # canonical names
+    TRANSACTION_TYPE = "transaction_type"
+    CUST_GSTIN = "customer_gstin"
+    ECOMMERCE_GSTIN = "ecommerce_gstin"
+    ECOMMERCE_OPERATOR_NAME = "ecommerce_operator_name"
+    CUST_NAME = "customer_name"
+    DOC_DATE = "document_date"
+    DOC_NUMBER = "document_number"
+    DOC_TYPE = "document_type"
+    DOC_VALUE = "document_value"
+    POS = "place_of_supply"
+    DIFF_PERCENTAGE = "diff_percentage"
+    REVERSE_CHARGE = "reverse_charge"
+    TAXABLE_VALUE = "total_taxable_value"
+    ITEMS = "items"
+    IGST = "total_igst_amount"
+    CGST = "total_cgst_amount"
+    SGST = "total_sgst_amount"
+    CESS = "total_cess_amount"
+    TAX_RATE = "tax_rate"
+
+    SHIPPING_BILL_NUMBER = "shipping_bill_number"
+    SHIPPING_BILL_DATE = "shipping_bill_date"
+    SHIPPING_PORT_CODE = "shipping_port_code"
+
+    EXEMPTED_AMOUNT = "exempted_amount"
+    NIL_RATED_AMOUNT = "nil_rated_amount"
+    NON_GST_AMOUNT = "non_gst_amount"
+
+    HSN_CODE = "hsn_code"
+    DESCRIPTION = "description"
+    UOM = "uom"
+    QUANTITY = "quantity"
+
+    FROM_SR = "from_sr_no"
+    TO_SR = "to_sr_no"
+    TOTAL_COUNT = "total_count"
+    DRAFT_COUNT = "draft_count"
+    CANCELLED_COUNT = "cancelled_count"
+    NET_ISSUE = "net_issue"
+    UPLOAD_STATUS = "upload_status"
+
+    ERROR_CD = "error_code"
+    ERROR_MSG = "error_message"
+
+
+class ItemField:
+    INDEX = "idx"
+    TAXABLE_VALUE = "taxable_value"
+    IGST = "igst_amount"
+    CGST = "cgst_amount"
+    SGST = "sgst_amount"
+    CESS = "cess_amount"
+    TAX_RATE = "tax_rate"
+    ITEM_DETAILS = "item_details"
+    ADDITIONAL_AMOUNT = "additional_amount"
+
+
+class RawField:
+    # portal JSON keys
+    CUST_GSTIN = "ctin"
+    ECOMMERCE_GSTIN = "etin"
+    DOC_DATE = "idt"
+    DOC_NUMBER = "inum"
+    DOC_VALUE = "val"
+    POS = "pos"
+    DIFF_PERCENTAGE = "diff_percent"
+    REVERSE_CHARGE = "rchrg"
+    TAXABLE_VALUE = "txval"
+    ITEMS = "itms"
+    IGST = "iamt"
+    CGST = "camt"
+    SGST = "samt"
+    CESS = "csamt"
+    TAX_RATE = "rt"
+    ITEM_DETAILS = "itm_det"
+    SHIPPING_BILL_NUMBER = "sbnum"
+    SHIPPING_BILL_DATE = "sbdt"
+    SHIPPING_PORT_CODE = "sbpcode"
+    SUPPLY_TYPE = "sply_ty"
+    NET_TAXABLE_VALUE = "suppval"
+
+    EXEMPTED_AMOUNT = "expt_amt"
+    NIL_RATED_AMOUNT = "nil_amt"
+    NON_GST_AMOUNT = "ngsup_amt"
+
+    HSN_DATA = "data"  # back-compat
+    HSN_CODE = "hsn_sc"
+    DESCRIPTION = "desc"
+    UOM = "uqc"
+    QUANTITY = "qty"
+    ADVANCE_AMOUNT = "ad_amt"
+
+    INDEX = "num"
+    FROM_SR = "from"
+    TO_SR = "to"
+    TOTAL_COUNT = "totnum"
+    CANCELLED_COUNT = "cancel"
+    DOC_ISSUE_DETAILS = "doc_det"
+    DOC_ISSUE_NUMBER = "doc_num"
+    DOC_ISSUE_LIST = "docs"
+    NET_ISSUE = "net_issue"
+
+    INVOICE_TYPE = "inv_typ"
+    INVOICES = "inv"
+    EXPORT_TYPE = "exp_typ"
+    TYPE = "typ"
+
+    NOTE_TYPE = "ntty"
+    NOTE_NUMBER = "nt_num"
+    NOTE_DATE = "nt_dt"
+    NOTE_DETAILS = "nt"
+
+    SUPECOM_52 = "clttx"
+    SUPECOM_9_5 = "paytx"
+
+    HSN_B2B = "hsn_b2b"
+    HSN_B2C = "hsn_b2c"
+
+    ERROR_CD = "error_cd"
+    ERROR_MSG = "error_msg"
+
+    FLAG = "flag"
+    CHECKSUM = "chksum"
+
+
+class ExcelLabel:
+    # column headers
+    CUST_GSTIN = "GSTIN/UIN of Recipient"
+    CUST_NAME = "Receiver Name"
+    INVOICE_NUMBER = "Invoice Number"
+    INVOICE_DATE = "Invoice date"
+    INVOICE_VALUE = "Invoice Value"
+    POS = "Place Of Supply"
+    REVERSE_CHARGE = "Reverse Charge"
+    DIFF_PERCENTAGE = "Applicable % of Tax Rate"
+    INVOICE_TYPE = "Invoice Type"
+    TAXABLE_VALUE = "Taxable Value"
+    ECOMMERCE_GSTIN = "E-Commerce GSTIN"
+    TAX_RATE = "Rate"
+    IGST = "Integrated Tax Amount"
+    CGST = "Central Tax Amount"
+    SGST = "State/UT Tax Amount"
+    CESS = "Cess Amount"
+
+    NOTE_NO = "Note Number"
+    NOTE_DATE = "Note Date"
+    NOTE_TYPE = "Note Type"
+    NOTE_VALUE = "Note Value"
+
+    PORT_CODE = "Port Code"
+    SHIPPING_BILL_NO = "Shipping Bill Number"
+    SHIPPING_BILL_DATE = "Shipping Bill Date"
+
+    DESCRIPTION = "Description"
+
+    HSN_CODE = "HSN"
+    UOM = "UQC"
+    QUANTITY = "Total Quantity"
+    TOTAL_VALUE = "Total Value"
+
+
+class JsonKey(Enum):
+    # top-level keys in gov JSON
+    B2B = "b2b"
+    EXP = "exp"
+    B2CL = "b2cl"
+    B2CS = "b2cs"
+    NIL_EXEMPT = "nil"
+    CDNR = "cdnr"
+    CDNUR = "cdnur"
+    AT = "at"
+    TXP = "txpd"
+    HSN = "hsn"
+    DOC_ISSUE = "doc_issue"
+    SUPECOM = "supeco"
+    RET_SUM = "sec_sum"
+
+
+class HSNKey(Enum):
+    # excel only
+    HSN = "hsn"
+    HSN_B2B = "hsn_b2b"
+    HSN_B2C = "hsn_b2c"
+
+
+class SheetName(Enum):
+    # gov excel worksheets
+    B2B = "b2b,sez,de"
+    EXP = "exp"
+    B2CL = "b2cl"
+    B2CS = "b2cs"
+    NIL_EXEMPT = "exemp"
+    CDNR = "cdnr"
+    CDNUR = "cdnur"
+    AT = "at"
+    TXP = "atadj"
+    HSN = "hsn"
+    HSN_B2B = "hsn(b2b)"
+    HSN_B2C = "hsn(b2c)"
+    DOC_ISSUE = "docs"
+    SUPECOM = "eco"
+    MASTER = "master"
+
+
+class B2BInvoiceType(Enum):
+    R = "Regular B2B"
+    SEWP = "SEZ supplies with payment"
+    SEWOP = "SEZ supplies without payment"
+    DE = "Deemed Exp"
+
+
+CATEGORY_SUB_CATEGORY_MAPPING = {
+    Category.B2B: (
+        SubCategory.B2B_REGULAR,
+        SubCategory.B2B_REVERSE_CHARGE,
+        SubCategory.SEZWP,
+        SubCategory.SEZWOP,
+        SubCategory.DE,
+    ),
+    Category.B2CL: (SubCategory.B2CL,),
+    Category.EXP: (SubCategory.EXPWP, SubCategory.EXPWOP),
+    Category.B2CS: (SubCategory.B2CS,),
+    Category.NIL_EXEMPT: (SubCategory.NIL_EXEMPT,),
+    Category.CDNR: (SubCategory.CDNR,),
+    Category.CDNUR: (SubCategory.CDNUR,),
+    Category.AT: (SubCategory.AT,),
+    Category.TXP: (SubCategory.TXP,),
+    Category.DOC_ISSUE: (SubCategory.DOC_ISSUE,),
+    Category.HSN: (SubCategory.HSN_B2B, SubCategory.HSN_B2C),
+    Category.SUPECOM: (SubCategory.SUPECOM_52, SubCategory.SUPECOM_9_5),
+}
+
+# back-compat
+PREVIOUS_VERSION = {Category.HSN.value: (SubCategory.HSN,)}
+
+SUB_CATEGORY_GOV_CATEGORY_MAPPING = {
+    SubCategory.B2B_REGULAR: JsonKey.B2B,
+    SubCategory.B2B_REVERSE_CHARGE: JsonKey.B2B,
+    SubCategory.SEZWP: JsonKey.B2B,
+    SubCategory.SEZWOP: JsonKey.B2B,
+    SubCategory.DE: JsonKey.B2B,
+    SubCategory.B2CL: JsonKey.B2CL,
+    SubCategory.EXPWP: JsonKey.EXP,
+    SubCategory.EXPWOP: JsonKey.EXP,
+    SubCategory.B2CS: JsonKey.B2CS,
+    SubCategory.NIL_EXEMPT: JsonKey.NIL_EXEMPT,
+    SubCategory.CDNR: JsonKey.CDNR,
+    SubCategory.CDNUR: JsonKey.CDNUR,
+    SubCategory.AT: JsonKey.AT,
+    SubCategory.TXP: JsonKey.TXP,
+    SubCategory.DOC_ISSUE: JsonKey.DOC_ISSUE,
+    SubCategory.HSN: JsonKey.HSN,  # back-compat
+    SubCategory.HSN_B2B: JsonKey.HSN,
+    SubCategory.HSN_B2C: JsonKey.HSN,
+    SubCategory.SUPECOM_52: JsonKey.SUPECOM,
+    SubCategory.SUPECOM_9_5: JsonKey.SUPECOM,
+}
+
+JSON_CATEGORY_EXCEL_CATEGORY_MAPPING = {
+    JsonKey.B2B.value: SheetName.B2B.value,
+    JsonKey.EXP.value: SheetName.EXP.value,
+    JsonKey.B2CL.value: SheetName.B2CL.value,
+    JsonKey.B2CS.value: SheetName.B2CS.value,
+    JsonKey.NIL_EXEMPT.value: SheetName.NIL_EXEMPT.value,
+    JsonKey.CDNR.value: SheetName.CDNR.value,
+    JsonKey.CDNUR.value: SheetName.CDNUR.value,
+    JsonKey.AT.value: SheetName.AT.value,
+    JsonKey.TXP.value: SheetName.TXP.value,
+    JsonKey.HSN.value: SheetName.HSN.value,
+    JsonKey.DOC_ISSUE.value: SheetName.DOC_ISSUE.value,
+    JsonKey.SUPECOM.value: SheetName.SUPECOM.value,
+    HSNKey.HSN_B2B.value: SheetName.HSN_B2B.value,
+    HSNKey.HSN_B2C.value: SheetName.HSN_B2C.value,
+}
+
+QUARTERLY_KEYS = (
+    "already_included_docs_for_quarterly",
+    "excluded_docs_for_quarterly",
+)
+
+SUBCATEGORIES_NOT_CONSIDERED_IN_TOTAL_TAXABLE_VALUE = [
+    SubCategory.HSN.value,  # back-compat
+    SubCategory.HSN_B2B.value,
+    SubCategory.HSN_B2C.value,
+    SubCategory.DOC_ISSUE.value,
+    SubCategory.SUPECOM_52.value,
+]
+
+SUBCATEGORIES_NOT_CONSIDERED_IN_TOTAL_TAX = [
+    SubCategory.B2B_REVERSE_CHARGE.value,
+    SubCategory.SUPECOM_9_5.value,
+    *SUBCATEGORIES_NOT_CONSIDERED_IN_TOTAL_TAXABLE_VALUE,
+]

--- a/india_compliance/gst_returns/fields/gstr2.py
+++ b/india_compliance/gst_returns/fields/gstr2.py
@@ -1,0 +1,26 @@
+"""GSTR-2A/2B/IMS categories. Raw/Doc/Item fields are raw literals in mappers, extracted in PR-6."""
+
+from enum import Enum
+
+
+class Category(Enum):
+    B2B = "B2B"
+    B2BA = "B2BA"
+    CDNR = "CDNR"
+    CDNRA = "CDNRA"
+    ISD = "ISD"
+    ISDA = "ISDA"  # 2B only
+    IMPG = "IMPG"
+    IMPGSEZ = "IMPGSEZ"
+
+    # IMS
+    B2BCN = "B2BCN"
+    B2BCNA = "B2BCNA"
+    B2BDN = "B2BDN"
+    B2BDNA = "B2BDNA"
+
+    # 2A only
+    ECOM = "ECOM"
+    ECOMA = "ECOMA"
+    TDS = "TDS"
+    TCS = "TCS"

--- a/india_compliance/gst_returns/fields/gstr3b.py
+++ b/india_compliance/gst_returns/fields/gstr3b.py
@@ -1,0 +1,1 @@
+"""GSTR-3B constants. None today (raw literals in code); will be filled in later PRs."""

--- a/india_compliance/gst_returns/fields/ims.py
+++ b/india_compliance/gst_returns/fields/ims.py
@@ -1,0 +1,3 @@
+"""IMS constants. Shares gstr2.Category; own fields are raw literals in mappers, extracted in future PRs."""
+
+from .gstr2 import Category  # noqa: F401

--- a/india_compliance/gst_returns/fields/ims.py
+++ b/india_compliance/gst_returns/fields/ims.py
@@ -1,3 +1,1 @@
 """IMS constants. Shares gstr2.Category; own fields are raw literals in mappers, extracted in future PRs."""
-
-from .gstr2 import Category  # noqa: F401

--- a/india_compliance/gst_returns/fields/itc04.py
+++ b/india_compliance/gst_returns/fields/itc04.py
@@ -1,0 +1,76 @@
+"""ITC-04 constants. Pure, no frappe. (Fields are Enums here, matching source access via .value.)"""
+
+from enum import Enum
+
+
+class JsonKey(Enum):
+    # portal keys
+    FG_RECEIVED = "table5A"
+    RM_SENT = "m2jw"
+
+
+class Category(Enum):
+    # internal section names
+    FG_RECEIVED = "FG Received"
+    RM_SENT = "RM Sent"
+
+
+class RawField(Enum):
+    JOB_WORKER_GSTIN = "ctin"
+    JOB_WORKER_STATE_CODE = "jw_stcd"
+    ITEMS = "items"
+    ORIGINAL_CHALLAN_NUMBER = "o_chnum"
+    ORIGINAL_CHALLAN_DATE = "o_chdt"
+    JOB_WORK_CHALLAN_NUMBER = "jw2_chnum"
+    JOB_WORK_CHALLAN_DATE = "jw2_chdt"
+    NATURE_OF_JOB = "nat_jw"
+    UOM = "uqc"
+    QUANTITY = "qty"
+    DESCRIPTION = "desc"
+    TAXABLE_VALUE = "txval"
+    GOODS_TYPE = "goods_ty"
+    IGST = "tx_i"
+    CGST = "tx_c"
+    SGST = "tx_s"
+    CESS_AMOUNT = "tx_cs"
+    FLAG = "flag"
+    LOST_QUANTITY = "lwqty"
+    LOST_UOM = "lwuqc"
+
+
+class RawFieldSE(Enum):
+    # RM-sent overrides
+    ITEMS = "itms"
+    ORIGINAL_CHALLAN_NUMBER = "chnum"
+    ORIGINAL_CHALLAN_DATE = "chdt"
+
+
+class DocField(Enum):
+    JOB_WORKER_GSTIN = "supplier_gstin"
+    JOB_WORKER_STATE_CODE = "jw_state_code"
+    ITEMS = "items"
+    ORIGINAL_CHALLAN_NUMBER = "original_challan_number"
+    ORIGINAL_CHALLAN_DATE = "original_challan_date"
+    JOB_WORK_CHALLAN_NUMBER = "jw_challan_number"
+    JOB_WORK_CHALLAN_DATE = "jw_challan_date"
+    TAXABLE_VALUE = "total_taxable_value"
+    IGST = "total_igst_rate"
+    CGST = "total_cgst_rate"
+    SGST = "total_sgst_rate"
+    CESS_AMOUNT = "total_cess_amount"
+    FLAG = "flag"
+
+
+class ItemField(Enum):
+    NATURE_OF_JOB = "nature_of_job"
+    UOM = "uom"
+    QUANTITY = "qty"
+    DESCRIPTION = "desc"
+    TAXABLE_VALUE = "taxable_value"
+    GOODS_TYPE = "goods_type"
+    IGST = "igst_rate"
+    CGST = "cgst_rate"
+    SGST = "sgst_rate"
+    CESS_AMOUNT = "cess_amount"
+    LOST_QUANTITY = "lost_qty"
+    LOST_UOM = "lost_uom"


### PR DESCRIPTION
### What

- Shared root for GST-returns field/section names.
- Old code untouched — old names still work.

### Note
- Only GSTR-1 and ITC-04 had reusable names today; moved those + the shared 2A/2B/IMS category list.
- 3B and the 2A/2B/IMS field names come later, where they're actually built.
- No behaviour change — same values, verified.


`PR-3 of refactor series`