### PR TITLE
fix: remove state based logic from patch

### DIFF
--- a/india_compliance/patches.txt
+++ b/india_compliance/patches.txt
@@ -87,7 +87,7 @@ india_compliance.patches.v16.update_tax_id_for_tax_withholding_entries
 india_compliance.patches.v16.sync_financial_report_templates
 india_compliance.patches.v16.update_tds_section_display_name
 execute:import frappe; frappe.db.set_single_value("GST Settings", "nil_exempt_e_invoice_treatment", "Do Not Generate")
-india_compliance.patches.post_install.set_india_compliance_default_tax_category
+india_compliance.patches.post_install.set_india_compliance_default_tax_category #1
 india_compliance.patches.post_install.remove_tax_category_gst_state
 india_compliance.patches.v16.remove_gstr_2a_category_preferences
 india_compliance.patches.v16.update_reconciliation_email_template_dates

--- a/india_compliance/patches/post_install/set_india_compliance_default_tax_category.py
+++ b/india_compliance/patches/post_install/set_india_compliance_default_tax_category.py
@@ -32,15 +32,14 @@ def execute():
 
     tax_categories = frappe.get_all(
         "Tax Category",
-        fields=["name", "is_inter_state", "is_reverse_charge", "gst_state"],
-        filters={"disabled": 0, "gst_state": ["is", "not set"]},
+        fields=["name", "is_inter_state", "is_reverse_charge"],
+        filters={"disabled": 0, "name": ["in", list(used_categories)]},
+        order_by="creation desc",
     )
 
     defaults = []
     for is_inter_state, is_reverse_charge in DEFAULT_SCENARIOS:
-        category = get_default_tax_category(
-            tax_categories, used_categories, is_inter_state, is_reverse_charge
-        )
+        category = get_default_tax_category(tax_categories, is_inter_state, is_reverse_charge)
         if category:
             defaults.append(category)
 
@@ -53,13 +52,9 @@ def execute():
     ).run()
 
 
-def get_default_tax_category(categories, used_categories, is_inter_state, is_reverse_charge):
+def get_default_tax_category(categories, is_inter_state, is_reverse_charge):
     for category in categories:
-        if (
-            category.is_inter_state == is_inter_state
-            and category.is_reverse_charge == is_reverse_charge
-            and category.name in used_categories
-        ):
+        if category.is_inter_state == is_inter_state and category.is_reverse_charge == is_reverse_charge:
             return category.name
 
     return None

--- a/india_compliance/patches/post_install/set_india_compliance_default_tax_category.py
+++ b/india_compliance/patches/post_install/set_india_compliance_default_tax_category.py
@@ -1,3 +1,4 @@
+import click
 import frappe
 
 TEMPLATE_DOCTYPES = (
@@ -5,19 +6,22 @@ TEMPLATE_DOCTYPES = (
     "Purchase Taxes and Charges Template",
 )
 
-DEFAULT_SCENARIOS = ((0, 0), (1, 0), (0, 1), (1, 1))
+#: (is_inter_state, is_reverse_charge) -> what the combination is commonly called
+DEFAULT_SCENARIOS = {
+    (0, 0): "In-State",
+    (1, 0): "Out-State",
+    (0, 1): "Reverse Charge In-State",
+    (1, 1): "Reverse Charge Out-State",
+}
 
 
 def execute():
     """Backfill the `is_india_compliance_default` flag on Tax Categories.
 
     Automatic GST tax template selection now only considers Tax Categories flagged as
-    India Compliance defaults.
+    India Compliance defaults. Combinations that already have one are left as they are.
     """
     if not frappe.db.has_column("Tax Category", "is_india_compliance_default"):
-        return
-
-    if frappe.db.exists("Tax Category", {"is_india_compliance_default": 1}):
         return
 
     used_categories = set()
@@ -38,10 +42,30 @@ def execute():
     )
 
     defaults = []
-    for is_inter_state, is_reverse_charge in DEFAULT_SCENARIOS:
+    for (is_inter_state, is_reverse_charge), scenario in DEFAULT_SCENARIOS.items():
+        if frappe.db.exists(
+            "Tax Category",
+            {
+                "is_india_compliance_default": 1,
+                "is_inter_state": is_inter_state,
+                "is_reverse_charge": is_reverse_charge,
+                "disabled": 0,
+            },
+        ):
+            continue
+
         category = get_default_tax_category(tax_categories, is_inter_state, is_reverse_charge)
-        if category:
-            defaults.append(category)
+
+        if not category:
+            click.secho(
+                f"No Tax Category could be set as the India Compliance Default for {scenario}"
+                " transactions. Please set it manually to use automatic GST tax template"
+                " selection.",
+                fg="yellow",
+            )
+            continue
+
+        defaults.append(category)
 
     if not defaults:
         return


### PR DESCRIPTION
Closes: https://github.com/resilient-tech/india-compliance/issues/4745
Issue: Users were using state-based categories, due to which these categories were ignored.

- This still doesn't completely resolve the issue because an incorrect category can be set, as categories may match using state.
- We are considering it as an exception.
- Also, increased the patch counter as the previous patch was skipped because we forgot to create the custom field.
