### PR TITLE
fix: `Sales Order`'s `GST Details` section now correctly renders in `More Info` tab

### DIFF
--- a/india_compliance/gst_india/constants/custom_fields.py
+++ b/india_compliance/gst_india/constants/custom_fields.py
@@ -511,15 +511,17 @@ CUSTOM_FIELDS = {
         "translatable": 0,
     },
     # Sales - GST Details Section
-    ("Sales Order", "Delivery Note", "Sales Invoice"): [
+    "Sales Order": [
         {
             "fieldname": "gst_section",
             "label": "GST Details",
             "fieldtype": "Section Break",
-            "insert_after": "gst_vehicle_type",
+            "insert_after": "language",
             "print_hide": 1,
             "collapsible": 1,
         },
+    ],
+    ("Sales Order", "Delivery Note", "Sales Invoice"): [
         {
             "fieldname": "ecommerce_gstin",
             "label": "E-commerce GSTIN",
@@ -616,8 +618,17 @@ CUSTOM_FIELDS = {
             "translatable": 0,
         },
     ],
-    # Sales Shipping Fields
     ("Delivery Note", "Sales Invoice"): [
+        # Sales - GST Details Section
+        {
+            "fieldname": "gst_section",
+            "label": "GST Details",
+            "fieldtype": "Section Break",
+            "insert_after": "gst_vehicle_type",
+            "print_hide": 1,
+            "collapsible": 1,
+        },
+        # Sales Shipping Fields
         {
             "fieldname": "port_address",
             "label": "Origin Port / Border Checkpost Address Name",

--- a/india_compliance/patches.txt
+++ b/india_compliance/patches.txt
@@ -5,7 +5,7 @@ execute:from frappe.installer import add_module_defs; add_module_defs("india_com
 
 [post_model_sync]
 india_compliance.patches.v14.set_default_for_overridden_accounts_setting
-execute:from india_compliance.gst_india.setup import create_custom_fields; create_custom_fields() #75
+execute:from india_compliance.gst_india.setup import create_custom_fields; create_custom_fields() #76
 execute:from india_compliance.gst_india.setup import create_property_setters; create_property_setters() #14
 execute:from india_compliance.income_tax_india.setup import create_custom_fields; create_custom_fields() #8
 india_compliance.patches.post_install.remove_old_fields #2


### PR DESCRIPTION
Fixes https://github.com/resilient-tech/india-compliance/issues/4720

### Before
<img width="1460" height="814" alt="Screenshot 2026-08-10 at 12 38 04 PM" src="https://github.com/user-attachments/assets/d7386614-970d-4168-9f2a-68822d826fd6" />

### After
<img width="733" height="415" alt="Screenshot 2026-08-10 at 12 36 38 PM" src="https://github.com/user-attachments/assets/eb732672-b837-428e-9b62-3dcc5f872084" />

