### PR TITLE
fix: convert HSN field in transactions to `Autocomplete`

### DIFF
--- a/india_compliance/gst_india/constants/custom_fields.py
+++ b/india_compliance/gst_india/constants/custom_fields.py
@@ -685,7 +685,7 @@ CUSTOM_FIELDS = {
         {
             "fieldname": "gst_hsn_code",
             "label": "HSN/SAC",
-            "fieldtype": "Data",
+            "fieldtype": "Autocomplete",
             "fetch_from": "item_code.gst_hsn_code",
             "insert_after": "description",
             "allow_on_submit": 1,
@@ -807,7 +807,7 @@ CUSTOM_FIELDS = {
         {
             "fieldname": "gst_hsn_code",
             "label": "HSN/SAC",
-            "fieldtype": "Data",
+            "fieldtype": "Autocomplete",
             "fetch_from": "item_code.gst_hsn_code",
             "insert_after": "description",
             "allow_on_submit": 1,

--- a/india_compliance/gst_india/constants/custom_fields.py
+++ b/india_compliance/gst_india/constants/custom_fields.py
@@ -47,6 +47,18 @@ party_fields = [
     },
 ]
 
+transaction_hsn_code_field = {
+    "fieldname": "gst_hsn_code",
+    "label": "HSN/SAC",
+    "fieldtype": "Autocomplete",
+    "fetch_from": "item_code.gst_hsn_code",
+    "insert_after": "description",
+    "allow_on_submit": 1,
+    "print_hide": 1,
+    "fetch_if_empty": 1,
+    "translatable": 0,
+}
+
 CUSTOM_FIELDS = {
     # Subcontracting: Tax Fields
     "Subcontracting Order": [
@@ -681,19 +693,7 @@ CUSTOM_FIELDS = {
         }
     ],
     # Transaction Item: Tax Fields
-    "Material Request Item": [
-        {
-            "fieldname": "gst_hsn_code",
-            "label": "HSN/SAC",
-            "fieldtype": "Autocomplete",
-            "fetch_from": "item_code.gst_hsn_code",
-            "insert_after": "description",
-            "allow_on_submit": 1,
-            "print_hide": 1,
-            "fetch_if_empty": 1,
-            "translatable": 0,
-        },
-    ],
+    "Material Request Item": [transaction_hsn_code_field],
     # Taxable Value
     (
         "Supplier Quotation Item",
@@ -804,17 +804,7 @@ CUSTOM_FIELDS = {
         "Stock Entry Detail",
         "Subcontracting Receipt Item",
     ): [
-        {
-            "fieldname": "gst_hsn_code",
-            "label": "HSN/SAC",
-            "fieldtype": "Autocomplete",
-            "fetch_from": "item_code.gst_hsn_code",
-            "insert_after": "description",
-            "allow_on_submit": 1,
-            "print_hide": 1,
-            "fetch_if_empty": 1,
-            "translatable": 0,
-        },
+        transaction_hsn_code_field,
         {
             "fieldname": "gst_treatment",
             "label": "GST Treatment",

--- a/india_compliance/gst_india/doctype/bill_of_entry/bill_of_entry.js
+++ b/india_compliance/gst_india/doctype/bill_of_entry/bill_of_entry.js
@@ -4,6 +4,7 @@
 frappe.ui.form.on("Bill of Entry", {
     setup(frm) {
         india_compliance.setup_itc_claim_period_query(frm);
+        india_compliance.set_hsn_code_autocomplete(frm);
     },
 
     onload(frm) {

--- a/india_compliance/gst_india/doctype/bill_of_entry_item/bill_of_entry_item.json
+++ b/india_compliance/gst_india/doctype/bill_of_entry_item/bill_of_entry_item.json
@@ -236,7 +236,7 @@
    "fetch_from": "item_code.gst_hsn_code",
    "fetch_if_empty": 1,
    "fieldname": "gst_hsn_code",
-   "fieldtype": "Data",
+   "fieldtype": "Autocomplete",
    "label": "HSN/SAC",
    "print_hide": 1
   },

--- a/india_compliance/gst_india/doctype/gst_hsn_code/test_gst_hsn_code.py
+++ b/india_compliance/gst_india/doctype/gst_hsn_code/test_gst_hsn_code.py
@@ -8,8 +8,13 @@ from frappe.tests import IntegrationTestCase, change_settings
 from india_compliance.gst_india.doctype.gst_hsn_code.gst_hsn_code import (
     update_taxes_in_item_master,
 )
+from india_compliance.gst_india.utils import get_hsn_code_list
 
 IGNORE_TEST_RECORD_DEPENDENCIES = ["Item Tax Template", "Tax Category"]
+
+FOUR_DIGIT_HSN = "0101"
+SIX_DIGIT_HSN = "010121"
+EIGHT_DIGIT_HSN = "01012100"
 
 
 class TestGSTHSNCode(IntegrationTestCase):
@@ -42,6 +47,31 @@ class TestGSTHSNCode(IntegrationTestCase):
 
         doc = frappe.get_doc({"doctype": "GST HSN Code", "hsn_code": "10000000"})
         doc.save()
+
+    @change_settings("GST Settings", {"validate_hsn_code": 1, "min_hsn_digits": 6})
+    def test_get_hsn_code_list_by_description(self):
+        # codes whose description matches, but which the code prefix search would miss
+        options = get_hsn_code_list(txt="HORSES FOR POLO", limit=100)
+        self.assertEqual([option.value for option in options], ["01012910", "01019010"])
+
+        # LIKE is case insensitive on MariaDB, and rendered as ILIKE on Postgres
+        self.assertEqual(options, get_hsn_code_list(txt="horses for polo", limit=100))
+
+    @change_settings("GST Settings", {"validate_hsn_code": 1, "min_hsn_digits": 8})
+    def test_get_hsn_code_list_respects_min_hsn_digits(self):
+        options = get_hsn_code_list(txt=FOUR_DIGIT_HSN, limit="100")
+        codes = [option.value for option in options]
+
+        self.assertIn(EIGHT_DIGIT_HSN, codes)
+        self.assertNotIn(FOUR_DIGIT_HSN, codes)
+        self.assertNotIn(SIX_DIGIT_HSN, codes)
+
+        option = options[0]
+        self.assertEqual(option.label, option.value)
+        self.assertEqual(
+            option.description,
+            frappe.db.get_value("GST HSN Code", option.value, "description"),
+        )
 
     def test_update_taxes_in_item_master(self):
         taxes = [{"item_tax_template": "GST 12% - _TIUC", "tax_category": "In-State"}]

--- a/india_compliance/gst_india/doctype/gst_hsn_code/test_gst_hsn_code.py
+++ b/india_compliance/gst_india/doctype/gst_hsn_code/test_gst_hsn_code.py
@@ -57,6 +57,21 @@ class TestGSTHSNCode(IntegrationTestCase):
         # LIKE is case insensitive on MariaDB, and rendered as ILIKE on Postgres
         self.assertEqual(options, get_hsn_code_list(txt="horses for polo", limit=100))
 
+    @change_settings("GST Settings", {"validate_hsn_code": 1, "min_hsn_digits": 6})
+    def test_get_hsn_code_list_excludes_invalid_lengths(self):
+        # no seeded code has an invalid length, so make one longer than min_hsn_digits
+        invalid_hsn = frappe.get_doc(
+            {"doctype": "GST HSN Code", "hsn_code": f"{FOUR_DIGIT_HSN}123", "description": "HORSES"}
+        )
+        invalid_hsn.flags.ignore_validate = True
+        invalid_hsn.insert(ignore_if_duplicate=True)
+        self.addCleanup(invalid_hsn.delete)
+
+        codes = [option.value for option in get_hsn_code_list(txt=FOUR_DIGIT_HSN, limit="100")]
+
+        self.assertIn(SIX_DIGIT_HSN, codes)
+        self.assertNotIn(invalid_hsn.name, codes)
+
     @change_settings("GST Settings", {"validate_hsn_code": 1, "min_hsn_digits": 8})
     def test_get_hsn_code_list_respects_min_hsn_digits(self):
         options = get_hsn_code_list(txt=FOUR_DIGIT_HSN, limit="100")

--- a/india_compliance/gst_india/utils/__init__.py
+++ b/india_compliance/gst_india/utils/__init__.py
@@ -13,6 +13,7 @@ from erpnext.stock.get_item_details import purchase_doctypes
 from frappe import _
 from frappe.contacts.doctype.contact.contact import get_contact_details
 from frappe.desk.form.load import get_docinfo, run_onload
+from frappe.query_builder.functions import Length
 from frappe.utils import (
     add_months,
     add_to_date,
@@ -501,9 +502,8 @@ def get_hsn_settings():
 
 @frappe.whitelist()
 def get_hsn_code_list(txt: str | None = None, limit: int = 20):
-    """
-    GST HSN Code is seeded public data, readable by all roles, hence no permission check.
-    """
+    # GST HSN Code is public data, hence no permission check.
+
     hsn_code = frappe.qb.DocType("GST HSN Code")
     query = (
         frappe.qb.from_(hsn_code)
@@ -514,7 +514,7 @@ def get_hsn_code_list(txt: str | None = None, limit: int = 20):
 
     validate_hsn_code, valid_hsn_length = get_hsn_settings()
     if validate_hsn_code and valid_hsn_length:
-        query = query.where(hsn_code.name.like("_" * min(valid_hsn_length) + "%"))
+        query = query.where(Length(hsn_code.name).isin(valid_hsn_length))
 
     if txt:
         query = query.where(hsn_code.name.like(f"{txt}%") | hsn_code.description.like(f"%{txt}%"))

--- a/india_compliance/gst_india/utils/__init__.py
+++ b/india_compliance/gst_india/utils/__init__.py
@@ -499,6 +499,29 @@ def get_hsn_settings():
     return validate_hsn_code, valid_hsn_length
 
 
+@frappe.whitelist()
+def get_hsn_code_list(txt: str | None = None, limit: int = 20):
+    """
+    GST HSN Code is seeded public data, readable by all roles, hence no permission check.
+    """
+    hsn_code = frappe.qb.DocType("GST HSN Code")
+    query = (
+        frappe.qb.from_(hsn_code)
+        .select(hsn_code.name.as_("value"), hsn_code.name.as_("label"), hsn_code.description)
+        .orderby(hsn_code.name)
+        .limit(cint(limit))
+    )
+
+    validate_hsn_code, valid_hsn_length = get_hsn_settings()
+    if validate_hsn_code and valid_hsn_length:
+        query = query.where(hsn_code.name.like("_" * min(valid_hsn_length) + "%"))
+
+    if txt:
+        query = query.where(hsn_code.name.like(f"{txt}%") | hsn_code.description.like(f"%{txt}%"))
+
+    return query.run(as_dict=True)
+
+
 def get_place_of_supply(party_details, doctype):
     """
     :param party_details: A frappe._dict or document containing fields related to party

--- a/india_compliance/patches.txt
+++ b/india_compliance/patches.txt
@@ -5,7 +5,7 @@ execute:from frappe.installer import add_module_defs; add_module_defs("india_com
 
 [post_model_sync]
 india_compliance.patches.v14.set_default_for_overridden_accounts_setting
-execute:from india_compliance.gst_india.setup import create_custom_fields; create_custom_fields() #75
+execute:from india_compliance.gst_india.setup import create_custom_fields; create_custom_fields() #76
 execute:from india_compliance.gst_india.setup import create_property_setters; create_property_setters() #14
 execute:from india_compliance.income_tax_india.setup import create_custom_fields; create_custom_fields() #8
 india_compliance.patches.post_install.remove_old_fields #2

--- a/india_compliance/public/js/transaction.js
+++ b/india_compliance/public/js/transaction.js
@@ -17,11 +17,22 @@ const SUBCONTRACTING_DOCTYPES = ["Stock Entry", "Subcontracting Order", "Subcont
 
 const POST_SUBMIT_GST_FIELDS = ["gst_category", "place_of_supply", "billing_address_gstin", "supplier_gstin"];
 
+const HSN_CODE_DOCTYPES = [
+    ...TRANSACTION_DOCTYPES,
+    ...SUBCONTRACTING_DOCTYPES,
+    "Material Request",
+    "POS Invoice",
+];
+
 for (const doctype of TRANSACTION_DOCTYPES) {
     fetch_gst_details(doctype);
     validate_overseas_gst_category(doctype);
     set_and_validate_gstin_status(doctype);
     set_gst_tax_breakup_on_load(doctype);
+}
+
+for (const doctype of HSN_CODE_DOCTYPES) {
+    set_hsn_code_autocomplete(doctype);
 }
 
 for (const doctype of SUBCONTRACTING_DOCTYPES) {
@@ -207,6 +218,14 @@ function set_gst_tax_breakup_on_load(doctype) {
         refresh(frm) {
             frm.doc.gst_breakup_table = frm.doc.__onload?._gst_breakup_table;
             frm.refresh_field("gst_breakup_table");
+        },
+    });
+}
+
+function set_hsn_code_autocomplete(doctype) {
+    frappe.ui.form.on(doctype, {
+        setup(frm) {
+            india_compliance.set_hsn_code_autocomplete(frm);
         },
     });
 }

--- a/india_compliance/public/js/utils.js
+++ b/india_compliance/public/js/utils.js
@@ -414,6 +414,15 @@ Object.assign(india_compliance, {
         };
     },
 
+    set_hsn_code_autocomplete(frm, table_fieldname = "items") {
+        const grid = frm.fields_dict[table_fieldname].grid;
+        frm.set_query("gst_hsn_code", table_fieldname, () => ({
+            query: "india_compliance.gst_india.utils.get_hsn_code_list",
+        }));
+
+        frappe.meta.get_docfield(grid.doctype, "gst_hsn_code").ignore_validation = 1;
+    },
+
     setup_itc_claim_period_query(frm) {
         frm.set_query("itc_claim_period", () => ({
             query: "india_compliance.gst_india.utils.itc_claim.get_itc_period_options",


### PR DESCRIPTION
Closes: https://github.com/resilient-tech/india-compliance/issues/4717

Existing behaviour to allow any HSN is also supported.

<img width="1086" height="826" alt="image" src="https://github.com/user-attachments/assets/2a9f49fe-db46-40cd-a1b2-50ef61b92ddf" />
