### PR TITLE
fix: correct summary comparison for nil section in gstr-1

### DIFF
--- a/india_compliance/gst_india/doctype/gst_return_log/generate_gstr_1.py
+++ b/india_compliance/gst_india/doctype/gst_return_log/generate_gstr_1.py
@@ -1077,9 +1077,7 @@ def get_differing_categories(mapped_summary, gov_summary):
     # TODO: Check this for all categories
     CATEGORY_KEYS = {
         (GSTR1_Category.NIL_EXEMPT.value): {
-            "total_exempted_amount",
-            "total_nil_rated_amount",
-            "total_non_gst_amount",
+            "total_taxable_value",
         },
         (GSTR1_Category.DOC_ISSUE.value): {
             "no_of_records",
@@ -1110,7 +1108,7 @@ def get_differing_categories(mapped_summary, gov_summary):
         keys_to_compare = CATEGORY_KEYS.get(category, KEYS_TO_COMPARE)
 
         for key in keys_to_compare:
-            if gov_entry.get(key, 0) != row.get(key):
+            if (gov_entry.get(key) or 0) != (row.get(key) or 0):
                 differing_categories.add(category)
                 break
 
@@ -1126,7 +1124,7 @@ def get_differing_categories(mapped_summary, gov_summary):
         keys_to_compare = CATEGORY_KEYS.get(row["description"], KEYS_TO_COMPARE)
 
         for key in keys_to_compare:
-            if row.get(key, 0) != 0:
+            if (row.get(key) or 0) != 0:
                 differing_categories.add(row["description"])
                 break
 

--- a/india_compliance/gst_india/utils/gstr_1/gstr_1_json_map.py
+++ b/india_compliance/gst_india/utils/gstr_1/gstr_1_json_map.py
@@ -1777,6 +1777,14 @@ class RETSUM(GSTR1DataMapper):
         if data.get("sec_nm") == "DOC_ISSUE":
             response["no_of_records"] = data.get("net_doc_issued", 0)
 
+        # Nil-Rated section is reported without a taxable value by the govt.
+        # Computed to compare against books summary.
+        elif data.get("sec_nm") == "NIL":
+            response[inv_f.TAXABLE_VALUE] = flt(
+                data.get("ttl_expt_amt", 0) + data.get("ttl_nilsup_amt", 0) + data.get("ttl_ngsup_amt", 0),
+                2,
+            )
+
         return response
 
     def format_subsection_data(self, section, subsection_data):

--- a/india_compliance/gst_india/utils/gstr_1/gstr_1_json_map.py
+++ b/india_compliance/gst_india/utils/gstr_1/gstr_1_json_map.py
@@ -1781,7 +1781,9 @@ class RETSUM(GSTR1DataMapper):
         # Computed to compare against books summary.
         elif data.get("sec_nm") == "NIL":
             response[inv_f.TAXABLE_VALUE] = flt(
-                data.get("ttl_expt_amt", 0) + data.get("ttl_nilsup_amt", 0) + data.get("ttl_ngsup_amt", 0),
+                flt(data.get("ttl_expt_amt"))
+                + flt(data.get("ttl_nilsup_amt"))
+                + flt(data.get("ttl_ngsup_amt")),
                 2,
             )
 

--- a/india_compliance/gst_india/utils/gstr_1/test_gstr_1_json_map.py
+++ b/india_compliance/gst_india/utils/gstr_1/test_gstr_1_json_map.py
@@ -1541,6 +1541,11 @@ class TestRETSUM(IntegrationTestCase):
 
         self.assertEqual(summary[self.NIL_EXEMPT][inv_f.TAXABLE_VALUE], 20055.0)
 
+        section = {**self.nil_section, "ttl_ngsup_amt": None}
+        summary = RETSUM().convert_to_internal_data_format([section])["summary"]
+
+        self.assertEqual(summary[self.NIL_EXEMPT][inv_f.TAXABLE_VALUE], 20040.0)
+
     def test_nil_section_summarized_without_records(self):
         """Section is summarized even if govt reports no records against it"""
         gov_summary = self.get_gov_summary({**self.nil_section, "ttl_rec": 0})

--- a/india_compliance/gst_india/utils/gstr_1/test_gstr_1_json_map.py
+++ b/india_compliance/gst_india/utils/gstr_1/test_gstr_1_json_map.py
@@ -4,11 +4,13 @@ from frappe.tests import IntegrationTestCase
 
 from india_compliance.gst_india.doctype.gst_return_log.generate_gstr_1 import (
     GenerateGSTR1,
+    get_differing_categories,
 )
 from india_compliance.gst_india.utils import get_party_for_gstin as _get_party_for_gstin
 from india_compliance.gst_india.utils.gstr_1 import GovDataField as gov_f
 from india_compliance.gst_india.utils.gstr_1 import (
     GSTR1_B2B_InvoiceType,
+    GSTR1_Category,
     GSTR1_SubCategory,
 )
 from india_compliance.gst_india.utils.gstr_1 import GSTR1_DataField as inv_f
@@ -22,11 +24,13 @@ from india_compliance.gst_india.utils.gstr_1.gstr_1_json_map import (
     CDNUR,
     DOC_ISSUE,
     HSNSUM,
+    RETSUM,
     SUPECOM,
     TXPD,
     Exports,
     NilRated,
     get_category_wise_data,
+    summarize_retsum_data,
 )
 
 
@@ -1490,3 +1494,79 @@ class TestHSNSUMError(IntegrationTestCase):
     def test_convert_to_internal_data_format(self):
         output = HSNSUM().convert_to_internal_data_format(self.json_data)
         self.assertDictEqual(self.mapped_data, output)
+
+
+class TestRETSUM(IntegrationTestCase):
+    """
+    Govt reports the Nil-Rated section without a taxable value. It's computed
+    from the nil rated / exempted / non-GST amounts to compare against books.
+    """
+
+    NIL_EXEMPT = GSTR1_Category.NIL_EXEMPT.value
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.nil_section = {
+            "sec_nm": "NIL",
+            "ttl_rec": 1,
+            "ttl_expt_amt": 20000.0,
+            "ttl_nilsup_amt": 40.0,
+            "ttl_ngsup_amt": 15.0,
+        }
+
+    def get_gov_summary(self, section=None):
+        summary = RETSUM().convert_to_internal_data_format([section or self.nil_section])["summary"]
+
+        return summarize_retsum_data(summary.values())
+
+    def get_books_summary(self, **kwargs):
+        return [
+            {
+                "description": self.NIL_EXEMPT,
+                "no_of_records": 1,
+                "indent": 0,
+                "total_taxable_value": 20055.0,
+                "total_igst_amount": 0.0,
+                "total_cgst_amount": 0.0,
+                "total_sgst_amount": 0.0,
+                "total_cess_amount": 0.0,
+                **kwargs,
+            }
+        ]
+
+    def test_convert_to_internal_data_format(self):
+        summary = RETSUM().convert_to_internal_data_format([self.nil_section])["summary"]
+
+        self.assertEqual(summary[self.NIL_EXEMPT][inv_f.TAXABLE_VALUE], 20055.0)
+
+    def test_nil_section_summarized_without_records(self):
+        """Section is summarized even if govt reports no records against it"""
+        gov_summary = self.get_gov_summary({**self.nil_section, "ttl_rec": 0})
+
+        self.assertEqual(gov_summary[0][inv_f.TAXABLE_VALUE], 20055.0)
+
+    def test_empty_nil_section_excluded(self):
+        self.assertEqual(self.get_gov_summary({"sec_nm": "NIL", "ttl_rec": 0}), [])
+
+    def test_matching_nil_summary(self):
+        self.assertEqual(
+            get_differing_categories(self.get_books_summary(), self.get_gov_summary()),
+            set(),
+        )
+
+    def test_differing_nil_summary(self):
+        books_summary = self.get_books_summary(total_taxable_value=20000.0)
+
+        self.assertEqual(
+            get_differing_categories(books_summary, self.get_gov_summary()),
+            {self.NIL_EXEMPT},
+        )
+
+    def test_missing_value_compared_as_zero(self):
+        """Keys absent in either summary should compare as zero, not differ"""
+        books_summary = self.get_books_summary(no_of_records="")
+        books_summary[0].pop("total_cess_amount")
+
+        self.assertEqual(get_differing_categories(books_summary, self.get_gov_summary()), set())


### PR DESCRIPTION
Closes: https://github.com/resilient-tech/india-compliance/issues/4289

Issue: Nil rated doesn't provide the total amount, and the books summary data does not have a breakdown, causing incorrect comparison.

<img width="2880" height="1396" alt="image" src="https://github.com/user-attachments/assets/2de749e8-e3ce-4b00-b534-4862c3a21227" />
