### PR TITLE
fix: send dispatchFromGSTIN/dispatchFromTradeName for e-Way Bill transaction types 3/4

### DIFF
--- a/india_compliance/gst_india/constants/e_waybill.py
+++ b/india_compliance/gst_india/constants/e_waybill.py
@@ -110,6 +110,9 @@ TRANSPORT_TYPES = {
 
 # transaction types where goods are shipped to an address different from Bill To
 SHIP_TO_TRANSACTION_TYPES = (2, 4)
+
+# transaction types where goods are dispatched from an address different from Bill From
+DISPATCH_FROM_TRANSACTION_TYPES = (3, 4)
 VEHICLE_TYPES = {"Regular": "R", "Over Dimensional Cargo (ODC)": "O"}
 
 TRANSIT_TYPES = {"Road": "R", "Warehouse": "W", "Others": "O"}

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -39,6 +39,7 @@ from india_compliance.gst_india.constants.e_waybill import (
     BUYING_DOCTYPES,
     CANCEL_REASON_CODES,
     CONSIGNMENT_STATUS,
+    DISPATCH_FROM_TRANSACTION_TYPES,
     E_WAYBILL_CHANGES_APPLICABLE_DATE,
     EXTEND_VALIDITY_REASON_CODES,
     ITEM_LIMIT,
@@ -1720,6 +1721,12 @@ class EWaybillData(GSTTransactionData):
             else self.ship_to.address_title
         )
 
+        self.ship_from.legal_name = (
+            self.bill_from.legal_name
+            if self.ship_from.gstin == self.bill_from.gstin
+            else self.ship_from.address_title
+        )
+
     def get_address_details(self, *args, **kwargs):
         address_details = super().get_address_details(*args, **kwargs)
         address_details.state_number = int(address_details.state_number)
@@ -1867,6 +1874,17 @@ class EWaybillData(GSTTransactionData):
                 {
                     "shipToGSTIN": self.ship_to.gstin,
                     "shipToTradeName": self.ship_to.legal_name,
+                }
+            )
+
+        if (
+            is_e_waybill_changes_applicable(self.settings)
+            and self.transaction_details.transaction_type in DISPATCH_FROM_TRANSACTION_TYPES
+        ):
+            data.update(
+                {
+                    "dispatchFromGSTIN": self.ship_from.gstin,
+                    "dispatchFromTradeName": self.ship_from.legal_name,
                 }
             )
 


### PR DESCRIPTION
## Summary
When a Sales/Purchase Invoice's Dispatch Address is a genuinely different registered place of business (its own GSTIN, different from the Company's GSTIN), the generated e-Way Bill correctly computes `transactionType` as `3` or `4`, and correctly resolves the dispatch address's own GSTIN internally via `get_address_details()` — but that GSTIN was never included in the JSON payload sent to the NIC e-Way Bill API. Only `fromGstin` (always the Company/Bill-From GSTIN) was ever sent.

This mirrors the existing, already-working `shipToGSTIN`/`shipToTradeName` mechanism for the ship-to side, adding an analogous `dispatchFromGSTIN`/`dispatchFromTradeName` block for the dispatch-from side.

## Root cause
- `self.ship_from.gstin` is correctly computed in `set_party_address_details()` (via `get_address_details()` reading the dispatch Address's own custom `gstin` field), but `get_transaction_data()` never reads it — only `self.bill_from.gstin` (correctly, for `fromGstin`) is used.
- `self.ship_from.legal_name` was never set at all (unlike `self.ship_to.legal_name`, which has explicit logic).
- Confirmed `dispatchFromGSTIN`/`dispatchFromTradeName` are the correct NIC API field names against the [official e-Way Bill API documentation](https://docs.ewaybillgst.gov.in/apidocs/version1.03/generate-eway-bill.html).
- The NIC error code table already present in this codebase (`gst_india/api_classes/nic/e_waybill_errors.py`) confirms NIC has a distinct "dispatch from GSTIN" concept (error codes 607, 610, 615, 617), further confirming this is a real, expected field.

## Fix
- Added `DISPATCH_FROM_TRANSACTION_TYPES = (3, 4)` constant, mirroring `SHIP_TO_TRANSACTION_TYPES = (2, 4)`.
- Set `self.ship_from.legal_name` in `set_party_address_details()`, mirroring the existing `self.ship_to.legal_name` logic.
- Added a `dispatchFromGSTIN`/`dispatchFromTradeName` block to `get_transaction_data()`, gated on the same `is_e_waybill_changes_applicable()` check used for `shipToGSTIN`.

No changes were made to `bill_from`/`fromGstin` logic — that was already correct (always the Company's GSTIN, per GST law's requirement that the invoicing entity's GSTIN is separate from the dispatch location's GSTIN).

## Testing
Verified in isolation against a real invoice + address pair with differing GSTINs (Company GSTIN vs. a Dispatch Address with its own distinct GSTIN):

```
transaction_type: 3
bill_from.gstin (Bill From):      <company GSTIN>   (unchanged, correct)
ship_from.gstin (Dispatch From):  <dispatch address's own GSTIN>  (previously never sent)
ship_from.legal_name:             <dispatch address title>
dispatchFromGSTIN would now be included in payload: True
```

I wasn't able to run the full existing e-Way Bill test suite in my environment due to an unrelated pre-existing fixture gap (missing `Warehouse Type: Transit` record needed for `before_tests` setup), unrelated to this change. Happy to add a test mirroring `test_e_waybill_ship_to_gstin_for_transaction_type_4` if maintainers would like one alongside this fix.