### PR TITLE
fix: correct ineligible for asset when non-perpetual

### DIFF
--- a/india_compliance/gst_india/overrides/ineligible_itc.py
+++ b/india_compliance/gst_india/overrides/ineligible_itc.py
@@ -359,7 +359,11 @@ class PurchaseInvoice(IneligibleITC):
 
     def is_debit_entry_required(self, item):
         # For Stock Entry / Fixed Asset in PI, Additional Debit is accounted automatically from valuation rates
-        return self.is_expense_item(item)
+        return not (
+            self.doc.update_stock
+            and self.is_perpetual
+            and (item.get("_is_stock_item") or item.get("is_fixed_asset"))
+        )
 
     def is_expense_item(self, item):
         """

--- a/india_compliance/gst_india/overrides/ineligible_itc.py
+++ b/india_compliance/gst_india/overrides/ineligible_itc.py
@@ -23,6 +23,7 @@ class IneligibleITC:
         self.company = frappe.get_cached_doc("Company", doc.company)
         self.is_perpetual = self.company.enable_perpetual_inventory
         self.cost_center = doc.cost_center or self.company.cost_center
+        self.conversion_rate = doc.get("conversion_rate") or 1
 
         self.dr_or_cr = "credit" if doc.get("is_return") else "debit"
         self.cr_or_dr = "debit" if doc.get("is_return") else "credit"
@@ -115,6 +116,9 @@ class IneligibleITC:
                     "account": self.company.default_gst_expense_account,
                     self.dr_or_cr: ineligible_item_tax_amount,
                     f"{self.dr_or_cr}_in_account_currency": ineligible_item_tax_amount,
+                    f"{self.dr_or_cr}_in_transaction_currency": flt(
+                        ineligible_item_tax_amount / self.conversion_rate
+                    ),
                     "cost_center": self.cost_center,
                 }
             )
@@ -127,6 +131,7 @@ class IneligibleITC:
                         "account": account,
                         self.cr_or_dr: amount,
                         f"{self.cr_or_dr}_in_account_currency": amount,
+                        f"{self.cr_or_dr}_in_transaction_currency": flt(amount / self.conversion_rate),
                         "cost_center": self.cost_center,
                     }
                 )
@@ -148,6 +153,9 @@ class IneligibleITC:
                     "account": self.company.default_gst_expense_account,
                     self.cr_or_dr: ineligible_item_tax_amount,
                     f"{self.cr_or_dr}_in_account_currency": ineligible_item_tax_amount,
+                    f"{self.cr_or_dr}_in_transaction_currency": flt(
+                        ineligible_item_tax_amount / self.conversion_rate
+                    ),
                     "cost_center": self.cost_center,
                 }
             )
@@ -169,6 +177,9 @@ class IneligibleITC:
                     "account": expense_account,
                     self.dr_or_cr: ineligible_item_tax_amount,
                     f"{self.dr_or_cr}_in_account_currency": ineligible_item_tax_amount,
+                    f"{self.dr_or_cr}_in_transaction_currency": flt(
+                        ineligible_item_tax_amount / self.conversion_rate
+                    ),
                     "cost_center": item.cost_center or self.cost_center,
                     "against": against_account,
                     "remarks": remarks,
@@ -202,6 +213,9 @@ class IneligibleITC:
 
             entry[self.dr_or_cr] -= ineligible_item_tax_amount
             entry[f"{self.dr_or_cr}_in_account_currency"] -= ineligible_item_tax_amount
+            entry[f"{self.dr_or_cr}_in_transaction_currency"] -= flt(
+                ineligible_item_tax_amount / self.conversion_rate
+            )
             break
 
         else:
@@ -212,6 +226,9 @@ class IneligibleITC:
                         "account": stock_account,
                         self.cr_or_dr: ineligible_item_tax_amount,
                         f"{self.cr_or_dr}_in_account_currency": ineligible_item_tax_amount,
+                        f"{self.cr_or_dr}_in_transaction_currency": flt(
+                            ineligible_item_tax_amount / self.conversion_rate
+                        ),
                         "cost_center": item.cost_center or self.cost_center,
                         "remarks": item.get("_remarks"),
                     }
@@ -224,6 +241,9 @@ class IneligibleITC:
 
             entry[self.dr_or_cr] += ineligible_item_tax_amount
             entry[f"{self.dr_or_cr}_in_account_currency"] += ineligible_item_tax_amount
+            entry[f"{self.dr_or_cr}_in_transaction_currency"] += flt(
+                ineligible_item_tax_amount / self.conversion_rate
+            )
             break
 
         else:
@@ -234,6 +254,9 @@ class IneligibleITC:
                         "account": cogs_account,
                         self.dr_or_cr: ineligible_item_tax_amount,
                         f"{self.dr_or_cr}_in_account_currency": ineligible_item_tax_amount,
+                        f"{self.dr_or_cr}_in_transaction_currency": flt(
+                            ineligible_item_tax_amount / self.conversion_rate
+                        ),
                         "cost_center": item.cost_center or self.cost_center,
                         "against": stock_account,
                         "remarks": item.get("_remarks"),

--- a/india_compliance/gst_india/overrides/test_ineligible_itc.py
+++ b/india_compliance/gst_india/overrides/test_ineligible_itc.py
@@ -377,89 +377,31 @@ class TestIneligibleITC(IntegrationTestCase):
             {"Test Fixed Asset": 1000, "Test Ineligible Fixed Asset": 1178.82},
         )  # 999 + 179.82
 
-    def test_purchase_invoice_with_update_stock_for_asset_expense_account(self):
+    @change_settings(
+        "Accounts Settings",
+        {"allow_multi_currency_invoices_against_single_party_account": 1},
+    )
+    def test_purchase_invoice_in_foreign_currency_for_asset_expense_account(self):
         """
-        Ineligible ITC for an item that is neither Stock Item nor Fixed Asset is debited
-        to it's expense account, even where the same is not an Expense account.
+        - Ineligible ITC for an item that is neither Stock Item nor Fixed Asset is debited
+          to it's expense account, even where the same is not an Expense account
+        - GST is always computed in company currency (taxable value = base net amount),
+          hence transaction currency amount for the same has to be derived
         """
         transaction_details = {
             "doctype": "Purchase Invoice",
             "bill_no": "BILL-11",
             "update_stock": 1,
+            "currency": "USD",
+            "conversion_rate": 100,
             "items": [
                 {
                     "item_code": "Test Ineligible Service Item",
-                    "qty": 2,
-                    "rate": 499,
+                    "qty": 1,
+                    "rate": 1000,
                     "expense_account": "CWIP Account - _TIRC",
                 }
             ],
-            "is_in_state": 1,
-        }
-
-        doc = create_transaction(**transaction_details)
-
-        self.assertEqual(doc.ineligibility_reason, "Ineligible As Per Section 17(5)")
-
-        self.assertGLEntry(
-            doc.name,
-            [
-                {
-                    "account": "GST Expense - _TIRC",
-                    "debit": 179.64,
-                    "credit": 179.64,
-                    "debit_in_transaction_currency": 179.64,
-                    "credit_in_transaction_currency": 179.64,
-                },  # 499 * 2 * 18%
-                {
-                    "account": "Input Tax SGST - _TIRC",
-                    "debit": 89.82,
-                    "credit": 89.82,
-                    "debit_in_transaction_currency": 89.82,
-                    "credit_in_transaction_currency": 89.82,
-                },
-                {
-                    "account": "Input Tax CGST - _TIRC",
-                    "debit": 89.82,
-                    "credit": 89.82,
-                    "debit_in_transaction_currency": 89.82,
-                    "credit_in_transaction_currency": 89.82,
-                },
-                {
-                    "account": "CWIP Account - _TIRC",
-                    "debit": 1177.64,
-                    "credit": 0.0,
-                    "debit_in_transaction_currency": 1177.64,
-                    "credit_in_transaction_currency": 0.0,
-                },  # 998 + 179.64
-                {
-                    "account": "Round Off - _TIRC",
-                    "debit": 0.36,
-                    "credit": 0.0,
-                    "debit_in_transaction_currency": 0.0,
-                    "credit_in_transaction_currency": 0.0,
-                },
-                {
-                    "account": "Creditors - _TIRC",
-                    "debit": 0.0,
-                    "credit": 1178.0,
-                    "debit_in_transaction_currency": 0.0,
-                    "credit_in_transaction_currency": 1178.0,
-                },
-            ],
-        )
-
-    @change_settings(
-        "Accounts Settings",
-        {"allow_multi_currency_invoices_against_single_party_account": 1},
-    )
-    def test_purchase_invoice_in_foreign_currency(self):
-        transaction_details = {
-            "doctype": "Purchase Invoice",
-            "bill_no": "BILL-12",
-            "currency": "USD",
-            "conversion_rate": 100,
-            "items": [{"item_code": "Test Ineligible Service Item", "qty": 1, "rate": 1000}],
             "is_in_state": 1,
         }
 
@@ -493,7 +435,7 @@ class TestIneligibleITC(IntegrationTestCase):
                     "credit_in_transaction_currency": 90.0,
                 },
                 {
-                    "account": "Administrative Expenses - _TIRC",
+                    "account": "CWIP Account - _TIRC",
                     "debit": 118000.0,
                     "credit": 0.0,
                     "debit_in_transaction_currency": 1180.0,

--- a/india_compliance/gst_india/overrides/test_ineligible_itc.py
+++ b/india_compliance/gst_india/overrides/test_ineligible_itc.py
@@ -237,6 +237,123 @@ class TestIneligibleITC(IntegrationTestCase):
         self.assertEqual(status, "Completed")
         self.assertGLEntry(doc.name, expected_entries)
 
+    @toggle_perpetual_inventory()
+    def test_purchase_invoice_with_update_stock_for_non_perpetual(self):
+        """
+        Without perpetual inventory, ERPNext books the item debit from base net amount
+        instead of valuation rate. Ineligible ITC is hence not accounted for on its own,
+        and is debited to the same account the item is booked in:
+        - Fixed Asset: CWIP Account, capitalized along with the asset
+        - Stock Item: Cost of Goods Sold, as stock is not booked in GL
+        """
+        transaction_details = {
+            "doctype": "Purchase Invoice",
+            "bill_no": "BILL-10",
+            "update_stock": 1,
+            "items": SAMPLE_ITEM_LIST,
+            "is_in_state": 1,
+        }
+
+        doc = create_transaction(**transaction_details)
+
+        self.assertEqual(doc.ineligibility_reason, "Ineligible As Per Section 17(5)")
+
+        self.assertGLEntry(
+            doc.name,
+            [
+                {"account": "Round Off - _TIRC", "debit": 0.28, "credit": 0.0},
+                {
+                    "account": "GST Expense - _TIRC",
+                    "debit": 369.72,
+                    "credit": 369.72,
+                },  # 179.64 + 179.82 + 10.26
+                {
+                    "account": "Input Tax SGST - _TIRC",
+                    "debit": 427.86,
+                    "credit": 184.86,  # 369.72 / 2
+                },
+                {
+                    "account": "Input Tax CGST - _TIRC",
+                    "debit": 427.86,
+                    "credit": 184.86,
+                },
+                {
+                    "account": "Administrative Expenses - _TIRC",
+                    "debit": 2677.64,  # 500 * 3 + 499 * 2 + 179.64
+                    "credit": 0.0,
+                },
+                {
+                    "account": "CWIP Account - _TIRC",
+                    "debit": 2178.82,
+                    "credit": 0.0,
+                },  # 1000 + 999 + 179.82
+                {
+                    "account": "Cost of Goods Sold - _TIRC",
+                    "debit": 267.26,
+                    "credit": 0.0,
+                },  # 20 * 5 + 19 * 3 + 100 * 1 + 10.26
+                {"account": "Creditors - _TIRC", "debit": 0.0, "credit": 5610.0},
+            ],
+        )
+
+        self.assertAssetValues(
+            "Purchase Invoice",
+            doc.name,
+            {"Test Fixed Asset": 1000, "Test Ineligible Fixed Asset": 1178.82},
+        )  # 999 + 179.82
+
+    def test_purchase_invoice_with_update_stock_for_asset_expense_account(self):
+        """
+        Ineligible ITC for an item that is neither Stock Item nor Fixed Asset is debited
+        to it's expense account, even where the same is not an Expense account.
+        """
+        transaction_details = {
+            "doctype": "Purchase Invoice",
+            "bill_no": "BILL-11",
+            "update_stock": 1,
+            "items": [
+                {
+                    "item_code": "Test Ineligible Service Item",
+                    "qty": 2,
+                    "rate": 499,
+                    "expense_account": "CWIP Account - _TIRC",
+                }
+            ],
+            "is_in_state": 1,
+        }
+
+        doc = create_transaction(**transaction_details)
+
+        self.assertEqual(doc.ineligibility_reason, "Ineligible As Per Section 17(5)")
+
+        self.assertGLEntry(
+            doc.name,
+            [
+                {
+                    "account": "GST Expense - _TIRC",
+                    "debit": 179.64,
+                    "credit": 179.64,
+                },  # 499 * 2 * 18%
+                {
+                    "account": "Input Tax SGST - _TIRC",
+                    "debit": 89.82,
+                    "credit": 89.82,
+                },
+                {
+                    "account": "Input Tax CGST - _TIRC",
+                    "debit": 89.82,
+                    "credit": 89.82,
+                },
+                {
+                    "account": "CWIP Account - _TIRC",
+                    "debit": 1177.64,
+                    "credit": 0.0,
+                },  # 998 + 179.64
+                {"account": "Round Off - _TIRC", "debit": 0.36, "credit": 0.0},
+                {"account": "Creditors - _TIRC", "debit": 0.0, "credit": 1178.0},
+            ],
+        )
+
     def test_purchase_invoice_with_ineligible_pos(self):
         transaction_details = {
             "doctype": "Purchase Invoice",

--- a/india_compliance/gst_india/overrides/test_ineligible_itc.py
+++ b/india_compliance/gst_india/overrides/test_ineligible_itc.py
@@ -123,38 +123,62 @@ class TestIneligibleITC(IntegrationTestCase):
         self.assertGLEntry(
             doc.name,
             [
-                {"account": "Round Off - _TIRC", "debit": 0.28, "credit": 0.0},
+                {
+                    "account": "Round Off - _TIRC",
+                    "debit": 0.28,
+                    "credit": 0.0,
+                    "debit_in_transaction_currency": 0.0,
+                    "credit_in_transaction_currency": 0.0,
+                },
                 {
                     "account": "GST Expense - _TIRC",
                     "debit": 369.72,
                     "credit": 369.72,
+                    "debit_in_transaction_currency": 369.72,
+                    "credit_in_transaction_currency": 369.72,
                 },  # 179.64 + 179.82 + 10.26
                 {
                     "account": "Input Tax SGST - _TIRC",
                     "debit": 427.86,
-                    "credit": 184.86,  # 369.72 / 2
+                    "credit": 184.86,
+                    "debit_in_transaction_currency": 427.86,
+                    "credit_in_transaction_currency": 184.86,  # 369.72 / 2
                 },
                 {
                     "account": "Input Tax CGST - _TIRC",
                     "debit": 427.86,
                     "credit": 184.86,
+                    "debit_in_transaction_currency": 427.86,
+                    "credit_in_transaction_currency": 184.86,
                 },
                 {
                     "account": "Administrative Expenses - _TIRC",
                     "debit": 2677.64,  # 500 * 3 + 499 * 2 + 179.64
                     "credit": 0.0,
+                    "debit_in_transaction_currency": 2677.64,
+                    "credit_in_transaction_currency": 0.0,
                 },
                 {
                     "account": "CWIP Account - _TIRC",
                     "debit": 2178.82,
                     "credit": 0.0,
+                    "debit_in_transaction_currency": 2178.82,
+                    "credit_in_transaction_currency": 0.0,
                 },  # 1000 + 999 + 179.82
                 {
                     "account": "Stock In Hand - _TIRC",
                     "debit": 267.26,
                     "credit": 0.0,
+                    "debit_in_transaction_currency": 267.26,
+                    "credit_in_transaction_currency": 0.0,
                 },  # 20 * 5 + 19 * 3 + 100 * 1 + 10.26
-                {"account": "Creditors - _TIRC", "debit": 0.0, "credit": 5610.0},
+                {
+                    "account": "Creditors - _TIRC",
+                    "debit": 0.0,
+                    "credit": 5610.0,
+                    "debit_in_transaction_currency": 0.0,
+                    "credit_in_transaction_currency": 5610.0,
+                },
             ],
         )
 
@@ -183,38 +207,62 @@ class TestIneligibleITC(IntegrationTestCase):
         doc.save()  # Repost Accounting on Save
 
         expected_entries = [
-            {"account": "Round Off - _TIRC", "debit": 0.28, "credit": 0.0},
+            {
+                "account": "Round Off - _TIRC",
+                "debit": 0.28,
+                "credit": 0.0,
+                "debit_in_transaction_currency": 0.0,
+                "credit_in_transaction_currency": 0.0,
+            },
             {
                 "account": "GST Expense - _TIRC",
                 "debit": 369.72,
                 "credit": 369.72,
+                "debit_in_transaction_currency": 369.72,
+                "credit_in_transaction_currency": 369.72,
             },  # 179.64 + 179.82 + 10.26
             {
                 "account": "Input Tax SGST - _TIRC",
                 "debit": 427.86,
-                "credit": 184.86,  # 369.72 / 2
+                "credit": 184.86,
+                "debit_in_transaction_currency": 427.86,
+                "credit_in_transaction_currency": 184.86,  # 369.72 / 2
             },
             {
                 "account": "Input Tax CGST - _TIRC",
                 "debit": 427.86,
                 "credit": 184.86,
+                "debit_in_transaction_currency": 427.86,
+                "credit_in_transaction_currency": 184.86,
             },
             {
                 "account": "Office Rent - _TIRC",
                 "debit": 2677.64,  # 500 * 3 + 499 * 2 + 179.64
                 "credit": 0.0,
+                "debit_in_transaction_currency": 2677.64,
+                "credit_in_transaction_currency": 0.0,
             },
             {
                 "account": "CWIP Account - _TIRC",
                 "debit": 2178.82,
                 "credit": 0.0,
+                "debit_in_transaction_currency": 2178.82,
+                "credit_in_transaction_currency": 0.0,
             },  # 1000 + 999 + 179.82
             {
                 "account": "Stock In Hand - _TIRC",
                 "debit": 267.26,
                 "credit": 0.0,
+                "debit_in_transaction_currency": 267.26,
+                "credit_in_transaction_currency": 0.0,
             },  # 20 * 5 + 19 * 3 + 100 * 1 + 10.26
-            {"account": "Creditors - _TIRC", "debit": 0.0, "credit": 5610.0},
+            {
+                "account": "Creditors - _TIRC",
+                "debit": 0.0,
+                "credit": 5610.0,
+                "debit_in_transaction_currency": 0.0,
+                "credit_in_transaction_currency": 5610.0,
+            },
         ]
 
         self.assertGLEntry(doc.name, expected_entries)
@@ -261,41 +309,68 @@ class TestIneligibleITC(IntegrationTestCase):
         self.assertGLEntry(
             doc.name,
             [
-                {"account": "Round Off - _TIRC", "debit": 0.28, "credit": 0.0},
+                {
+                    "account": "Round Off - _TIRC",
+                    "debit": 0.28,
+                    "credit": 0.0,
+                    "debit_in_transaction_currency": 0.0,
+                    "credit_in_transaction_currency": 0.0,
+                },
                 {
                     "account": "GST Expense - _TIRC",
                     "debit": 369.72,
                     "credit": 369.72,
+                    "debit_in_transaction_currency": 369.72,
+                    "credit_in_transaction_currency": 369.72,
                 },  # 179.64 + 179.82 + 10.26
                 {
                     "account": "Input Tax SGST - _TIRC",
                     "debit": 427.86,
-                    "credit": 184.86,  # 369.72 / 2
+                    "credit": 184.86,
+                    "debit_in_transaction_currency": 427.86,
+                    "credit_in_transaction_currency": 184.86,  # 369.72 / 2
                 },
                 {
                     "account": "Input Tax CGST - _TIRC",
                     "debit": 427.86,
                     "credit": 184.86,
+                    "debit_in_transaction_currency": 427.86,
+                    "credit_in_transaction_currency": 184.86,
                 },
                 {
                     "account": "Administrative Expenses - _TIRC",
                     "debit": 2677.64,  # 500 * 3 + 499 * 2 + 179.64
                     "credit": 0.0,
+                    "debit_in_transaction_currency": 2677.64,
+                    "credit_in_transaction_currency": 0.0,
                 },
                 {
                     "account": "CWIP Account - _TIRC",
                     "debit": 2178.82,
                     "credit": 0.0,
+                    "debit_in_transaction_currency": 2178.82,
+                    "credit_in_transaction_currency": 0.0,
                 },  # 1000 + 999 + 179.82
                 {
                     "account": "Cost of Goods Sold - _TIRC",
                     "debit": 267.26,
                     "credit": 0.0,
+                    "debit_in_transaction_currency": 267.26,
+                    "credit_in_transaction_currency": 0.0,
                 },  # 20 * 5 + 19 * 3 + 100 * 1 + 10.26
-                {"account": "Creditors - _TIRC", "debit": 0.0, "credit": 5610.0},
+                {
+                    "account": "Creditors - _TIRC",
+                    "debit": 0.0,
+                    "credit": 5610.0,
+                    "debit_in_transaction_currency": 0.0,
+                    "credit_in_transaction_currency": 5610.0,
+                },
             ],
         )
 
+        # Stock Ledger is updated without perpetual inventory, but ineligible ITC is
+        # not capitalized in valuation rate, as it's booked in Cost of Goods Sold
+        self.assertStockValues(doc.name, {"Test Stock Item": 20, "Test Ineligible Stock Item": 19})
         self.assertAssetValues(
             "Purchase Invoice",
             doc.name,
@@ -333,24 +408,44 @@ class TestIneligibleITC(IntegrationTestCase):
                     "account": "GST Expense - _TIRC",
                     "debit": 179.64,
                     "credit": 179.64,
+                    "debit_in_transaction_currency": 179.64,
+                    "credit_in_transaction_currency": 179.64,
                 },  # 499 * 2 * 18%
                 {
                     "account": "Input Tax SGST - _TIRC",
                     "debit": 89.82,
                     "credit": 89.82,
+                    "debit_in_transaction_currency": 89.82,
+                    "credit_in_transaction_currency": 89.82,
                 },
                 {
                     "account": "Input Tax CGST - _TIRC",
                     "debit": 89.82,
                     "credit": 89.82,
+                    "debit_in_transaction_currency": 89.82,
+                    "credit_in_transaction_currency": 89.82,
                 },
                 {
                     "account": "CWIP Account - _TIRC",
                     "debit": 1177.64,
                     "credit": 0.0,
+                    "debit_in_transaction_currency": 1177.64,
+                    "credit_in_transaction_currency": 0.0,
                 },  # 998 + 179.64
-                {"account": "Round Off - _TIRC", "debit": 0.36, "credit": 0.0},
-                {"account": "Creditors - _TIRC", "debit": 0.0, "credit": 1178.0},
+                {
+                    "account": "Round Off - _TIRC",
+                    "debit": 0.36,
+                    "credit": 0.0,
+                    "debit_in_transaction_currency": 0.0,
+                    "credit_in_transaction_currency": 0.0,
+                },
+                {
+                    "account": "Creditors - _TIRC",
+                    "debit": 0.0,
+                    "credit": 1178.0,
+                    "debit_in_transaction_currency": 0.0,
+                    "credit_in_transaction_currency": 1178.0,
+                },
             ],
         )
 
@@ -372,33 +467,55 @@ class TestIneligibleITC(IntegrationTestCase):
         self.assertGLEntry(
             doc.name,
             [
-                {"account": "Round Off - _TIRC", "debit": 0.28, "credit": 0.0},
+                {
+                    "account": "Round Off - _TIRC",
+                    "debit": 0.28,
+                    "credit": 0.0,
+                    "debit_in_transaction_currency": 0.0,
+                    "credit_in_transaction_currency": 0.0,
+                },
                 {
                     "account": "GST Expense - _TIRC",
                     "debit": 855.72,
                     "credit": 855.72,
+                    "debit_in_transaction_currency": 855.72,
+                    "credit_in_transaction_currency": 855.72,
                 },  # full taxes reversed
                 {
                     "account": "Input Tax IGST - _TIRC",
                     "debit": 855.72,
                     "credit": 855.72,
+                    "debit_in_transaction_currency": 855.72,
+                    "credit_in_transaction_currency": 855.72,
                 },
                 {
                     "account": "Administrative Expenses - _TIRC",
                     "debit": 2947.64,
                     "credit": 0.0,
+                    "debit_in_transaction_currency": 2947.64,
+                    "credit_in_transaction_currency": 0.0,
                 },
                 {
                     "account": "CWIP Account - _TIRC",
                     "debit": 2358.82,
                     "credit": 0.0,
+                    "debit_in_transaction_currency": 2358.82,
+                    "credit_in_transaction_currency": 0.0,
                 },
                 {
                     "account": "Stock In Hand - _TIRC",
                     "debit": 303.26,
                     "credit": 0.0,
+                    "debit_in_transaction_currency": 303.26,
+                    "credit_in_transaction_currency": 0.0,
                 },
-                {"account": "Creditors - _TIRC", "debit": 0.0, "credit": 5610.0},
+                {
+                    "account": "Creditors - _TIRC",
+                    "debit": 0.0,
+                    "credit": 5610.0,
+                    "debit_in_transaction_currency": 0.0,
+                    "credit_in_transaction_currency": 5610.0,
+                },
             ],
         )
 
@@ -429,26 +546,36 @@ class TestIneligibleITC(IntegrationTestCase):
                     "account": "GST Expense - _TIRC",
                     "debit": 0.0,
                     "credit": 190.08,
+                    "debit_in_transaction_currency": 0.0,
+                    "credit_in_transaction_currency": 190.08,
                 },  # 10.26 + 179.82
                 {
                     "account": "Asset Received But Not Billed - _TIRC",
                     "debit": 0.0,
                     "credit": 1999.0,
+                    "debit_in_transaction_currency": 0.0,
+                    "credit_in_transaction_currency": 1999.0,
                 },
                 {
                     "account": "CWIP Account - _TIRC",
                     "debit": 2178.82,  # 1999 + 179.82
                     "credit": 0.0,
+                    "debit_in_transaction_currency": 2178.82,
+                    "credit_in_transaction_currency": 0.0,
                 },
                 {
                     "account": "Stock Received But Not Billed - _TIRC",
                     "debit": 0.0,
                     "credit": 257.0,
+                    "debit_in_transaction_currency": 0.0,
+                    "credit_in_transaction_currency": 257.0,
                 },
                 {
                     "account": "Stock In Hand - _TIRC",
                     "debit": 267.26,  # 257 + 10.26
                     "credit": 0.0,
+                    "debit_in_transaction_currency": 267.26,
+                    "credit_in_transaction_currency": 0.0,
                 },
             ],
         )
@@ -487,38 +614,62 @@ class TestIneligibleITC(IntegrationTestCase):
         self.assertGLEntry(
             doc.name,
             [
-                {"account": "Round Off - _TIRC", "debit": 0.28, "credit": 0.0},
+                {
+                    "account": "Round Off - _TIRC",
+                    "debit": 0.28,
+                    "credit": 0.0,
+                    "debit_in_transaction_currency": 0.0,
+                    "credit_in_transaction_currency": 0.0,
+                },
                 {
                     "account": "GST Expense - _TIRC",
                     "debit": 369.72,  # 179.82 + 179.64 + 10.26
                     "credit": 179.64,  # Only Expense
+                    "debit_in_transaction_currency": 369.72,
+                    "credit_in_transaction_currency": 179.64,
                 },
                 {
                     "account": "Input Tax SGST - _TIRC",
                     "debit": 427.86,
                     "credit": 184.86,
+                    "debit_in_transaction_currency": 427.86,
+                    "credit_in_transaction_currency": 184.86,
                 },
                 {
                     "account": "Input Tax CGST - _TIRC",
                     "debit": 427.86,
-                    "credit": 184.86,  # 369.72 / 2
+                    "credit": 184.86,
+                    "debit_in_transaction_currency": 427.86,
+                    "credit_in_transaction_currency": 184.86,  # 369.72 / 2
                 },
                 {
                     "account": "Asset Received But Not Billed - _TIRC",
                     "debit": 1999.0,
                     "credit": 0.0,
+                    "debit_in_transaction_currency": 1999.0,
+                    "credit_in_transaction_currency": 0.0,
                 },
                 {
                     "account": "Administrative Expenses - _TIRC",
                     "debit": 2677.64,  # 1500 + 998 + 179.64
                     "credit": 0.0,
+                    "debit_in_transaction_currency": 2677.64,
+                    "credit_in_transaction_currency": 0.0,
                 },
                 {
                     "account": "Stock Received But Not Billed - _TIRC",
                     "debit": 257.0,
                     "credit": 0.0,
+                    "debit_in_transaction_currency": 257.0,
+                    "credit_in_transaction_currency": 0.0,
                 },
-                {"account": "Creditors - _TIRC", "debit": 0.0, "credit": 5610.0},
+                {
+                    "account": "Creditors - _TIRC",
+                    "debit": 0.0,
+                    "credit": 5610.0,
+                    "debit_in_transaction_currency": 0.0,
+                    "credit_in_transaction_currency": 5610.0,
+                },
             ],
         )
 
@@ -540,26 +691,36 @@ class TestIneligibleITC(IntegrationTestCase):
                     "account": "GST Expense - _TIRC",
                     "debit": 0.0,
                     "credit": 406.08,
+                    "debit_in_transaction_currency": 0.0,
+                    "credit_in_transaction_currency": 406.08,
                 },  # 855.72 - 449.64 (reversal on expense)
                 {
                     "account": "Asset Received But Not Billed - _TIRC",
                     "debit": 0.0,
                     "credit": 1999.0,
+                    "debit_in_transaction_currency": 0.0,
+                    "credit_in_transaction_currency": 1999.0,
                 },
                 {
                     "account": "CWIP Account - _TIRC",
                     "debit": 2358.82,
                     "credit": 0.0,
+                    "debit_in_transaction_currency": 2358.82,
+                    "credit_in_transaction_currency": 0.0,
                 },
                 {
                     "account": "Stock Received But Not Billed - _TIRC",
                     "debit": 0.0,
                     "credit": 257.0,
+                    "debit_in_transaction_currency": 0.0,
+                    "credit_in_transaction_currency": 257.0,
                 },
                 {
                     "account": "Stock In Hand - _TIRC",
                     "debit": 303.26,
                     "credit": 0.0,
+                    "debit_in_transaction_currency": 303.26,
+                    "credit_in_transaction_currency": 0.0,
                 },
             ],
         )
@@ -587,33 +748,55 @@ class TestIneligibleITC(IntegrationTestCase):
         self.assertGLEntry(
             doc.name,
             [
-                {"account": "Round Off - _TIRC", "debit": 0.28, "credit": 0.0},
+                {
+                    "account": "Round Off - _TIRC",
+                    "debit": 0.28,
+                    "credit": 0.0,
+                    "debit_in_transaction_currency": 0.0,
+                    "credit_in_transaction_currency": 0.0,
+                },
                 {
                     "account": "GST Expense - _TIRC",
                     "debit": 855.72,
-                    "credit": 449.64,  # expense reversal
+                    "credit": 449.64,
+                    "debit_in_transaction_currency": 855.72,
+                    "credit_in_transaction_currency": 449.64,  # expense reversal
                 },
                 {
                     "account": "Input Tax IGST - _TIRC",
                     "debit": 855.72,
                     "credit": 855.72,
+                    "debit_in_transaction_currency": 855.72,
+                    "credit_in_transaction_currency": 855.72,
                 },
                 {
                     "account": "Asset Received But Not Billed - _TIRC",
                     "debit": 1999.0,
                     "credit": 0.0,
+                    "debit_in_transaction_currency": 1999.0,
+                    "credit_in_transaction_currency": 0.0,
                 },
                 {
                     "account": "Administrative Expenses - _TIRC",
                     "debit": 2947.64,
                     "credit": 0.0,
+                    "debit_in_transaction_currency": 2947.64,
+                    "credit_in_transaction_currency": 0.0,
                 },
                 {
                     "account": "Stock Received But Not Billed - _TIRC",
                     "debit": 257.0,
                     "credit": 0.0,
+                    "debit_in_transaction_currency": 257.0,
+                    "credit_in_transaction_currency": 0.0,
                 },
-                {"account": "Creditors - _TIRC", "debit": 0.0, "credit": 5610.0},
+                {
+                    "account": "Creditors - _TIRC",
+                    "debit": 0.0,
+                    "credit": 5610.0,
+                    "debit_in_transaction_currency": 0.0,
+                    "credit_in_transaction_currency": 5610.0,
+                },
             ],
         )
 
@@ -634,38 +817,62 @@ class TestIneligibleITC(IntegrationTestCase):
         self.assertGLEntry(
             doc.name,
             [
-                {"account": "Round Off - _TIRC", "debit": 0.0, "credit": 0.28},
+                {
+                    "account": "Round Off - _TIRC",
+                    "debit": 0.0,
+                    "credit": 0.28,
+                    "debit_in_transaction_currency": 0.0,
+                    "credit_in_transaction_currency": 0.0,
+                },
                 {
                     "account": "GST Expense - _TIRC",
                     "debit": 369.72,
                     "credit": 369.72,
+                    "debit_in_transaction_currency": 369.72,
+                    "credit_in_transaction_currency": 369.72,
                 },
                 {
                     "account": "Input Tax SGST - _TIRC",
                     "debit": 0.0,
                     "credit": 243.0,
+                    "debit_in_transaction_currency": 0.0,
+                    "credit_in_transaction_currency": 243.0,
                 },
                 {
                     "account": "Input Tax CGST - _TIRC",
                     "debit": 0.0,
                     "credit": 243.0,
+                    "debit_in_transaction_currency": 0.0,
+                    "credit_in_transaction_currency": 243.0,
                 },
                 {
                     "account": "CWIP Account - _TIRC",
                     "debit": 0.0,
                     "credit": 2178.82,
+                    "debit_in_transaction_currency": 0.0,
+                    "credit_in_transaction_currency": 2178.82,
                 },
                 {
                     "account": "Administrative Expenses - _TIRC",
                     "debit": 0.0,
                     "credit": 2677.64,
+                    "debit_in_transaction_currency": 0.0,
+                    "credit_in_transaction_currency": 2677.64,
                 },
                 {
                     "account": "Stock In Hand - _TIRC",
                     "debit": 0.0,
                     "credit": 267.26,
+                    "debit_in_transaction_currency": 0.0,
+                    "credit_in_transaction_currency": 267.26,
                 },
-                {"account": "Creditors - _TIRC", "debit": 5610.0, "credit": 0.0},
+                {
+                    "account": "Creditors - _TIRC",
+                    "debit": 5610.0,
+                    "credit": 0.0,
+                    "debit_in_transaction_currency": 5610.0,
+                    "credit_in_transaction_currency": 0.0,
+                },
             ],
         )
 
@@ -692,31 +899,43 @@ class TestIneligibleITC(IntegrationTestCase):
                     "account": "GST Expense - _TIRC",
                     "debit": 190.08,  # 10.26 + 179.82
                     "credit": 0.0,
+                    "debit_in_transaction_currency": 190.08,
+                    "credit_in_transaction_currency": 0.0,
                 },
                 {
                     "account": "Asset Received But Not Billed - _TIRC",
                     "debit": 1999.0,
                     "credit": 0.0,
+                    "debit_in_transaction_currency": 1999.0,
+                    "credit_in_transaction_currency": 0.0,
                 },
                 {
                     "account": "CWIP Account - _TIRC",
                     "debit": 0.0,
-                    "credit": 2178.82,  # 1999 + 179.82
+                    "credit": 2178.82,
+                    "debit_in_transaction_currency": 0.0,
+                    "credit_in_transaction_currency": 2178.82,  # 1999 + 179.82
                 },
                 {
                     "account": "Stock Received But Not Billed - _TIRC",
                     "debit": 257.0,
                     "credit": 0.0,
+                    "debit_in_transaction_currency": 257.0,
+                    "credit_in_transaction_currency": 0.0,
                 },
                 {
                     "account": "Stock In Hand - _TIRC",
                     "debit": 0.0,
-                    "credit": 267.26,  # 257 + 10.26
+                    "credit": 267.26,
+                    "debit_in_transaction_currency": 0.0,
+                    "credit_in_transaction_currency": 267.26,  # 257 + 10.26
                 },
                 {
                     "account": "Cost of Goods Sold - _TIRC",
                     "debit": 10.26,
                     "credit": 10.26,
+                    "debit_in_transaction_currency": 10.26,
+                    "credit_in_transaction_currency": 10.26,
                 },
             ],
         )
@@ -742,16 +961,22 @@ class TestIneligibleITC(IntegrationTestCase):
                     "account": "GST Expense - _TIRC",
                     "debit": 0.0,
                     "credit": 179.82,
+                    "debit_in_transaction_currency": 0.0,
+                    "credit_in_transaction_currency": 179.82,
                 },  # only asset
                 {
                     "account": "Asset Received But Not Billed - _TIRC",
                     "debit": 0.0,
                     "credit": 1999.0,
+                    "debit_in_transaction_currency": 0.0,
+                    "credit_in_transaction_currency": 1999.0,
                 },
                 {
                     "account": "CWIP Account - _TIRC",
                     "debit": 2178.82,
                     "credit": 0.0,
+                    "debit_in_transaction_currency": 2178.82,
+                    "credit_in_transaction_currency": 0.0,
                 },
             ],
         )
@@ -772,38 +997,62 @@ class TestIneligibleITC(IntegrationTestCase):
         self.assertGLEntry(
             doc.name,
             [
-                {"account": "Round Off - _TIRC", "debit": 0.28, "credit": 0.0},
+                {
+                    "account": "Round Off - _TIRC",
+                    "debit": 0.28,
+                    "credit": 0.0,
+                    "debit_in_transaction_currency": 0.0,
+                    "credit_in_transaction_currency": 0.0,
+                },
                 {
                     "account": "GST Expense - _TIRC",
                     "debit": 369.72,
                     "credit": 189.9,
+                    "debit_in_transaction_currency": 369.72,
+                    "credit_in_transaction_currency": 189.9,
                 },
                 {
                     "account": "Input Tax SGST - _TIRC",
                     "debit": 427.86,
                     "credit": 184.86,
+                    "debit_in_transaction_currency": 427.86,
+                    "credit_in_transaction_currency": 184.86,
                 },
                 {
                     "account": "Input Tax CGST - _TIRC",
                     "debit": 427.86,
                     "credit": 184.86,
+                    "debit_in_transaction_currency": 427.86,
+                    "credit_in_transaction_currency": 184.86,
                 },
                 {
                     "account": "Asset Received But Not Billed - _TIRC",
                     "debit": 1999.0,
                     "credit": 0.0,
+                    "debit_in_transaction_currency": 1999.0,
+                    "credit_in_transaction_currency": 0.0,
                 },
                 {
                     "account": "Administrative Expenses - _TIRC",
                     "debit": 2677.64,
                     "credit": 0.0,
+                    "debit_in_transaction_currency": 2677.64,
+                    "credit_in_transaction_currency": 0.0,
                 },
                 {
                     "account": "Cost of Goods Sold - _TIRC",
                     "debit": 267.26,  # stock with gst expense
                     "credit": 0.0,
+                    "debit_in_transaction_currency": 267.26,
+                    "credit_in_transaction_currency": 0.0,
                 },
-                {"account": "Creditors - _TIRC", "debit": 0.0, "credit": 5610.0},
+                {
+                    "account": "Creditors - _TIRC",
+                    "debit": 0.0,
+                    "credit": 5610.0,
+                    "debit_in_transaction_currency": 0.0,
+                    "credit_in_transaction_currency": 5610.0,
+                },
             ],
         )
 
@@ -825,46 +1074,68 @@ class TestIneligibleITC(IntegrationTestCase):
         self.assertGLEntry(
             doc.name,
             [
-                {"account": "GST Expense - _TIRC", "debit": 0.0, "credit": 190.08},
+                {
+                    "account": "GST Expense - _TIRC",
+                    "debit": 0.0,
+                    "credit": 190.08,
+                    "debit_in_transaction_currency": 0.0,
+                    "credit_in_transaction_currency": 190.08,
+                },
                 {
                     "account": "Asset Received But Not Billed - _TIRC",
                     "debit": 0.0,
                     "credit": 1999.0,
+                    "debit_in_transaction_currency": 0.0,
+                    "credit_in_transaction_currency": 1999.0,
                 },
                 {
                     "account": "CWIP Account - _TIRC",
                     "debit": 2178.82,
                     "credit": 0.0,
+                    "debit_in_transaction_currency": 2178.82,
+                    "credit_in_transaction_currency": 0.0,
                 },
                 {
                     "account": "Administrative Expenses - _TIRC",
                     "debit": 998.0,
                     "credit": 0.0,
+                    "debit_in_transaction_currency": 998.0,
+                    "credit_in_transaction_currency": 0.0,
                 },
                 {
                     "account": "Unsecured Loans - _TIRC",
                     "debit": 0.0,
                     "credit": 998.0,
+                    "debit_in_transaction_currency": 0.0,
+                    "credit_in_transaction_currency": 998.0,
                 },
                 {
                     "account": "Administrative Expenses - _TIRC",
                     "debit": 1500.0,
                     "credit": 0.0,
+                    "debit_in_transaction_currency": 1500.0,
+                    "credit_in_transaction_currency": 0.0,
                 },
                 {
                     "account": "Unsecured Loans - _TIRC",
                     "debit": 0.0,
                     "credit": 1500.0,
+                    "debit_in_transaction_currency": 0.0,
+                    "credit_in_transaction_currency": 1500.0,
                 },
                 {
                     "account": "Stock Received But Not Billed - _TIRC",
                     "debit": 0.0,
                     "credit": 257.0,
+                    "debit_in_transaction_currency": 0.0,
+                    "credit_in_transaction_currency": 257.0,
                 },
                 {
                     "account": "Stock In Hand - _TIRC",
                     "debit": 267.26,
                     "credit": 0.0,
+                    "debit_in_transaction_currency": 267.26,
+                    "credit_in_transaction_currency": 0.0,
                 },
             ],
         )
@@ -887,38 +1158,62 @@ class TestIneligibleITC(IntegrationTestCase):
         self.assertGLEntry(
             doc.name,
             [
-                {"account": "Round Off - _TIRC", "debit": 0.28, "credit": 0.0},
+                {
+                    "account": "Round Off - _TIRC",
+                    "debit": 0.28,
+                    "credit": 0.0,
+                    "debit_in_transaction_currency": 0.0,
+                    "credit_in_transaction_currency": 0.0,
+                },
                 {
                     "account": "GST Expense - _TIRC",
                     "debit": 369.72,
                     "credit": 179.64,
+                    "debit_in_transaction_currency": 369.72,
+                    "credit_in_transaction_currency": 179.64,
                 },
                 {
                     "account": "Input Tax SGST - _TIRC",
                     "debit": 427.86,
                     "credit": 184.86,
+                    "debit_in_transaction_currency": 427.86,
+                    "credit_in_transaction_currency": 184.86,
                 },
                 {
                     "account": "Input Tax CGST - _TIRC",
                     "debit": 427.86,
                     "credit": 184.86,
+                    "debit_in_transaction_currency": 427.86,
+                    "credit_in_transaction_currency": 184.86,
                 },
                 {
                     "account": "Asset Received But Not Billed - _TIRC",
                     "debit": 1999.0,
                     "credit": 0.0,
+                    "debit_in_transaction_currency": 1999.0,
+                    "credit_in_transaction_currency": 0.0,
                 },
                 {
                     "account": "Administrative Expenses - _TIRC",
                     "debit": 2677.64,
                     "credit": 0.0,
+                    "debit_in_transaction_currency": 2677.64,
+                    "credit_in_transaction_currency": 0.0,
                 },
                 {
                     "account": "Stock Received But Not Billed - _TIRC",
                     "debit": 257.0,
                     "credit": 0.0,
+                    "debit_in_transaction_currency": 257.0,
+                    "credit_in_transaction_currency": 0.0,
                 },
-                {"account": "Creditors - _TIRC", "debit": 0.0, "credit": 5610.0},
+                {
+                    "account": "Creditors - _TIRC",
+                    "debit": 0.0,
+                    "credit": 5610.0,
+                    "debit_in_transaction_currency": 0.0,
+                    "credit_in_transaction_currency": 5610.0,
+                },
             ],
         )
 
@@ -944,15 +1239,37 @@ class TestIneligibleITC(IntegrationTestCase):
                     "account": "Administrative Expenses - _TIRC",
                     "debit": 179.64,
                     "credit": 0.0,
+                    "debit_in_transaction_currency": 179.64,
+                    "credit_in_transaction_currency": 0.0,
                 },
                 {
                     "account": "Customs Duty Payable - _TIRC",
                     "debit": 0.0,
                     "credit": 855.72,
+                    "debit_in_transaction_currency": 0.0,
+                    "credit_in_transaction_currency": 855.72,
                 },
-                {"account": "GST Expense - _TIRC", "debit": 369.72, "credit": 179.64},
-                {"account": "Input Tax IGST - _TIRC", "debit": 0.0, "credit": 369.72},
-                {"account": "Input Tax IGST - _TIRC", "debit": 855.72, "credit": 0.0},
+                {
+                    "account": "GST Expense - _TIRC",
+                    "debit": 369.72,
+                    "credit": 179.64,
+                    "debit_in_transaction_currency": 369.72,
+                    "credit_in_transaction_currency": 179.64,
+                },
+                {
+                    "account": "Input Tax IGST - _TIRC",
+                    "debit": 0.0,
+                    "credit": 369.72,
+                    "debit_in_transaction_currency": 0.0,
+                    "credit_in_transaction_currency": 369.72,
+                },
+                {
+                    "account": "Input Tax IGST - _TIRC",
+                    "debit": 855.72,
+                    "credit": 0.0,
+                    "debit_in_transaction_currency": 855.72,
+                    "credit_in_transaction_currency": 0.0,
+                },
             ],
         )
 
@@ -977,7 +1294,13 @@ class TestIneligibleITC(IntegrationTestCase):
         gl_entries = frappe.get_all(
             "GL Entry",
             filters={"voucher_no": docname, "is_cancelled": 0},
-            fields=["account", "debit", "credit"],
+            fields=[
+                "account",
+                "debit",
+                "credit",
+                "debit_in_transaction_currency",
+                "credit_in_transaction_currency",
+            ],
         )
 
         out_str = json.dumps(sorted(gl_entries, key=json.dumps))

--- a/india_compliance/gst_india/overrides/test_ineligible_itc.py
+++ b/india_compliance/gst_india/overrides/test_ineligible_itc.py
@@ -449,6 +449,66 @@ class TestIneligibleITC(IntegrationTestCase):
             ],
         )
 
+    @change_settings(
+        "Accounts Settings",
+        {"allow_multi_currency_invoices_against_single_party_account": 1},
+    )
+    def test_purchase_invoice_in_foreign_currency(self):
+        transaction_details = {
+            "doctype": "Purchase Invoice",
+            "bill_no": "BILL-12",
+            "currency": "USD",
+            "conversion_rate": 100,
+            "items": [{"item_code": "Test Ineligible Service Item", "qty": 1, "rate": 1000}],
+            "is_in_state": 1,
+        }
+
+        doc = create_transaction(**transaction_details)
+
+        self.assertEqual(doc.ineligibility_reason, "Ineligible As Per Section 17(5)")
+
+        # 1000 USD = 100000 INR, GST 18% = 18000 INR or 180 USD
+        self.assertGLEntry(
+            doc.name,
+            [
+                {
+                    "account": "GST Expense - _TIRC",
+                    "debit": 18000.0,
+                    "credit": 18000.0,
+                    "debit_in_transaction_currency": 180.0,
+                    "credit_in_transaction_currency": 180.0,
+                },
+                {
+                    "account": "Input Tax SGST - _TIRC",
+                    "debit": 9000.0,
+                    "credit": 9000.0,
+                    "debit_in_transaction_currency": 90.0,
+                    "credit_in_transaction_currency": 90.0,
+                },
+                {
+                    "account": "Input Tax CGST - _TIRC",
+                    "debit": 9000.0,
+                    "credit": 9000.0,
+                    "debit_in_transaction_currency": 90.0,
+                    "credit_in_transaction_currency": 90.0,
+                },
+                {
+                    "account": "Administrative Expenses - _TIRC",
+                    "debit": 118000.0,
+                    "credit": 0.0,
+                    "debit_in_transaction_currency": 1180.0,
+                    "credit_in_transaction_currency": 0.0,
+                },  # 100000 + 18000
+                {
+                    "account": "Creditors - _TIRC",
+                    "debit": 0.0,
+                    "credit": 118000.0,
+                    "debit_in_transaction_currency": 0.0,
+                    "credit_in_transaction_currency": 1180.0,
+                },
+            ],
+        )
+
     def test_purchase_invoice_with_ineligible_pos(self):
         transaction_details = {
             "doctype": "Purchase Invoice",


### PR DESCRIPTION
Issue: When it is not perpetual, then for asset also gl is not booked from SL.

- Also fixed the transaction currency.

