### PR TITLE
fix: add multiple doctypes to `audit_trail_doctypes` hook

### DIFF
--- a/india_compliance/hooks.py
+++ b/india_compliance/hooks.py
@@ -467,10 +467,7 @@ audit_trail_doctypes = [
     # Additional ERPNext DocTypes that constitute "Books of Account"
     "Asset Depreciation Schedule",
     "POS Invoice",
-    # Affects the GL entry creation
     "Cost Center Allocation",
-    # ERPNext DocTypes that have track_changes enabled by default
-    # Need to add here to stop them from being disabled when Audit Trail is enabled
     "Exchange Rate Revaluation",
     "Asset Value Adjustment",
     # India Compliance DocTypes that make GL Entries

--- a/india_compliance/hooks.py
+++ b/india_compliance/hooks.py
@@ -465,6 +465,7 @@ audit_trail_doctypes = [
     "Stock Reconciliation",
     "Subcontracting Receipt",
     # Additional ERPNext DocTypes that constitute "Books of Account"
+    "Asset Depreciation Schedule",
     "POS Invoice",
     # India Compliance DocTypes that make GL Entries
     "Bill of Entry",

--- a/india_compliance/hooks.py
+++ b/india_compliance/hooks.py
@@ -467,6 +467,12 @@ audit_trail_doctypes = [
     # Additional ERPNext DocTypes that constitute "Books of Account"
     "Asset Depreciation Schedule",
     "POS Invoice",
+    # Affects the GL entry creation
+    "Cost Center Allocation",
+    # ERPNext DocTypes that have track_changes enabled by default
+    # Need to add here to stop them from being disabled when Audit Trail is enabled
+    "Exchange Rate Revaluation",
+    "Asset Value Adjustment",
     # India Compliance DocTypes that make GL Entries
     "Bill of Entry",
 ]

--- a/india_compliance/patches.txt
+++ b/india_compliance/patches.txt
@@ -18,7 +18,7 @@ india_compliance.patches.v14.remove_ecommerce_gstin_from_purchase_invoice
 india_compliance.patches.v14.set_sandbox_mode_in_gst_settings
 execute:from india_compliance.gst_india.setup import add_fields_to_item_variant_settings; add_fields_to_item_variant_settings()
 execute:from india_compliance.gst_india.setup import create_accounting_dimension_fields; create_accounting_dimension_fields()
-execute:from india_compliance.audit_trail.setup import setup_fixtures; setup_fixtures()
+execute:from india_compliance.audit_trail.setup import setup_fixtures; setup_fixtures() #1
 india_compliance.patches.v14.set_default_for_audit_trail_notification
 india_compliance.patches.post_install.update_state_name_to_puducherry
 india_compliance.patches.post_install.rename_import_of_capital_goods


### PR DESCRIPTION
As per custom request `Asset Depreciation Schedule` should have track_changes in sync with `Enable Audit Trail` of `Account Settings`. Run `bench migrate` after this change to fix the issue.

Some other DocTypes may have get the same issue. Selected ones are finally added to hooks in this PR.

#### ERPNext
- [ ] ~Process Period Closing Voucher (majorly machine generated)~
- [x] Cost Center Allocation (not direct transaction, but governs GL entry split) *
_____
  `track_changes` true but editable
- [ ] ~Repost Payment Ledger (not set in voucher_no)~
- [x] Exchange Rate Revaluation. (makes JE and not GL)
- [x] Asset Value Adjustment (makes JE and not GL)
- [ ] ~Bank Transaction (no GL but has allow on submit fields)~

#### HRMS

separate PR made in HRMS
- [x] Gratuity *
- [X] Salary Slip
- [X] Payroll Entry
- [X] Expense Claim
____
 `track_changes` true but editable
- [x] Leave Encashment *
- [ ] ~Employee Advance (no direct GL)~
- [ ] ~Full and Final Statement~