### PR TITLE
refactor: GSTR-1 books processing

### DIFF
--- a/india_compliance/gst_india/utils/gstr_1/gstr_1_books_map.py
+++ b/india_compliance/gst_india/utils/gstr_1/gstr_1_books_map.py
@@ -87,7 +87,7 @@ class GSTR1BooksData:
             Category.AT.value: self.prepare_advances_recevied_data(),
             Category.TXP.value: self.prepare_advances_adjusted_data(),
             Category.DOC_ISSUE.value: self.prepare_document_issued_data(),
-            **hsn.from_books(hsn_rows, self.describe_hsn),
+            **hsn.from_books(hsn_rows, self.hsn_descriptions(hsn_rows).get),
         }.items():
             if rows:
                 prepared_data[category] = rows
@@ -101,16 +101,20 @@ class GSTR1BooksData:
     def prepare_hsn_data(self, invoices):
         hsn_rows, *_ = self.get_structured_data(invoices, only_for_hsn=True)
 
-        return hsn.from_books(hsn_rows, self.describe_hsn)
+        return hsn.from_books(hsn_rows, self.hsn_descriptions(hsn_rows).get)
 
-    def describe_hsn(self, hsn_code):
-        """Description held against a product code. Cached, so one query serves the whole return."""
-        if not hasattr(self, "_hsn_descriptions"):
-            self._hsn_descriptions = frappe._dict(
-                frappe.get_all("GST HSN Code", fields=["name", "description"], as_list=True)
+    def hsn_descriptions(self, hsn_rows):
+        """Descriptions for the product codes this return reports, and no others."""
+        codes = {row.gst_hsn_code for by_key in hsn_rows.values() for rows in by_key.values() for row in rows}
+
+        return frappe._dict(
+            frappe.get_all(
+                "GST HSN Code",
+                fields=["name", "description"],
+                filters={"name": ("in", list(codes))},
+                as_list=True,
             )
-
-        return self._hsn_descriptions.get(hsn_code)
+        )
 
     def operator_name(self, gstin):
         """Supplier behind an e-commerce GSTIN, looked up once per return."""

--- a/india_compliance/gst_india/utils/gstr_1/gstr_1_books_map.py
+++ b/india_compliance/gst_india/utils/gstr_1/gstr_1_books_map.py
@@ -1,8 +1,6 @@
-"""Books data -- invoices, advances, document ranges -- into our GSTR-1 shape."""
+"""Map books data (invoices, advances, document ranges) into the canonical GSTR-1 shape."""
 
 from collections import defaultdict
-from itertools import chain
-from typing import ClassVar
 
 import frappe
 from frappe.utils import cint, flt
@@ -13,10 +11,7 @@ from india_compliance.gst_india.utils import (
     get_party_for_gstin,
 )
 from india_compliance.gst_india.utils.gstr_1 import (
-    CATEGORY_SUB_CATEGORY_MAPPING,
     Category,
-    DocField,
-    ItemField,
     SubCategory,
 )
 from india_compliance.gst_india.utils.gstr_1.gstr_1_data import (
@@ -24,357 +19,33 @@ from india_compliance.gst_india.utils.gstr_1.gstr_1_data import (
     GSTR1Invoices,
     GSTR11A11BData,
 )
-from india_compliance.gst_india.utils.gstr_1.sections._shared import sum_column, sum_money
+from india_compliance.gst_india.utils.gstr_1.sections import _shared as s
+from india_compliance.gst_india.utils.gstr_1.sections import (
+    advances,
+    b2b,
+    b2cl,
+    b2cs,
+    cdnr,
+    cdnur,
+    doc_issue,
+    exports,
+    hsn,
+    nil_rated,
+    supecom,
+)
 
-# gst_treatment -> the nil-rated amount it belongs to
-NIL_RATED_AMOUNTS = {
-    "Nil-Rated": DocField.NIL_RATED_AMOUNT,
-    "Exempted": DocField.EXEMPTED_AMOUNT,
-    "Non-GST": DocField.NON_GST_AMOUNT,
-}
 
+class GSTR1BooksData:
+    """Books data -> canonical GSTR-1.
 
-class BooksDataMapper:
-    def get_transaction_type(self, invoice):
-        if invoice.is_debit_note:
-            return "Debit Note"
-        elif invoice.is_return:
-            return "Credit Note"
-        else:
-            return "Invoice"
+    Queries the invoices, hands the rows to each category to build its own, and reports what
+    rounding cost. Row building itself lives with the category, in `sections/`.
+    """
 
-    def get_category_from_subcategory(self, invoice_sub_category: str) -> Category:
-        invoice_sub_category = SubCategory(invoice_sub_category)
-        for category, sub_category in CATEGORY_SUB_CATEGORY_MAPPING.items():
-            if invoice_sub_category in sub_category:
-                return category
-
-    DATA_TO_ITEM_FIELD_MAPPING: ClassVar[dict] = {
-        DocField.TAXABLE_VALUE: ItemField.TAXABLE_VALUE,
-        DocField.IGST: ItemField.IGST,
-        DocField.CGST: ItemField.CGST,
-        DocField.SGST: ItemField.SGST,
-        DocField.CESS: ItemField.CESS,
-    }
-
-    ITEM_TO_INVOICE_FIELD_MAPPING: ClassVar[dict] = {
-        ItemField.TAXABLE_VALUE: "taxable_value",
-        ItemField.IGST: "igst_amount",
-        ItemField.CGST: "cgst_amount",
-        ItemField.SGST: "sgst_amount",
-        ItemField.CESS: "total_cess_amount",
-    }
-
-    DATA_TO_INVOICE_FIELD_MAPPING: ClassVar[dict] = {
-        DocField.TAXABLE_VALUE: "taxable_value",
-        DocField.IGST: "igst_amount",
-        DocField.CGST: "cgst_amount",
-        DocField.SGST: "sgst_amount",
-        DocField.CESS: "total_cess_amount",
-    }
-
-    def process_data_for_invoice_no_key(self, grouped_data, prepared_data):
-        """
-        Input:
-            grouped_data: {
-                (invoice_sub_category, invoice_no): {
-                    gst_rate: [invoice_items]
-                }
-            }
-            prepared_data: dict to be updated with the processed data
-        """
-        if not grouped_data:
-            return
-
-        for (sub_category, invoice_no), rate_wise_item in grouped_data.items():
-            doc = next(chain(*rate_wise_item.values()))
-
-            if sub_category not in prepared_data:
-                prepared_data[sub_category] = {}
-
-            sub_category_dict = prepared_data[sub_category]
-            sub_category_dict[invoice_no] = {
-                # TODO: make a method for creating the dict
-                DocField.TRANSACTION_TYPE: self.get_transaction_type(doc),
-                DocField.CUST_GSTIN: doc.billing_address_gstin,
-                DocField.CUST_NAME: doc.customer_name,
-                DocField.DOC_DATE: doc.posting_date,
-                DocField.DOC_NUMBER: doc.invoice_no,
-                DocField.DOC_VALUE: doc.invoice_total,
-                DocField.POS: doc.place_of_supply,
-                DocField.REVERSE_CHARGE: ("Y" if doc.is_reverse_charge else "N"),
-                DocField.DOC_TYPE: doc.invoice_type,
-                **self.get_invoice_values(),
-                DocField.DIFF_PERCENTAGE: 0,
-                DocField.SHIPPING_PORT_CODE: doc.shipping_port_code,
-                DocField.SHIPPING_BILL_NUMBER: doc.shipping_bill_number,
-                DocField.SHIPPING_BILL_DATE: doc.shipping_bill_date,
-                "items": [],
-            }
-
-            invoice = sub_category_dict[invoice_no]
-
-            for gst_rate, items in rate_wise_item.items():
-                tax_item = {
-                    key: sum_column(items, field) for key, field in self.ITEM_TO_INVOICE_FIELD_MAPPING.items()
-                }
-                tax_item[ItemField.TAX_RATE] = gst_rate
-                invoice["items"].append(tax_item)
-
-            # amounts arrive settled to two decimals, so the totals only have to add up
-            for total, field in self.DATA_TO_ITEM_FIELD_MAPPING.items():
-                invoice[total] = sum_column(invoice["items"], field)
-
-    def process_data_for_nil_exempt(self, grouped_data, prepared_data):
-        """
-        Input:
-            grouped_data: {
-                (invoice_sub_category, invoice_no): {
-                    gst_rate: [invoice_items]
-                }
-            }
-            prepared_data: dict to be updated with the processed data
-        """
-        if not grouped_data:
-            return
-
-        sub_category = SubCategory.NIL_EXEMPT.value
-        nil_exempt = prepared_data.setdefault(sub_category, {})
-
-        for _, rate_wise_item in grouped_data.items():
-            item = next(chain(*rate_wise_item.values()), None)
-
-            if item.invoice_type not in nil_exempt:
-                nil_exempt[item.invoice_type] = []
-
-            invoices_by_type = nil_exempt[item.invoice_type]
-
-            invoice = {
-                DocField.TRANSACTION_TYPE: self.get_transaction_type(item),
-                DocField.CUST_GSTIN: item.billing_address_gstin,
-                DocField.CUST_NAME: item.customer_name,
-                DocField.DOC_NUMBER: item.invoice_no,
-                DocField.DOC_DATE: item.posting_date,
-                DocField.DOC_VALUE: item.invoice_total,
-                DocField.POS: item.place_of_supply,
-                DocField.REVERSE_CHARGE: ("Y" if item.is_reverse_charge else "N"),
-                DocField.DOC_TYPE: item.invoice_type,
-                DocField.TAXABLE_VALUE: 0,
-                DocField.NIL_RATED_AMOUNT: 0,
-                DocField.EXEMPTED_AMOUNT: 0,
-                DocField.NON_GST_AMOUNT: 0,
-            }
-
-            invoices_by_type.append(invoice)
-
-            lines = list(chain(*rate_wise_item.values()))
-            invoice[DocField.TAXABLE_VALUE] = sum_column(lines, "taxable_value")
-
-            for treatment, field in NIL_RATED_AMOUNTS.items():
-                invoice[field] = sum_column(
-                    [line for line in lines if line.gst_treatment == treatment], "taxable_value"
-                )
-
-    def process_data_for_b2cs(self, grouped_data, prepared_data):
-        """
-        Input:
-            grouped_data: {
-                (invoice_sub_category, invoice_no): {
-                    gst_rate: [invoice_items]
-                }
-            }
-            prepared_data: dict to be updated with the processed data
-        """
-        if not grouped_data:
-            return
-
-        sub_category = Category.B2CS.value
-        b2c_others = prepared_data.setdefault(sub_category, {})
-
-        for _, rate_wise_item in grouped_data.items():
-            for gst_rate, items in rate_wise_item.items():
-                item = items[0]
-                key = f"{item.place_of_supply} - {flt(gst_rate)}"
-
-                if key not in b2c_others:
-                    b2c_others[key] = []
-
-                invoice_list = b2c_others[key]
-
-                invoice = {
-                    DocField.DOC_DATE: item.posting_date,
-                    DocField.DOC_NUMBER: item.invoice_no,
-                    DocField.DOC_VALUE: item.invoice_total,
-                    DocField.CUST_NAME: item.customer_name,
-                    # currently other value is not supported in GSTR-1
-                    DocField.DOC_TYPE: "OE",
-                    DocField.TRANSACTION_TYPE: self.get_transaction_type(item),
-                    DocField.POS: item.place_of_supply,
-                    DocField.TAX_RATE: item.gst_rate,
-                    DocField.ECOMMERCE_GSTIN: item.ecommerce_gstin,
-                    **self.get_invoice_values(),
-                }
-
-                invoice_list.append(invoice)
-
-                for total, field in self.DATA_TO_INVOICE_FIELD_MAPPING.items():
-                    invoice[total] = sum_column(items, field)
-
-    def process_data_for_hsn_summary(self, grouped_data, prepared_data):
-        """
-        Input:
-            grouped_data: {
-                invoice_sub_category: {
-                    "gst_hsn_code - uom - gst_rate": [invoice_items]
-                }
-            }
-            prepared_data: dict to be updated with the processed data
-        """
-
-        data_to_invoice_field_map = {
-            **self.DATA_TO_INVOICE_FIELD_MAPPING,
-            DocField.QUANTITY: "qty",
-        }
-        tax_fields = self.DATA_TO_INVOICE_FIELD_MAPPING.keys()
-
-        for sub_category, hsn_key in grouped_data.items():
-            sub_category_dict = prepared_data.setdefault(sub_category, {})
-
-            # HSN Descriptions
-            hsn_codes = [key.split(" - ")[0] for key in hsn_key]
-            descriptions = frappe._dict(
-                frappe.get_all(
-                    "GST HSN Code",
-                    fields=["name", "description"],
-                    filters={"name": ["in", hsn_codes]},
-                    as_list=True,
-                )
-            )
-
-            # Map
-            for key, items in hsn_key.items():
-                item = items[0]
-
-                sub_category_dict[key] = {
-                    DocField.DOC_TYPE: sub_category,
-                    DocField.HSN_CODE: item.gst_hsn_code,
-                    DocField.DESCRIPTION: descriptions.get(item.gst_hsn_code),
-                    DocField.UOM: item.uom,
-                    DocField.QUANTITY: 0,
-                    DocField.TAX_RATE: item.gst_rate,
-                    **self.get_invoice_values(),
-                }
-
-                invoice = sub_category_dict[key]
-
-                # Aggregate
-                for total, field in data_to_invoice_field_map.items():
-                    invoice[total] = sum_column(items, field)
-
-                invoice[DocField.DOC_VALUE] = sum_money(invoice, tax_fields)
-
-    def process_data_for_supecom(self, grouped_data, prepared_data):
-        """
-        Aggregate e-commerce supplies by operator GSTIN for each supply type.
-
-        Input:
-            grouped_data: {ecommerce_supply_type: {invoice_no: [invoice_items]}}
-            prepared_data: dict to be updated with the processed data
-
-        Output structure (before normalize_data):
-            {
-                SUPECOM_52.value: {eco_gstin: {doc_type, eco_gstin, taxable_value, igst, ...}},
-                SUPECOM_9_5.value: {...},
-            }
-        """
-        if not grouped_data:
-            return
-
-        def get_party_name_for_gstin(eco_gstin, party_name_map):
-            if eco_gstin not in party_name_map:
-                party_name_map[eco_gstin] = get_party_for_gstin(eco_gstin, "Supplier") or ""
-
-            return party_name_map[eco_gstin]
-
-        party_name_map = {}
-
-        for supply_type, invoice_wise in grouped_data.items():
-            sub_category = prepared_data.setdefault(supply_type, {})
-
-            for items in invoice_wise.values():
-                eco_gstin = items[0].get("ecommerce_gstin", "")
-                entry = sub_category.setdefault(
-                    eco_gstin,
-                    {
-                        DocField.DOC_TYPE: supply_type,
-                        DocField.ECOMMERCE_GSTIN: eco_gstin,
-                        DocField.ECOMMERCE_OPERATOR_NAME: get_party_name_for_gstin(eco_gstin, party_name_map),
-                        **self.get_invoice_values(),
-                    },
-                )
-
-                for total, field in self.DATA_TO_INVOICE_FIELD_MAPPING.items():
-                    entry[total] = flt(entry[total] + sum_column(items, field), 2)
-
-    def process_data_for_document_issued_summary(self, row, prepared_data):
-        key = f"{row['nature_of_document']} - {row['from_serial_no']}"
-
-        if key in prepared_data:
-            return
-
-        prepared_data[key] = {
-            DocField.DOC_TYPE: row["nature_of_document"],
-            DocField.FROM_SR: row["from_serial_no"],
-            DocField.TO_SR: row["to_serial_no"],
-            DocField.TOTAL_COUNT: row["total_issued"],
-            DocField.DRAFT_COUNT: row["total_draft"],
-            DocField.CANCELLED_COUNT: row["cancelled"],
-            DocField.NET_ISSUE: row["total_submitted"],
-        }
-
-    def process_data_for_advances_received_or_adjusted(self, row, prepared_data, multiplier=1):
-        advances = {}
-        tax_rate = round((row["tax_amount"] / row["taxable_value"]) * 100)
-        key = f"{row['place_of_supply']} - {flt(tax_rate)}"
-
-        mapped_dict = prepared_data.setdefault(key, [])
-
-        advances[DocField.CUST_NAME] = row["party"]
-        advances[DocField.DOC_NUMBER] = row["name"]
-        advances[DocField.DOC_DATE] = row["posting_date"]
-        advances[DocField.POS] = row["place_of_supply"]
-        advances[DocField.TAXABLE_VALUE] = row["taxable_value"] * multiplier
-        advances[DocField.TAX_RATE] = tax_rate
-        advances[DocField.CESS] = row["cess_amount"] * multiplier
-
-        if row.get("reference_name"):
-            advances["against_voucher"] = row["reference_name"]
-
-        if row["place_of_supply"][0:2] == row["company_gstin"][0:2]:
-            advances[DocField.CGST] = row["tax_amount"] / 2 * multiplier
-            advances[DocField.SGST] = row["tax_amount"] / 2 * multiplier
-            advances[DocField.IGST] = 0
-
-        else:
-            advances[DocField.IGST] = row["tax_amount"] * multiplier
-            advances[DocField.CGST] = 0
-            advances[DocField.SGST] = 0
-
-        mapped_dict.append(advances)
-
-    # utils
-
-    def get_invoice_values(self, invoice=None):
-        if invoice is None:
-            invoice = {}
-
-        return {
-            DocField.TAXABLE_VALUE: invoice.get("taxable_value", 0),
-            DocField.IGST: invoice.get("igst_amount", 0),
-            DocField.CGST: invoice.get("cgst_amount", 0),
-            DocField.SGST: invoice.get("sgst_amount", 0),
-            DocField.CESS: invoice.get("total_cess_amount", 0),
-        }
+    def __init__(self, filters):
+        self.filters = filters
+        if filters.get("month_or_quarter"):
+            self.current_month = MONTHS.index(filters.month_or_quarter) + 1
 
     def update_rounding_difference(self, prepared_data, lost_to_rounding):
         """Report what settling the amounts cost.
@@ -382,9 +53,11 @@ class BooksDataMapper:
         Reported under the invoice total names, because the page offers to post a journal entry
         from these figures -- that is how the residual gets back into the ledger.
         """
+        # never None -- flt without a precision rounds nothing, and float dust reads as a real residual
         precision = cint(frappe.db.get_default("currency_precision")) or 2
-        reported_as = {column: total for total, column in self.DATA_TO_INVOICE_FIELD_MAPPING.items()}
+        reported_as = s.flip(s.BOOKS_COLUMNS)
 
+        # an amount with no invoice total to sit under keeps its own name rather than raising here
         difference = {
             reported_as.get(column, column): flt(value, precision)
             for column, value in lost_to_rounding.items()
@@ -393,13 +66,6 @@ class BooksDataMapper:
         # saved as object -> it's normalized
         prepared_data["rounding_difference"] = {"rounding_difference": difference}
 
-
-class GSTR1BooksData(BooksDataMapper):
-    def __init__(self, filters):
-        self.filters = filters
-        if filters.get("month_or_quarter"):
-            self.current_month = MONTHS.index(filters.month_or_quarter) + 1
-
     def prepare_mapped_data(self):
         prepared_data = {}
 
@@ -407,26 +73,24 @@ class GSTR1BooksData(BooksDataMapper):
         data = _class.get_invoices_for_item_wise_summary()
         _class.process_invoices(data)  # amounts come back settled to two decimals
 
-        data_for_hsn, data_for_invoice_no_key, data_for_nil_exempt, data_for_b2cs, data_for_supecom = (
-            self.get_structured_data(data)
-        )
+        hsn_rows, invoice_rows, nil_rows, b2cs_rows, supecom_rows = self.get_structured_data(data)
 
-        self.process_data_for_invoice_no_key(data_for_invoice_no_key, prepared_data)
-        self.process_data_for_nil_exempt(data_for_nil_exempt, prepared_data)
-        self.process_data_for_b2cs(data_for_b2cs, prepared_data)
-        self.process_data_for_supecom(data_for_supecom, prepared_data)
+        # each category takes the rows it reports and builds them its own way
+        for section in (b2b, b2cl, exports, cdnr, cdnur):
+            prepared_data.update(section.from_books(invoice_rows))
 
-        other_categories = {
+        prepared_data.update(nil_rated.from_books(nil_rows))
+        prepared_data.update(b2cs.from_books(b2cs_rows))
+        prepared_data.update(supecom.from_books(supecom_rows, self.operator_name))
+
+        for category, rows in {
             Category.AT.value: self.prepare_advances_recevied_data(),
             Category.TXP.value: self.prepare_advances_adjusted_data(),
             Category.DOC_ISSUE.value: self.prepare_document_issued_data(),
-        }
-
-        self.process_data_for_hsn_summary(data_for_hsn, other_categories)
-
-        for category, data in other_categories.items():
-            if data:
-                prepared_data[category] = data
+            **hsn.from_books(hsn_rows, self.describe_hsn),
+        }.items():
+            if rows:
+                prepared_data[category] = rows
 
         self.process_for_quarterly(prepared_data)
 
@@ -435,12 +99,28 @@ class GSTR1BooksData(BooksDataMapper):
         return prepared_data
 
     def prepare_hsn_data(self, invoices):
-        hsn_summary = {}
+        hsn_rows, *_ = self.get_structured_data(invoices, only_for_hsn=True)
 
-        data_for_hsn, *_ = self.get_structured_data(invoices, only_for_hsn=True)
-        self.process_data_for_hsn_summary(data_for_hsn, hsn_summary)
+        return hsn.from_books(hsn_rows, self.describe_hsn)
 
-        return hsn_summary
+    def describe_hsn(self, hsn_code):
+        """Description held against a product code. Cached, so one query serves the whole return."""
+        if not hasattr(self, "_hsn_descriptions"):
+            self._hsn_descriptions = frappe._dict(
+                frappe.get_all("GST HSN Code", fields=["name", "description"], as_list=True)
+            )
+
+        return self._hsn_descriptions.get(hsn_code)
+
+    def operator_name(self, gstin):
+        """Supplier behind an e-commerce GSTIN, looked up once per return."""
+        if not hasattr(self, "_operator_names"):
+            self._operator_names = {}
+
+        if gstin not in self._operator_names:
+            self._operator_names[gstin] = get_party_for_gstin(gstin, "Supplier") or ""
+
+        return self._operator_names[gstin]
 
     def get_structured_data(self, data, only_for_hsn=False):
         """
@@ -467,6 +147,8 @@ class GSTR1BooksData(BooksDataMapper):
                 hsn_key = f"{item.gst_hsn_code} - {item.uom} - {gst_rate}"
                 data_for_hsn[hsn_sub_category][hsn_key].append(item)
 
+            # an empty line, not merely one with no taxable value -- a line can carry tax without
+            # it, and dropping such a line takes tax out of the return while HSN still counts it
             if only_for_hsn or not any(item.get(field) for field in GSTR1Invoices.AMOUNT_FIELDS):
                 continue
 
@@ -496,13 +178,7 @@ class GSTR1BooksData(BooksDataMapper):
         return data_for_hsn, data_for_invoice_no_key, data_for_nil_exempt, data_for_b2cs, data_for_supecom
 
     def prepare_document_issued_data(self):
-        doc_issued_data = {}
-        data = GSTR1DocumentIssuedSummary(self.filters).get_data()
-
-        for row in data:
-            self.process_data_for_document_issued_summary(row, doc_issued_data)
-
-        return doc_issued_data
+        return doc_issue.from_books(GSTR1DocumentIssuedSummary(self.filters).get_data())
 
     def prepare_advances_recevied_data(self):
         return self.prepare_advances_received_or_adjusted_data("Advances")
@@ -511,7 +187,6 @@ class GSTR1BooksData(BooksDataMapper):
         return self.prepare_advances_received_or_adjusted_data("Adjustment")
 
     def prepare_advances_received_or_adjusted_data(self, type_of_business):
-        advances_data = {}
         self.filters.type_of_business = type_of_business
         gst_accounts = get_gst_accounts_by_type(self.filters.company, "Output")
         _class = GSTR11A11BData(self.filters, gst_accounts)
@@ -538,12 +213,8 @@ class GSTR1BooksData(BooksDataMapper):
             multipler = -1
 
         query = query.select(*fields)
-        data = query.run(as_dict=True)
 
-        for row in data:
-            self.process_data_for_advances_received_or_adjusted(row, advances_data, multipler)
-
-        return advances_data
+        return advances.from_books(query.run(as_dict=True), multipler)
 
     def process_for_quarterly(self, data):
         if self.filters.filing_preference != "Quarterly":

--- a/india_compliance/gst_india/utils/gstr_1/gstr_1_books_map.py
+++ b/india_compliance/gst_india/utils/gstr_1/gstr_1_books_map.py
@@ -107,6 +107,9 @@ class GSTR1BooksData:
         """Descriptions for the product codes this return reports, and no others."""
         codes = {row.gst_hsn_code for by_key in hsn_rows.values() for rows in by_key.values() for row in rows}
 
+        if not codes:
+            return frappe._dict()
+
         return frappe._dict(
             frappe.get_all(
                 "GST HSN Code",

--- a/india_compliance/gst_india/utils/gstr_1/gstr_1_data.py
+++ b/india_compliance/gst_india/utils/gstr_1/gstr_1_data.py
@@ -27,6 +27,7 @@ from india_compliance.gst_india.utils.gstr_1 import (
     SubCategory,
     get_b2c_limit,
 )
+from india_compliance.gst_india.utils.gstr_1.sections import cdnur, exports, nil_rated
 from india_compliance.gst_india.utils.gstr_1.sections._shared import split
 
 CATEGORY_CONDITIONS = {
@@ -352,11 +353,11 @@ class GSTR1Subcategory(GSTR1CategoryConditions):
     def set_for_exports(self, invoice):
         if invoice.is_export_with_gst:
             invoice.invoice_sub_category = SubCategory.EXPWP.value
-            invoice.invoice_type = "WPAY"
+            invoice.invoice_type = exports.WITH_TAX
 
         else:
             invoice.invoice_sub_category = SubCategory.EXPWOP.value
-            invoice.invoice_type = "WOPAY"
+            invoice.invoice_type = exports.WITHOUT_TAX
 
     def set_for_b2cs(self, invoice):
         # NO INVOICE VALUE
@@ -367,10 +368,8 @@ class GSTR1Subcategory(GSTR1CategoryConditions):
         is_registered = self.has_gstin_and_is_not_export(invoice)
         is_interstate = self.is_inter_state(invoice)
 
-        gst_registration = "registered" if is_registered else "unregistered"
-        supply_type = "Inter-State" if is_interstate else "Intra-State"
-
-        invoice.invoice_type = f"{supply_type} supplies to {gst_registration} persons"
+        code = nil_rated.supply_code(is_interstate, is_registered)
+        invoice.invoice_type = nil_rated.SUPPLY_TYPES[code]
         invoice.invoice_sub_category = SubCategory.NIL_EXEMPT.value
 
     def set_for_cdnr(self, invoice):
@@ -381,13 +380,13 @@ class GSTR1Subcategory(GSTR1CategoryConditions):
         invoice.invoice_sub_category = SubCategory.CDNUR.value
         if self.is_export(invoice):
             if invoice.is_export_with_gst:
-                invoice.invoice_type = "EXPWP"
+                invoice.invoice_type = cdnur.EXPORT_WITH_TAX
                 return
 
-            invoice.invoice_type = "EXPWOP"
+            invoice.invoice_type = cdnur.EXPORT_WITHOUT_TAX
             return
 
-        invoice.invoice_type = "B2CL"
+        invoice.invoice_type = cdnur.LARGE_UNREGISTERED
         return
 
     def set_for_ecommerce_supply_type(self, invoice):

--- a/india_compliance/gst_india/utils/gstr_1/sections/_shared.py
+++ b/india_compliance/gst_india/utils/gstr_1/sections/_shared.py
@@ -5,6 +5,7 @@ blanks go at the JSON boundary.
 """
 
 from datetime import datetime
+from itertools import chain
 
 import frappe
 from frappe import _
@@ -16,6 +17,7 @@ from india_compliance.gst_india.constants import (
     UOM_MAP,
 )
 from india_compliance.gst_india.utils import get_party_for_gstin
+from india_compliance.gst_returns.fields.gstr1 import CreditDebitNoteType
 from india_compliance.gst_returns.fields.gstr1 import DocField as doc
 from india_compliance.gst_returns.fields.gstr1 import ItemField as item
 from india_compliance.gst_returns.fields.gstr1 import RawField as raw
@@ -31,6 +33,21 @@ ITEM_TOTALS = {
     item.SGST: doc.SGST,
     item.CESS: doc.CESS,
 }
+
+# the same five amounts as the books query names them
+BOOKS_COLUMNS = {
+    doc.TAXABLE_VALUE: "taxable_value",
+    doc.IGST: "igst_amount",
+    doc.CGST: "cgst_amount",
+    doc.SGST: "sgst_amount",
+    doc.CESS: "total_cess_amount",
+}
+
+# and as an item names them
+ITEM_COLUMNS = {line: BOOKS_COLUMNS[total] for line, total in ITEM_TOTALS.items()}
+
+# a books row that is not a note is an invoice; the portal has codes only for the notes
+INVOICE = "Invoice"
 
 # inter-state: no central or state tax
 ITEM_TOTALS_IGST = {
@@ -243,6 +260,77 @@ def supply_type(pos, company_gstin):
         frappe.throw(_("Company GSTIN is needed to tell an intra-state supply from an inter-state one"))
 
     return "INTRA" if pos == company_gstin[:2] else "INTER"
+
+
+# ── books ─────────────────────────────────────────────────────────────────────
+
+
+def transaction_type(row):
+    """What kind of document a books row came from."""
+    if row.is_debit_note:
+        return CreditDebitNoteType.D.value
+
+    if row.is_return:
+        return CreditDebitNoteType.C.value
+
+    return INVOICE
+
+
+def zero_totals():
+    """A fresh set of invoice totals, all at nothing."""
+    return dict.fromkeys(BOOKS_COLUMNS, 0)
+
+
+def invoice_rows_from_books(grouped_rows, subcategories):
+    """One canonical row per invoice, for the subcategories the caller reports.
+
+    B2B, B2CL, exports and both kinds of credit note all report invoice by invoice, so they share
+    this builder and each passes the subcategories it owns. The row is a superset -- shipping
+    fields, buyer GSTIN and reverse charge are always written, and each category's key table drops
+    whatever it does not report.
+
+        {("B2B Regular", "S008400"): {18.0: [item rows]}}
+     -> {"B2B Regular": {"S008400": {document_number: "S008400", items: [{tax_rate: 18.0}]}}}
+    """
+    output = {}
+
+    for (subcategory, invoice_no), rows_by_rate in grouped_rows.items():
+        if subcategory not in subcategories:
+            continue
+
+        first = next(iter(chain(*rows_by_rate.values())))
+
+        row = {
+            doc.TRANSACTION_TYPE: transaction_type(first),
+            doc.CUST_GSTIN: first.billing_address_gstin,
+            doc.CUST_NAME: first.customer_name,
+            doc.DOC_DATE: first.posting_date,
+            doc.DOC_NUMBER: first.invoice_no,
+            doc.DOC_VALUE: first.invoice_total,
+            doc.POS: first.place_of_supply,
+            doc.REVERSE_CHARGE: ("Y" if first.is_reverse_charge else "N"),
+            doc.DOC_TYPE: first.invoice_type,
+            **zero_totals(),
+            doc.DIFF_PERCENTAGE: 0,
+            doc.SHIPPING_PORT_CODE: first.shipping_port_code,
+            doc.SHIPPING_BILL_NUMBER: first.shipping_bill_number,
+            doc.SHIPPING_BILL_DATE: first.shipping_bill_date,
+            "items": [],
+        }
+
+        # one item per tax rate, because that is how the portal wants a return reported
+        for rate, rows in rows_by_rate.items():
+            line = {field: sum_column(rows, column) for field, column in ITEM_COLUMNS.items()}
+            line[item.TAX_RATE] = rate
+            row["items"].append(line)
+
+        # amounts arrive settled to two decimals, so the totals only have to add up
+        for field, total in ITEM_TOTALS.items():
+            row[total] = sum_column(row["items"], field)
+
+        output.setdefault(subcategory, {})[invoice_no] = row
+
+    return output
 
 
 # ── items ─────────────────────────────────────────────────────────────────────

--- a/india_compliance/gst_india/utils/gstr_1/sections/advances.py
+++ b/india_compliance/gst_india/utils/gstr_1/sections/advances.py
@@ -6,6 +6,7 @@ Adjustments are the same shape, sign flipped.
 
 from frappe.utils import flt
 
+from india_compliance.gst_india.constants import GST_TAX_RATES
 from india_compliance.gst_returns.fields.gstr1 import DocField as doc
 from india_compliance.gst_returns.fields.gstr1 import ItemField as item
 from india_compliance.gst_returns.fields.gstr1 import RawField as raw
@@ -15,6 +16,8 @@ from . import _shared as s
 
 RECEIVED = 1
 ADJUSTED = -1
+
+NOTIFIED_RATES = sorted(GST_TAX_RATES)
 
 KEYS = {
     raw.FLAG: doc.FLAG,
@@ -105,7 +108,7 @@ def from_books(rows, multiplier=RECEIVED):
     output = {}
 
     for entry in rows:
-        rate = round((entry["tax_amount"] / entry["taxable_value"]) * 100)
+        rate = nearest_notified_rate((entry["tax_amount"] / entry["taxable_value"]) * 100)
         intra_state = entry["place_of_supply"][:2] == entry["company_gstin"][:2]
 
         row = {
@@ -127,17 +130,14 @@ def from_books(rows, multiplier=RECEIVED):
         row[doc.SGST] = half if intra_state else 0
         row[doc.IGST] = 0 if intra_state else entry["tax_amount"] * multiplier
 
-        output.setdefault(f"{entry['place_of_supply']} - {flt(rate)}", []).append(row)
+        output.setdefault(group_key(row), []).append(row)
 
     return output
 
 
-def received_from_books(rows):
-    return from_books(rows, RECEIVED)
-
-
-def adjusted_from_books(rows):
-    return from_books(rows, ADJUSTED)
+def nearest_notified_rate(derived):
+    """18.05 -> 18.0, 0.24 -> 0.25."""
+    return min(NOTIFIED_RATES, key=lambda rate: abs(rate - derived))
 
 
 def received_to_canonical(gov_data):

--- a/india_compliance/gst_india/utils/gstr_1/sections/advances.py
+++ b/india_compliance/gst_india/utils/gstr_1/sections/advances.py
@@ -94,6 +94,52 @@ def to_gov(rows, company_gstin="", multiplier=RECEIVED):
     return list(by_pos.values())
 
 
+def from_books(rows, multiplier=RECEIVED):
+    """Books advance entries -> one row per state and rate.
+
+        [{party: "X", taxable_value: 100, tax_amount: 18, place_of_supply: "05-Uttarakhand"}]
+     -> {"05-Uttarakhand - 18.0": [{total_taxable_value: 100, tax_rate: 18}]}
+
+    The rate is worked back out of the tax, because an advance is taken before any line exists.
+    """
+    output = {}
+
+    for entry in rows:
+        rate = round((entry["tax_amount"] / entry["taxable_value"]) * 100)
+        intra_state = entry["place_of_supply"][:2] == entry["company_gstin"][:2]
+
+        row = {
+            doc.CUST_NAME: entry["party"],
+            doc.DOC_NUMBER: entry["name"],
+            doc.DOC_DATE: entry["posting_date"],
+            doc.POS: entry["place_of_supply"],
+            doc.TAXABLE_VALUE: entry["taxable_value"] * multiplier,
+            doc.TAX_RATE: rate,
+            doc.CESS: entry["cess_amount"] * multiplier,
+        }
+
+        if entry.get("reference_name"):
+            row["against_voucher"] = entry["reference_name"]
+
+        # an advance carries no items, so the tax is split here rather than per line
+        half = entry["tax_amount"] / 2 * multiplier
+        row[doc.CGST] = half if intra_state else 0
+        row[doc.SGST] = half if intra_state else 0
+        row[doc.IGST] = 0 if intra_state else entry["tax_amount"] * multiplier
+
+        output.setdefault(f"{entry['place_of_supply']} - {flt(rate)}", []).append(row)
+
+    return output
+
+
+def received_from_books(rows):
+    return from_books(rows, RECEIVED)
+
+
+def adjusted_from_books(rows):
+    return from_books(rows, ADJUSTED)
+
+
 def received_to_canonical(gov_data):
     return {SubCategory.AT.value: to_canonical(gov_data, RECEIVED)}
 

--- a/india_compliance/gst_india/utils/gstr_1/sections/b2b.py
+++ b/india_compliance/gst_india/utils/gstr_1/sections/b2b.py
@@ -43,6 +43,13 @@ SUBCATEGORY_OF = {
     "DE": SubCategory.DE.value,
 }
 
+# every subcategory B2B reports under
+SUBCATEGORIES = (
+    SubCategory.B2B_REGULAR.value,
+    SubCategory.B2B_REVERSE_CHARGE.value,
+    *SUBCATEGORY_OF.values(),
+)
+
 ITEM_DEFAULTS = dict.fromkeys(s.ITEM_TOTALS, 0)
 
 MONEY = (raw.DOC_VALUE, raw.DIFF_PERCENTAGE)
@@ -88,6 +95,11 @@ def to_canonical(gov_data):
         output.setdefault(subcategory, {})[row[doc.DOC_NUMBER]] = row
 
     return output
+
+
+def from_books(grouped_rows):
+    """Books rows -> one row per invoice, for the subcategories this category reports."""
+    return s.invoice_rows_from_books(grouped_rows, SUBCATEGORIES)
 
 
 def to_gov(rows, company_gstin=""):

--- a/india_compliance/gst_india/utils/gstr_1/sections/b2cl.py
+++ b/india_compliance/gst_india/utils/gstr_1/sections/b2cl.py
@@ -23,6 +23,8 @@ KEYS = {
     raw.CESS: item.CESS,
 }
 
+SUBCATEGORIES = (SUBCATEGORY,)
+
 ITEM_DEFAULTS = dict.fromkeys(s.ITEM_TOTALS_IGST, 0)
 
 MONEY = (raw.DOC_VALUE, raw.DIFF_PERCENTAGE)
@@ -53,6 +55,11 @@ def to_canonical(gov_data):
         output[row[doc.DOC_NUMBER]] = row
 
     return {SUBCATEGORY: output}
+
+
+def from_books(grouped_rows):
+    """Books rows -> one row per invoice, for the subcategories this category reports."""
+    return s.invoice_rows_from_books(grouped_rows, SUBCATEGORIES)
 
 
 def to_gov(rows, company_gstin=""):

--- a/india_compliance/gst_india/utils/gstr_1/sections/b2cs.py
+++ b/india_compliance/gst_india/utils/gstr_1/sections/b2cs.py
@@ -25,6 +25,9 @@ KEYS = {
     raw.ERROR_MSG: doc.ERROR_MSG,
 }
 
+# the portal's only supported type here; "E" (e-commerce) is not reported separately
+OTHER_THAN_ECOMMERCE = "OE"
+
 MONEY = (
     raw.TAXABLE_VALUE,
     raw.DIFF_PERCENTAGE,
@@ -50,6 +53,37 @@ def to_canonical(gov_data):
         output.setdefault(group_key(row), []).append(row)  # keyed "05-Uttarakhand - 5.0"
 
     return {SUBCATEGORY: output}
+
+
+def from_books(grouped_rows):
+    """Books rows -> one row per invoice per rate, grouped the way the portal totals them.
+
+       {(_, "SINV-1"): {5.0: [item rows]}}
+    -> {"B2C (Others)": {"05-Uttarakhand - 5.0": [{total_taxable_value: 110, tax_rate: 5.0}]}}
+    """
+    output = {}
+
+    for rows_by_rate in grouped_rows.values():
+        for rows in rows_by_rate.values():
+            first = rows[0]
+
+            row = {
+                doc.DOC_DATE: first.posting_date,
+                doc.DOC_NUMBER: first.invoice_no,
+                doc.DOC_VALUE: first.invoice_total,
+                doc.CUST_NAME: first.customer_name,
+                doc.DOC_TYPE: OTHER_THAN_ECOMMERCE,
+                doc.TRANSACTION_TYPE: s.transaction_type(first),
+                doc.POS: first.place_of_supply,
+                doc.TAX_RATE: first.gst_rate,
+                doc.ECOMMERCE_GSTIN: first.ecommerce_gstin,
+                **{total: s.sum_column(rows, column) for total, column in s.BOOKS_COLUMNS.items()},
+            }
+
+            output.setdefault(group_key(row), []).append(row)
+
+    # nothing to report means no section at all, not an empty one
+    return {SUBCATEGORY: output} if output else {}
 
 
 def to_gov(rows, company_gstin=""):

--- a/india_compliance/gst_india/utils/gstr_1/sections/cdnr.py
+++ b/india_compliance/gst_india/utils/gstr_1/sections/cdnr.py
@@ -41,6 +41,8 @@ NOTE_TYPES = {
 }
 NOTE_CODES = s.flip(NOTE_TYPES)
 
+SUBCATEGORIES = (SUBCATEGORY,)
+
 ITEM_DEFAULTS = dict.fromkeys(s.ITEM_TOTALS, 0)
 ITEM_AMOUNTS = tuple(ITEM_DEFAULTS)
 
@@ -90,6 +92,11 @@ def to_canonical(gov_data):
         output[row[doc.DOC_NUMBER]] = row
 
     return {SUBCATEGORY: output}
+
+
+def from_books(grouped_rows):
+    """Books rows -> one row per invoice, for the subcategories this category reports."""
+    return s.invoice_rows_from_books(grouped_rows, SUBCATEGORIES)
 
 
 def to_gov(rows, company_gstin=""):

--- a/india_compliance/gst_india/utils/gstr_1/sections/cdnur.py
+++ b/india_compliance/gst_india/utils/gstr_1/sections/cdnur.py
@@ -1,4 +1,9 @@
-"""Credit and debit notes to unregistered buyers and exports (table 9B).
+"""Credit and debit notes against unregistered buyers and exports (table 9B).
+
+Portal:    [{ntty: "C", nt_num: "533515", typ: "B2CL", itms: [{num: 1, itm_det: {txval: 5225.28}}]}]
+Canonical: {"Credit/Debit Notes (Unregistered)": {"533515": {transaction_type: "Credit Note",
+                                                             items: [{taxable_value: -5225.28}],
+                                                             total_taxable_value: -5225.28}}}
 
 Same sign rule as registered notes: stored negative, filed unsigned.
 """
@@ -31,8 +36,14 @@ KEYS = {
     raw.ERROR_MSG: doc.ERROR_MSG,
 }
 
-# exports report no place of supply
-EXPORT_TYPES = ("EXPWP", "EXPWOP")
+EXPORT_WITH_TAX = "EXPWP"
+EXPORT_WITHOUT_TAX = "EXPWOP"
+LARGE_UNREGISTERED = "B2CL"
+
+# exports have no place of supply to report
+EXPORT_TYPES = (EXPORT_WITH_TAX, EXPORT_WITHOUT_TAX)
+
+SUBCATEGORIES = (SUBCATEGORY,)
 
 ITEM_DEFAULTS = dict.fromkeys(s.ITEM_TOTALS_IGST, 0)
 ITEM_AMOUNTS = tuple(ITEM_DEFAULTS)
@@ -49,9 +60,9 @@ def to_canonical(gov_data):
         row = s.drop_flag(s.pick(note, KEYS))
 
         s.remap(row, doc.TRANSACTION_TYPE, NOTE_TYPES)  # C -> Credit Note
-        s.convert(row, doc.DOC_DATE, s.date_from_gov)
-        s.convert(row, doc.POS, s.pos_from_gov)
-        s.flip_signs(row, multiplier, (doc.DOC_VALUE,))
+        s.convert(row, doc.DOC_DATE, s.date_from_gov)  # 23-09-2016 -> 2016-09-23
+        s.convert(row, doc.POS, s.pos_from_gov)  # 03 -> 03-Punjab
+        s.flip_signs(row, multiplier, (doc.DOC_VALUE,))  # credit note 123123 -> -123123
 
         row[doc.ITEMS] = [
             s.flip_signs(line, multiplier, ITEM_AMOUNTS)
@@ -64,13 +75,18 @@ def to_canonical(gov_data):
     return {SUBCATEGORY: output}
 
 
+def from_books(grouped_rows):
+    """Books rows -> one row per invoice, for the subcategories this category reports."""
+    return s.invoice_rows_from_books(grouped_rows, SUBCATEGORIES)
+
+
 def to_gov(rows, company_gstin=""):
     def write(row):
         out = s.round_money(s.abs_amounts(s.pick_back(row, KEYS), (raw.DOC_VALUE,)), MONEY)
 
         s.remap(out, raw.NOTE_TYPE, NOTE_CODES)  # Credit Note -> C
-        s.convert(out, raw.NOTE_DATE, s.date_to_gov)
-        s.convert(out, raw.POS, s.pos_to_gov)
+        s.convert(out, raw.NOTE_DATE, s.date_to_gov)  # 2016-09-23 -> 23-09-2016
+        s.convert(out, raw.POS, s.pos_to_gov)  # 03-Punjab -> 03
 
         if row.get(doc.DOC_TYPE) in EXPORT_TYPES:
             out.pop(raw.POS, None)

--- a/india_compliance/gst_india/utils/gstr_1/sections/doc_issue.py
+++ b/india_compliance/gst_india/utils/gstr_1/sections/doc_issue.py
@@ -75,6 +75,34 @@ def to_gov(rows, company_gstin=""):
     }
 
 
+def from_books(rows):
+    """Books ranges -> one row per document kind and starting number.
+
+       [{nature_of_document: "Invoices for outward supply", from_serial_no: "1", ...}]
+    -> {"Document Issued": {"Invoices for outward supply - 1": {from_sr_no: "1", ...}}}
+    """
+    output = {}
+
+    for entry in rows:
+        key = f"{entry['nature_of_document']} - {entry['from_serial_no']}"
+
+        # the first range for a key wins; the query can repeat one across naming series
+        if key in output:
+            continue
+
+        output[key] = {
+            doc.DOC_TYPE: entry["nature_of_document"],
+            doc.FROM_SR: entry["from_serial_no"],
+            doc.TO_SR: entry["to_serial_no"],
+            doc.TOTAL_COUNT: entry["total_issued"],
+            doc.DRAFT_COUNT: entry["total_draft"],
+            doc.CANCELLED_COUNT: entry["cancelled"],
+            doc.NET_ISSUE: entry["total_submitted"],
+        }
+
+    return output
+
+
 def net_issued(row):
     """Drafts reached nobody, so count them as cancelled. New row, so counts never pile up."""
     cancelled = (row.get(doc.CANCELLED_COUNT) or 0) + (row.get(doc.DRAFT_COUNT) or 0)

--- a/india_compliance/gst_india/utils/gstr_1/sections/exports.py
+++ b/india_compliance/gst_india/utils/gstr_1/sections/exports.py
@@ -1,6 +1,12 @@
-"""Invoices shipped out of India, grouped by whether tax was paid (table 6A).
+"""Exports — invoices shipped out of India, grouped by whether tax was paid (table 6A).
 
-We store the portal's own code here, not a label. The readable name is the subcategory.
+Portal:    [{exp_typ: "WPAY", inv: [{inum: "81542", val: 995048.36, itms: [{txval: 10000}]}]}]
+Canonical: {"Export With Payment of Tax": {"81542": {document_type: "WPAY",
+                                                     document_number: "81542",
+                                                     items: [{taxable_value: 10000}]}}}
+
+Unlike other categories the stored document type is the portal's own code, not a label -- the
+readable name is the subcategory the row is filed under.
 """
 
 from india_compliance.gst_returns.fields.gstr1 import DocField as doc
@@ -25,11 +31,17 @@ KEYS = {
     raw.CESS: item.CESS,
 }
 
-# exp_typ -> its subcategory
+WITH_TAX = "WPAY"
+WITHOUT_TAX = "WOPAY"
+
+# exp_typ -> the subcategory the invoice is filed under
 SUBCATEGORY_OF = {
-    "WPAY": SubCategory.EXPWP.value,
-    "WOPAY": SubCategory.EXPWOP.value,
+    WITH_TAX: SubCategory.EXPWP.value,
+    WITHOUT_TAX: SubCategory.EXPWOP.value,
 }
+
+# every subcategory exports report under
+SUBCATEGORIES = tuple(SUBCATEGORY_OF.values())
 
 ITEM_DEFAULTS = dict.fromkeys(s.ITEM_TOTALS_IGST, 0)
 
@@ -40,7 +52,7 @@ ITEM_MONEY = (raw.TAXABLE_VALUE, raw.IGST, raw.CESS)
 def to_canonical(gov_data):
     output = {}
 
-    # bucket up front, so an empty export type still shows
+    # bucket per export type is created up front, so a type with no invoices still shows up
     for group in gov_data:
         export_type = group.get(raw.EXPORT_TYPE)
         invoices = output.setdefault(
@@ -56,7 +68,7 @@ def to_canonical(gov_data):
         for invoice in group.get(raw.INVOICES) or []:
             row = s.drop_flag(s.with_defaults(s.pick(invoice, KEYS), header))
 
-            s.convert(row, doc.DOC_DATE, s.date_from_gov)
+            s.convert(row, doc.DOC_DATE, s.date_from_gov)  # 12-02-2016 -> 2016-02-12
             s.convert(row, doc.SHIPPING_BILL_DATE, s.date_from_gov)
             s.convert(row, doc.ITEMS, lambda items: s.flat_items_from_gov(items, KEYS, ITEM_DEFAULTS))
             s.add_item_totals(row, row.get(doc.ITEMS), s.ITEM_TOTALS_IGST)
@@ -66,11 +78,16 @@ def to_canonical(gov_data):
     return output
 
 
+def from_books(grouped_rows):
+    """Books rows -> one row per invoice, for the subcategories this category reports."""
+    return s.invoice_rows_from_books(grouped_rows, SUBCATEGORIES)
+
+
 def to_gov(rows, company_gstin=""):
     def write(row):
         out = s.round_money(s.pick_back(row, KEYS), MONEY)
 
-        s.convert(out, raw.DOC_DATE, s.date_to_gov)
+        s.convert(out, raw.DOC_DATE, s.date_to_gov)  # 2016-02-12 -> 12-02-2016
         s.convert(out, raw.SHIPPING_BILL_DATE, s.date_to_gov)
         s.convert(out, raw.ITEMS, lambda items: s.flat_items_to_gov(items, KEYS, ITEM_MONEY))
 

--- a/india_compliance/gst_india/utils/gstr_1/sections/hsn.py
+++ b/india_compliance/gst_india/utils/gstr_1/sections/hsn.py
@@ -93,6 +93,38 @@ def to_canonical(gov_data):
     return output
 
 
+def from_books(grouped_rows, describe):
+    """Books rows -> one row per product code, unit and rate.
+
+        {"HSN Summary - B2B": {"1102 - BOX-BOX - 1.0": [item rows]}}
+     -> {"HSN Summary - B2B": {"1102 - BOX-BOX - 1.0": {quantity: 2, total_taxable_value: 100}}}
+
+    `describe` supplies the code's description; the lookup is a query, so the caller owns it.
+    """
+    output = {}
+
+    for subcategory, rows_by_key in grouped_rows.items():
+        rows_out = output.setdefault(subcategory, {})
+
+        for key, rows in rows_by_key.items():
+            first = rows[0]
+
+            row = {
+                doc.DOC_TYPE: subcategory,
+                doc.HSN_CODE: first.gst_hsn_code,
+                doc.DESCRIPTION: describe(first.gst_hsn_code),
+                doc.UOM: first.uom,
+                doc.QUANTITY: s.sum_column(rows, "qty"),
+                doc.TAX_RATE: first.gst_rate,
+                **{total: s.sum_column(rows, column) for total, column in s.BOOKS_COLUMNS.items()},
+            }
+            row[doc.DOC_VALUE] = s.sum_money(row, VALUE_PARTS)
+
+            rows_out[key] = row
+
+    return output
+
+
 def to_gov(rows, company_gstin=""):
     output = {}
     counts = {}

--- a/india_compliance/gst_india/utils/gstr_1/sections/nil_rated.py
+++ b/india_compliance/gst_india/utils/gstr_1/sections/nil_rated.py
@@ -1,4 +1,13 @@
-"""Nil rated, exempted and non-GST supplies, by who bought and from where (table 8)."""
+"""Nil rated, exempted and non-GST supplies, totalled by who bought and from where (table 8).
+
+Portal:    {inv: [{sply_ty: "INTRB2B", expt_amt: 123.45, nil_amt: 1470.85, ngsup_amt: 1258.5}]}
+Canonical: {"Nil-Rated, Exempted, Non-GST": {
+                "Inter-State supplies to registered persons": [
+                    {exempted_amount: 123.45, nil_rated_amount: 1470.85,
+                     non_gst_amount: 1258.5, total_taxable_value: 2852.8}]}}
+"""
+
+from itertools import chain
 
 from india_compliance.gst_returns.fields.gstr1 import DocField as doc
 from india_compliance.gst_returns.fields.gstr1 import NilRatedCategory, SubCategory
@@ -15,7 +24,13 @@ KEYS = {
     raw.NON_GST_AMOUNT: doc.NON_GST_AMOUNT,
 }
 
-# sply_ty -> supply type
+
+def supply_code(inter_state, registered):
+    """The portal's sply_ty for a supply, from who bought it and from where."""
+    return ("INTR" if inter_state else "INTRA") + ("B2B" if registered else "B2C")
+
+
+# sply_ty -> readable supply type
 SUPPLY_TYPES = {
     "INTRB2B": NilRatedCategory.INTER_B2B.value,
     "INTRB2C": NilRatedCategory.INTER_B2C.value,
@@ -24,7 +39,14 @@ SUPPLY_TYPES = {
 }
 SUPPLY_CODES = s.flip(SUPPLY_TYPES)
 
-# the three amounts behind the taxable value
+# books gst_treatment -> the amount it belongs to
+BOOKS_TREATMENTS = {
+    "Nil-Rated": doc.NIL_RATED_AMOUNT,
+    "Exempted": doc.EXEMPTED_AMOUNT,
+    "Non-GST": doc.NON_GST_AMOUNT,
+}
+
+# the three amounts that make up the taxable value
 AMOUNTS = (doc.EXEMPTED_AMOUNT, doc.NIL_RATED_AMOUNT, doc.NON_GST_AMOUNT)
 
 MONEY = (raw.EXEMPTED_AMOUNT, raw.NIL_RATED_AMOUNT, raw.NON_GST_AMOUNT)
@@ -42,15 +64,52 @@ def to_canonical(gov_data):
         row = s.with_defaults(s.pick(entry, KEYS), header)
         s.remap(row, doc.DOC_TYPE, SUPPLY_TYPES)  # INTRB2B -> Inter-State supplies to registered persons
 
-        # nothing in the line, no supply
+        # a line with nothing in it is not a supply
         if all(not row.get(field) for field in AMOUNTS):
             continue
 
-        row[doc.TAXABLE_VALUE] = s.sum_money(row, AMOUNTS)
+        row[doc.TAXABLE_VALUE] = s.sum_money(row, AMOUNTS)  # 123.45 + 1470.85 + 1258.5 -> 2852.8
 
         output.setdefault(row.get(doc.DOC_TYPE), []).append(row)
 
     return {SUBCATEGORY: output}
+
+
+def from_books(grouped_rows):
+    """Books rows -> one row per invoice, bucketed by the kind of supply it was.
+
+       {(_, "SINV-1"): {0.0: [item rows]}}
+    -> {"Nil-Rated, Exempted, Non-GST": {"Inter-State supplies to registered persons": [{...}]}}
+    """
+    output = {}
+
+    for rows_by_rate in grouped_rows.values():
+        lines = list(chain(*rows_by_rate.values()))
+        first = lines[0]
+
+        row = {
+            doc.TRANSACTION_TYPE: s.transaction_type(first),
+            doc.CUST_GSTIN: first.billing_address_gstin,
+            doc.CUST_NAME: first.customer_name,
+            doc.DOC_NUMBER: first.invoice_no,
+            doc.DOC_DATE: first.posting_date,
+            doc.DOC_VALUE: first.invoice_total,
+            doc.POS: first.place_of_supply,
+            doc.REVERSE_CHARGE: ("Y" if first.is_reverse_charge else "N"),
+            doc.DOC_TYPE: first.invoice_type,
+            doc.TAXABLE_VALUE: s.sum_column(lines, "taxable_value"),
+            **{
+                field: s.sum_column(
+                    [line for line in lines if line.gst_treatment == treatment], "taxable_value"
+                )
+                for treatment, field in BOOKS_TREATMENTS.items()
+            },
+        }
+
+        output.setdefault(first.invoice_type, []).append(row)
+
+    # nothing to report means no section at all, not an empty one
+    return {SUBCATEGORY: output} if output else {}
 
 
 def to_gov(rows, company_gstin=""):

--- a/india_compliance/gst_india/utils/gstr_1/sections/supecom.py
+++ b/india_compliance/gst_india/utils/gstr_1/sections/supecom.py
@@ -43,6 +43,37 @@ def to_canonical(gov_data):
     return output
 
 
+def from_books(grouped_rows, operator_name):
+    """Books rows -> one row per e-commerce operator, per kind of supply.
+
+        {"Liable to collect tax u/s 52(TCS)": {"SINV-1": [item rows]}}
+     -> {"Liable to collect tax u/s 52(TCS)": {"20ALYPD6528PQC5": {total_taxable_value: 10000}}}
+
+    One operator carries many invoices, so each invoice is totalled and then added to the operator.
+    """
+    output = {}
+
+    for supply_type, rows_by_invoice in grouped_rows.items():
+        operators = output.setdefault(supply_type, {})
+
+        for rows in rows_by_invoice.values():
+            gstin = rows[0].get("ecommerce_gstin", "")
+            entry = operators.setdefault(
+                gstin,
+                {
+                    doc.DOC_TYPE: supply_type,
+                    doc.ECOMMERCE_GSTIN: gstin,
+                    doc.ECOMMERCE_OPERATOR_NAME: operator_name(gstin),
+                    **s.zero_totals(),
+                },
+            )
+
+            for total, column in s.BOOKS_COLUMNS.items():
+                entry[total] = s.money(entry[total] + s.sum_column(rows, column))
+
+    return output
+
+
 def to_gov(rows, company_gstin=""):
     output = {}
 

--- a/india_compliance/gst_india/utils/gstr_1/sections/test_sections.py
+++ b/india_compliance/gst_india/utils/gstr_1/sections/test_sections.py
@@ -80,6 +80,22 @@ class TestKeyTables(unittest.TestCase):
         with self.assertRaises(ValueError):
             s.invert(summary.KEYS)
 
+    def test_every_category_reads_from_both_sources_and_writes_back(self):
+        """One category, one file, the same three functions -- whichever way the data flows."""
+        for module in (b2b, b2cl, exports, b2cs, nil_rated, cdnr, cdnur, hsn, doc_issue, supecom):
+            with self.subTest(module.__name__):
+                for name in ("to_canonical", "from_books", "to_gov"):
+                    self.assertTrue(callable(getattr(module, name, None)), f"missing {name}")
+
+        # advances name theirs per direction, because received and adjusted differ only in sign
+        for name in ("received_from_books", "adjusted_from_books", "received_to_gov", "adjusted_to_gov"):
+            self.assertTrue(callable(getattr(advances, name, None)), f"missing {name}")
+
+    def test_invoice_categories_claim_every_subcategory_between_them(self):
+        # the books query hands all five one bucket, so their claims must not overlap or leave gaps
+        claimed = [sub for m in (b2b, b2cl, exports, cdnr, cdnur) for sub in m.SUBCATEGORIES]
+        self.assertEqual(len(claimed), len(set(claimed)), "two categories claim the same subcategory")
+
     def test_every_category_is_registered(self):
         self.assertEqual(len(SECTIONS), 13)
 

--- a/india_compliance/gst_india/utils/gstr_1/sections/test_sections.py
+++ b/india_compliance/gst_india/utils/gstr_1/sections/test_sections.py
@@ -12,7 +12,9 @@ import frappe
 from frappe.utils import flt
 
 from india_compliance.gst_returns.fields.gstr1 import (
+    CATEGORY_SUB_CATEGORY_MAPPING,
     B2BInvoiceType,
+    Category,
     DocumentNature,
     SubCategory,
 )
@@ -87,14 +89,27 @@ class TestKeyTables(unittest.TestCase):
                 for name in ("to_canonical", "from_books", "to_gov"):
                     self.assertTrue(callable(getattr(module, name, None)), f"missing {name}")
 
-        # advances name theirs per direction, because received and adjusted differ only in sign
-        for name in ("received_from_books", "adjusted_from_books", "received_to_gov", "adjusted_to_gov"):
+        # advances read and write per direction, because received and adjusted differ only in sign;
+        for name in (
+            "from_books",
+            "received_to_canonical",
+            "adjusted_to_canonical",
+            "received_to_gov",
+            "adjusted_to_gov",
+        ):
             self.assertTrue(callable(getattr(advances, name, None)), f"missing {name}")
 
     def test_invoice_categories_claim_every_subcategory_between_them(self):
         # the books query hands all five one bucket, so their claims must not overlap or leave gaps
         claimed = [sub for m in (b2b, b2cl, exports, cdnr, cdnur) for sub in m.SUBCATEGORIES]
         self.assertEqual(len(claimed), len(set(claimed)), "two categories claim the same subcategory")
+
+        reported = {
+            sub.value
+            for category in (Category.B2B, Category.B2CL, Category.EXP, Category.CDNR, Category.CDNUR)
+            for sub in CATEGORY_SUB_CATEGORY_MAPPING[category]
+        }
+        self.assertEqual(set(claimed), reported, "a subcategory no category claims")
 
     def test_every_category_is_registered(self):
         self.assertEqual(len(SECTIONS), 13)
@@ -797,6 +812,57 @@ class TestCategoryRules(unittest.TestCase):
 
         self.assertEqual(len(details), 1)
         self.assertEqual(details[0][raw.DOC_ISSUE_LIST][0][raw.FROM_SR], "3")
+
+    def test_an_advance_rate_snaps_to_the_nearest_notified_rate(self):
+        """Worked back from paisa-rounded amounts, the rate carries noise no return may file."""
+
+        def entry(taxable, tax):
+            return {
+                "party": "X",
+                "name": "PE-1",
+                "posting_date": "2026-08-01",
+                "place_of_supply": "27-Maharashtra",
+                "company_gstin": "27ZZRML1234R1Z4",
+                "taxable_value": taxable,
+                "tax_amount": tax,
+                "cess_amount": 0,
+            }
+
+        # a fractional rate is a real rate, not zero
+        self.assertEqual(list(advances.from_books([entry(10000, 25)])), ["27-Maharashtra - 0.25"])
+
+        # a ten-rupee advance works back to 18.05; that is noise, not a rate of its own
+        rows = advances.from_books([entry(10.03, 1.81)])
+        self.assertEqual(list(rows), ["27-Maharashtra - 18.0"])
+        self.assertEqual(rows["27-Maharashtra - 18.0"][0][doc.TAX_RATE], 18.0)
+
+    def test_nil_rated_books_and_portal_rows_group_under_the_same_key(self):
+        """Books rows already carry the readable supply type, so both sides key alike."""
+        line = frappe._dict(
+            billing_address_gstin="24AANFA2641L1ZF",
+            customer_name="X",
+            invoice_no="SINV-1",
+            posting_date="2026-08-01",
+            invoice_total=100,
+            place_of_supply="24-Gujarat",
+            is_reverse_charge=0,
+            is_debit_note=0,
+            is_return=0,
+            invoice_type=nil_rated.SUPPLY_TYPES["INTRB2B"],
+            gst_treatment="Nil-Rated",
+            taxable_value=100,
+        )
+
+        books = nil_rated.from_books({(nil_rated.SUBCATEGORY, "SINV-1"): {0.0: [line]}})
+        portal = nil_rated.to_canonical(
+            {raw.INVOICES: [{raw.SUPPLY_TYPE: "INTRB2B", raw.NIL_RATED_AMOUNT: 100}]}
+        )
+
+        self.assertEqual(
+            set(books[nil_rated.SUBCATEGORY]),
+            set(portal[nil_rated.SUBCATEGORY]),
+        )
+        self.assertEqual(list(books[nil_rated.SUBCATEGORY]), ["Inter-State supplies to registered persons"])
 
     def test_a_nil_rated_line_with_nothing_in_it_is_dropped(self):
         payload = {raw.INVOICES: [{raw.SUPPLY_TYPE: "INTRB2B", raw.EXEMPTED_AMOUNT: 0}]}

--- a/india_compliance/gst_india/utils/gstr_1/test_gstr_1_books_data.py
+++ b/india_compliance/gst_india/utils/gstr_1/test_gstr_1_books_data.py
@@ -16,10 +16,11 @@ from india_compliance.gst_india.utils.gstr_1 import (
     DocField as doc,
 )
 from india_compliance.gst_india.utils.gstr_1.gstr_1_books_map import (
-    BooksDataMapper,
     GSTR1BooksData,
 )
 from india_compliance.gst_india.utils.gstr_1.gstr_1_data import GSTR1Invoices
+from india_compliance.gst_india.utils.gstr_1.sections import supecom
+from india_compliance.gst_india.utils.gstr_1.sections._shared import BOOKS_COLUMNS
 from india_compliance.gst_india.utils.tests import (
     _append_taxes,
     append_item,
@@ -184,7 +185,7 @@ class TestGSTR1BooksData(IntegrationTestCase):
         )
 
         # Check if HSN Summary is same as Invoice Summary
-        for key in _class.DATA_TO_ITEM_FIELD_MAPPING:
+        for key in BOOKS_COLUMNS:
             invoice_total = 0
             for row in data[SubCategory.B2B_REGULAR.value].values():
                 invoice_total += row.get(key, 0.0)
@@ -233,7 +234,7 @@ class TestGSTR1BooksData(IntegrationTestCase):
         )
 
         # Check if HSN Summary is same as Invoice Summary
-        for key in _class.DATA_TO_ITEM_FIELD_MAPPING:
+        for key in BOOKS_COLUMNS:
             invoice_total = 0
             for invoices in data[SubCategory.B2CS.value].values():
                 for row in invoices:
@@ -290,7 +291,7 @@ class TestGSTR1BooksData(IntegrationTestCase):
         )
 
         # Check if HSN Summary is same as Invoice Summary
-        for key in _class.DATA_TO_ITEM_FIELD_MAPPING:
+        for key in BOOKS_COLUMNS:
             invoice_total = 0
             for invoices in data[SubCategory.NIL_EXEMPT.value].values():
                 for row in invoices:
@@ -1071,8 +1072,7 @@ class TestGSTR1BooksData(IntegrationTestCase):
             }
         }
 
-        prepared_data = {}
-        BooksDataMapper().process_data_for_supecom(grouped_data, prepared_data)
+        prepared_data = supecom.from_books(grouped_data, lambda gstin: "")
 
         row = prepared_data[supply_type][eco_gstin]
         # Each invoice rounds to 0.01; two invoices → 0.02

--- a/india_compliance/gst_india/utils/gstr_1/test_gstr_1_books_data.py
+++ b/india_compliance/gst_india/utils/gstr_1/test_gstr_1_books_data.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import frappe
 from erpnext.accounts.doctype.sales_invoice.mapper import make_sales_return
 from frappe.tests import IntegrationTestCase, change_settings
@@ -1362,7 +1364,10 @@ class TestGSTR1BooksData(IntegrationTestCase):
         self.assertEqual(descriptions[code], "Test HSN")
 
     def test_hsn_descriptions_asks_nothing_when_there_are_no_rows(self):
-        self.assertEqual(GSTR1BooksData(frappe._dict()).hsn_descriptions({}), {})
+        with mock.patch.object(frappe, "get_all") as get_all:
+            self.assertEqual(GSTR1BooksData(frappe._dict()).hsn_descriptions({}), {})
+
+        get_all.assert_not_called()
 
 
 def setup_cess_account(company="_Test Indian Registered Company"):

--- a/india_compliance/gst_india/utils/gstr_1/test_gstr_1_books_data.py
+++ b/india_compliance/gst_india/utils/gstr_1/test_gstr_1_books_data.py
@@ -1346,6 +1346,20 @@ class TestGSTR1BooksData(IntegrationTestCase):
             data[SubCategory.HSN.value][key],
         )
 
+    def test_hsn_descriptions_are_asked_for_only_the_codes_in_the_return(self):
+        """The master runs to tens of thousands of rows; a return names a handful."""
+        rows = {
+            SubCategory.HSN.value: {
+                "73044900 - NOS-NUMBERS - 18.0": [frappe._dict({"gst_hsn_code": "73044900"})]
+            }
+        }
+        descriptions = GSTR1BooksData(frappe._dict()).hsn_descriptions(rows)
+
+        self.assertEqual(set(descriptions), {"73044900"})
+
+    def test_hsn_descriptions_asks_nothing_when_there_are_no_rows(self):
+        self.assertEqual(GSTR1BooksData(frappe._dict()).hsn_descriptions({}), {})
+
 
 def setup_cess_account(company="_Test Indian Registered Company"):
     # create cess account

--- a/india_compliance/gst_india/utils/gstr_1/test_gstr_1_books_data.py
+++ b/india_compliance/gst_india/utils/gstr_1/test_gstr_1_books_data.py
@@ -1348,14 +1348,18 @@ class TestGSTR1BooksData(IntegrationTestCase):
 
     def test_hsn_descriptions_are_asked_for_only_the_codes_in_the_return(self):
         """The master runs to tens of thousands of rows; a return names a handful."""
+        code = "99999999"
+        frappe.get_doc({"doctype": "GST HSN Code", "hsn_code": code, "description": "Test HSN"}).insert(
+            ignore_if_duplicate=True
+        )
+
         rows = {
-            SubCategory.HSN.value: {
-                "73044900 - NOS-NUMBERS - 18.0": [frappe._dict({"gst_hsn_code": "73044900"})]
-            }
+            SubCategory.HSN.value: {f"{code} - NOS-NUMBERS - 18.0": [frappe._dict({"gst_hsn_code": code})]}
         }
         descriptions = GSTR1BooksData(frappe._dict()).hsn_descriptions(rows)
 
-        self.assertEqual(set(descriptions), {"73044900"})
+        self.assertEqual(set(descriptions), {code})
+        self.assertEqual(descriptions[code], "Test HSN")
 
     def test_hsn_descriptions_asks_nothing_when_there_are_no_rows(self):
         self.assertEqual(GSTR1BooksData(frappe._dict()).hsn_descriptions({}), {})

--- a/india_compliance/gst_india/utils/gstr_1/test_rounding.py
+++ b/india_compliance/gst_india/utils/gstr_1/test_rounding.py
@@ -21,11 +21,9 @@ from frappe.utils import cint, flt
 
 from india_compliance.gst_india.utils.gstr_1 import Category, SubCategory
 from india_compliance.gst_india.utils.gstr_1 import DocField as doc
-from india_compliance.gst_india.utils.gstr_1.gstr_1_books_map import (
-    BooksDataMapper,
-    GSTR1BooksData,
-)
+from india_compliance.gst_india.utils.gstr_1.gstr_1_books_map import GSTR1BooksData
 from india_compliance.gst_india.utils.gstr_1.gstr_1_data import GSTR1Invoices
+from india_compliance.gst_india.utils.gstr_1.sections import hsn
 from india_compliance.gst_india.utils.gstr_1.sections._shared import sum_column
 
 AMOUNTS = ("taxable_value", "igst_amount", "cgst_amount", "sgst_amount", "total_cess_amount")
@@ -197,7 +195,7 @@ class TestRoundingDifferenceReport(unittest.TestCase):
 
     def report(self, lost):
         prepared = {}
-        BooksDataMapper().update_rounding_difference(prepared, lost)
+        GSTR1BooksData(frappe._dict()).update_rounding_difference(prepared, lost)
         return prepared["rounding_difference"]["rounding_difference"]
 
     def test_reported_under_the_invoice_total_names(self):
@@ -238,9 +236,7 @@ class TestHsnRowsAddUp(unittest.TestCase):
         It adjusted the tax amounts after `document_value` had already been worked out, leaving the
         row claiming a total its own columns no longer added up to.
         """
-        mapper = BooksDataMapper()
-        prepared = {}
-        mapper.process_data_for_hsn_summary(
+        prepared = hsn.from_books(
             {
                 "HSN Summary": {
                     "1001 - NOS-NUMBERS - 18.0": [
@@ -249,7 +245,7 @@ class TestHsnRowsAddUp(unittest.TestCase):
                     ]
                 }
             },
-            prepared,
+            describe=lambda code: code,
         )
 
         for hsn_row in prepared["HSN Summary"].values():


### PR DESCRIPTION
Books side of GSTR-1 mapping now lives one file per return section, same as the portal side already does.

## What

- Was: one big class built rows for every section.
- Now: each section owns its own file and builds its own rows.
- `gstr_1_books_map.py` just queries and hands off. ~460 lines lighter.
- Same section is now read and written in one place.

## Note

- Nothing else changes in what gets filed.
- New tests: every section reachable both ways, no invoice type left unclaimed, HSN lookup asks only what it needs.