### PR TITLE
fix: handle missing Email Template reference doctype

### DIFF
--- a/india_compliance/patches/v16/update_reconciliation_email_template_dates.py
+++ b/india_compliance/patches/v16/update_reconciliation_email_template_dates.py
@@ -8,12 +8,13 @@ TEMPLATE_FIELDS = ("subject", "response", "response_html")
 
 
 def execute():
+    or_filters = {"name": "Purchase Reconciliation"}
+    if frappe.db.has_column("Email Template", "reference_doctype"):
+        or_filters["reference_doctype"] = "Purchase Reconciliation Tool"
+
     templates = frappe.get_all(
         "Email Template",
-        or_filters={
-            "name": "Purchase Reconciliation",
-            "reference_doctype": "Purchase Reconciliation Tool",
-        },
+        or_filters=or_filters,
         fields=("name", *TEMPLATE_FIELDS),
     )
 

--- a/india_compliance/tests/test_patches.py
+++ b/india_compliance/tests/test_patches.py
@@ -1,6 +1,7 @@
 from contextlib import contextmanager
 from pathlib import Path
 from typing import ClassVar
+from unittest.mock import patch
 
 import frappe
 from frappe.database.schema import add_column
@@ -18,6 +19,26 @@ from india_compliance.install import POST_INSTALL_PATCHES
 
 
 class TestPatches(IntegrationTestCase):
+    @patch(
+        "india_compliance.patches.v16.update_reconciliation_email_template_dates.frappe.get_all",
+        return_value=[],
+    )
+    @patch(
+        "india_compliance.patches.v16.update_reconciliation_email_template_dates.frappe.db.has_column",
+        return_value=False,
+    )
+    def test_reconciliation_email_patch_without_reference_doctype(self, has_column, get_all):
+        from india_compliance.patches.v16.update_reconciliation_email_template_dates import execute
+
+        execute()
+
+        has_column.assert_called_once_with("Email Template", "reference_doctype")
+        get_all.assert_called_once_with(
+            "Email Template",
+            or_filters={"name": "Purchase Reconciliation"},
+            fields=("name", "subject", "response", "response_html"),
+        )
+
     def test_post_install_patch_exists(self):
         for patch in POST_INSTALL_PATCHES:
             self.assertTrue(frappe.get_attr(f"india_compliance.patches.post_install.{patch}.execute"))


### PR DESCRIPTION
## What changed

- Check whether the Email Template reference_doctype database column exists before adding it to the reconciliation-template query.
- Preserve the broader query on schemas that provide the column.
- Add regression coverage for Frappe v16 schemas where the column is absent.

## Why

The v16 update_reconciliation_email_template_dates patch currently fails during migrate with MySQL error 1054 when Email Template has no reference_doctype column. This prevents all later migrations from running.

## Validation

- Python bytecode compilation passed.
- git diff --check passed.
- Added a regression test asserting the fallback query.