### PR TITLE
fix: handle missing Email Template reference doctype

### DIFF
--- a/india_compliance/patches.txt
+++ b/india_compliance/patches.txt
@@ -90,4 +90,4 @@ execute:import frappe; frappe.db.set_single_value("GST Settings", "nil_exempt_e_
 india_compliance.patches.post_install.set_india_compliance_default_tax_category #1
 india_compliance.patches.post_install.remove_tax_category_gst_state
 india_compliance.patches.v16.remove_gstr_2a_category_preferences
-india_compliance.patches.v16.update_reconciliation_email_template_dates
+india_compliance.patches.v16.update_reconciliation_email_template_dates #1

--- a/india_compliance/patches/v16/update_reconciliation_email_template_dates.py
+++ b/india_compliance/patches/v16/update_reconciliation_email_template_dates.py
@@ -8,12 +8,14 @@ TEMPLATE_FIELDS = ("subject", "response", "response_html")
 
 
 def execute():
+    or_filters = {"name": "Purchase Reconciliation"}
+
+    if frappe.db.has_column("Email Template", "reference_doctype"):
+        or_filters["reference_doctype"] = "Purchase Reconciliation Tool"
+
     templates = frappe.get_all(
         "Email Template",
-        or_filters={
-            "name": "Purchase Reconciliation",
-            "reference_doctype": "Purchase Reconciliation Tool",
-        },
+        or_filters=or_filters,
         fields=("name", *TEMPLATE_FIELDS),
     )
 


### PR DESCRIPTION
```

post pulling this the migration is failing due to india_compliance.patches.v16.update_reconciliation_email_template_dates Unknown column 'reference_doctype' in 'WHERE'

here is the trace back
Migrating purvagroup.m.frappe.cloud Updating DocTypes for frappe : [========================================] 100% Updating DocTypes for erpnext : [========================================] 100% Updating DocTypes for india_compliance: [========================================] 100% Updating DocTypes for offsite_backups: [========================================] 100% Executing execute:from india_compliance.gst_india.setup import create_custom_fields; create_custom_fields() #76 in purvagroup.m.frappe.cloud (_087b7c4f00e3ee27) Success: Done in 0.961s Executing execute:from india_compliance.income_tax_india.setup import create_custom_fields; create_custom_fields() #9 in purvagroup.m.frappe.cloud (_087b7c4f00e3ee27) Success: Done in 0.047s Executing execute:from india_compliance.audit_trail.setup import setup_fixtures; setup_fixtures() #1 in purvagroup.m.frappe.cloud (_087b7c4f00e3ee27) Success: Done in 0.109s Executing india_compliance.patches.post_install.set_india_compliance_default_tax_category #1 in purvagroup.m.frappe.cloud (_087b7c4f00e3ee27) Backfill the is_india_compliance_default flag on Tax Categories. Automatic GST tax template selection now only considers Tax Categories flagged as India Compliance defaults. Combinations that already have one are left as they are. Success: Done in 0.029s Executing india_compliance.patches.v16.update_reconciliation_email_template_dates in purvagroup.m.frappe.cloud (_087b7c4f00e3ee27) Traceback (most recent call last): File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 48, in invoke return super().invoke(ctx) ~~~~~~~~~~~~~~^^^^^ File "/home/frappe/frappe-bench/env/lib/python3.14/site-packages/click/core.py", line 1902, in invoke return processresult(sub_ctx.command.invoke(sub_ctx)) ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^ File "/home/frappe/frappe-bench/env/lib/python3.14/site-packages/click/core.py", line 1298, in invoke return ctx.invoke(self.callback, **ctx.params) ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/home/frappe/frappe-bench/env/lib/python3.14/site-packages/click/core.py", line 853, in invoke return callback(*args, **kwargs) File "/home/frappe/frappe-bench/env/lib/python3.14/site-packages/click/decorators.py", line 34, in new_func return f(get_current_context(), args, *kwargs) File "/home/frappe/frappe-bench/apps/frappe/frappe/commands/__init__.py", line 28, in func ret = f(ctx.obj, args, *kwargs) File "/home/frappe/frappe-bench/apps/frappe/frappe/commands/site.py", line 722, in migrate ).run(site=site) ~~~^^^^^^^^^^^ File "/home/frappe/frappe-bench/apps/frappe/frappe/migrate.py", line 279, in run self.runschema_updates() ~~~~~~~~~~~~~~~~~~~~~~~^^ File "/home/frappe/frappe-bench/apps/frappe/frappe/migrate.py", line 58, in wrapper raise e File "/home/frappe/frappe-bench/apps/frappe/frappe/migrate.py", line 50, in wrapper ret = method(*args, kwargs) File "/home/frappe/frappe-bench/apps/frappe/frappe/migrate.py", line 143, in run_schema_updates frappe.modules.patch_handler.run_all( ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^ skip_failing=self.skip_failing, patch_type=PatchType.post_model_sync ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ) ^ File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 76, in run_all run_patch(patch) ~~~~~~~~~^^^^^^^ File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 62, in run_patch if not run_single(patchmodule=patch): ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^ File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 152, in run_single return execute_patch(patchmodule, method, methodargs) File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 188, in execute_patch patch() ~~~~~~^^ File "/home/frappe/frappe-bench/apps/indiacompliance/india_compliance/patches/v16/update_reconciliation_email_template_dates.py", line 11, in execute templates = frappe.get_all( "Email Template", ...<4 lines>... fields=("name", TEMPLATE_FIELDS), ) File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 1405, in get_all return get_list(doctype, args, kwargs) File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 1380, in get_list return frappe.model.qb_query.DatabaseQuery(doctype).execute(*args, **kwargs) ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^ File "/home/frappe/frappe-bench/apps/frappe/frappe/model/qb_query.py", line 212, in execute result = query.run(debug=debug, as_dict=not as_list, update=update) File "/home/frappe/frappe-bench/apps/frappe/frappe/query_builder/utils.py", line 135, in execute_query result = frappe.local.db.sql(query, params, args, *kwargs) # nosemgrep File "/home/frappe/frappe-bench/apps/frappe/frappe/database/database
```

Reference doctype is not backported: https://github.com/frappe/frappe/pull/39559