### PR TITLE
fix: abs before round 

### DIFF
--- a/india_compliance/gst_india/overrides/test_transaction_data.py
+++ b/india_compliance/gst_india/overrides/test_transaction_data.py
@@ -329,6 +329,19 @@ class TestTransactionData(IntegrationTestCase):
             ],
         )
 
+    @change_settings("System Settings", {"rounding_method": "Banker's Rounding (legacy)"})
+    def test_rounded_is_symmetric_about_zero(self):
+        """-x must round to the same size as x."""
+        for value in (1.005, 2.675, 0.125, 1234.565):
+            for precision in (2, 3):
+                self.assertEqual(
+                    GSTTransactionData.rounded(-value, precision),
+                    -GSTTransactionData.rounded(value, precision),
+                )
+
+        # no -0.0 in the payload
+        self.assertEqual(repr(GSTTransactionData.rounded(-0.001)), "0.0")
+
     @change_settings("System Settings", {"currency_precision": 3})
     def test_transaction_total_equals_sum_of_rounded_item_values(self):
         """transaction_details.total must equal Σ rounded(item.taxable_value).

--- a/india_compliance/gst_india/utils/e_invoice.py
+++ b/india_compliance/gst_india/utils/e_invoice.py
@@ -668,9 +668,9 @@ class EInvoiceData(GSTTransactionData):
                 "serial_no": "",
                 "is_service_item": ("Y" if item.gst_hsn_code.startswith(SERVICE_HSN_PREFIX) else "N"),
                 "unit_rate": (
-                    abs(self.rounded(item_details.taxable_amount / item.qty, 3))
+                    self.rounded(abs(item_details.taxable_amount / item.qty), 3)
                     if item.qty
-                    else abs(self.rounded(item_details.taxable_amount, 3))
+                    else self.rounded(abs(item_details.taxable_amount), 3)
                 ),
                 "barcode": self.sanitize_value(item.barcode, max_length=30, truncate=False),
             }
@@ -686,7 +686,7 @@ class EInvoiceData(GSTTransactionData):
             )
 
         if self.doc.is_reverse_charge:
-            item_details["total_value"] = abs(self.rounded(item.taxable_value, 2))
+            item_details["total_value"] = self.rounded(abs(item.taxable_value), 2)
 
     def update_transaction_details(self):
         invoice_type = "INV"
@@ -734,7 +734,7 @@ class EInvoiceData(GSTTransactionData):
             credit_days = (getdate(self.doc.due_date) - getdate(self.doc.posting_date)).days
 
         if (self.doc.is_pos or self.doc.advances) and self.doc.base_paid_amount:
-            paid_amount = abs(self.rounded(self.doc.base_paid_amount))
+            paid_amount = self.rounded(abs(self.doc.base_paid_amount))
 
         self.transaction_details.update(
             {
@@ -742,7 +742,7 @@ class EInvoiceData(GSTTransactionData):
                 "mode_of_payment": self.get_mode_of_payment(),
                 "paid_amount": paid_amount,
                 "credit_days": credit_days,
-                "outstanding_amount": abs(self.rounded(self.doc.outstanding_amount)),
+                "outstanding_amount": self.rounded(abs(self.doc.outstanding_amount)),
                 "payment_terms": self.sanitize_value(self.doc.payment_terms_template),
             }
         )

--- a/india_compliance/gst_india/utils/e_invoice.py
+++ b/india_compliance/gst_india/utils/e_invoice.py
@@ -668,9 +668,9 @@ class EInvoiceData(GSTTransactionData):
                 "serial_no": "",
                 "is_service_item": ("Y" if item.gst_hsn_code.startswith(SERVICE_HSN_PREFIX) else "N"),
                 "unit_rate": (
-                    self.rounded(abs(item_details.taxable_amount / item.qty), 3)
+                    abs(self.rounded(item_details.taxable_amount / item.qty, 3))
                     if item.qty
-                    else self.rounded(abs(item_details.taxable_amount), 3)
+                    else abs(self.rounded(item_details.taxable_amount, 3))
                 ),
                 "barcode": self.sanitize_value(item.barcode, max_length=30, truncate=False),
             }
@@ -686,7 +686,7 @@ class EInvoiceData(GSTTransactionData):
             )
 
         if self.doc.is_reverse_charge:
-            item_details["total_value"] = self.rounded(abs(item.taxable_value), 2)
+            item_details["total_value"] = abs(self.rounded(item.taxable_value, 2))
 
     def update_transaction_details(self):
         invoice_type = "INV"
@@ -734,7 +734,7 @@ class EInvoiceData(GSTTransactionData):
             credit_days = (getdate(self.doc.due_date) - getdate(self.doc.posting_date)).days
 
         if (self.doc.is_pos or self.doc.advances) and self.doc.base_paid_amount:
-            paid_amount = self.rounded(abs(self.doc.base_paid_amount))
+            paid_amount = abs(self.rounded(self.doc.base_paid_amount))
 
         self.transaction_details.update(
             {
@@ -742,7 +742,7 @@ class EInvoiceData(GSTTransactionData):
                 "mode_of_payment": self.get_mode_of_payment(),
                 "paid_amount": paid_amount,
                 "credit_days": credit_days,
-                "outstanding_amount": self.rounded(abs(self.doc.outstanding_amount)),
+                "outstanding_amount": abs(self.rounded(self.doc.outstanding_amount)),
                 "payment_terms": self.sanitize_value(self.doc.payment_terms_template),
             }
         )

--- a/india_compliance/gst_india/utils/transaction_data.py
+++ b/india_compliance/gst_india/utils/transaction_data.py
@@ -70,10 +70,12 @@ class GSTTransactionData:
             )
 
     def set_transaction_details(self):
-        rounding_adjustment = self.rounded(self.doc.get("base_rounding_adjustment") or 0)
+        rounding_adjustment = self.doc.get("base_rounding_adjustment") or 0
 
         if self.doc.get("is_return"):
             rounding_adjustment = -rounding_adjustment
+
+        rounding_adjustment = self.rounded(rounding_adjustment)
 
         grand_total_fieldname = (
             "base_grand_total" if self.doc.get("disable_rounded_total", 1) else "base_rounded_total"
@@ -113,18 +115,18 @@ class GSTTransactionData:
                     or frappe.db.get_value(self.doc.doctype, self.party_name, self.party_name_field)
                 ),
                 "date": format_date(self.doc.posting_date, self.DATE_FORMAT),
-                "total": abs(self.rounded(total)),
-                "total_taxable_value": abs(self.rounded(total_taxable_value)),
-                "total_non_taxable_value": abs(self.rounded(total - total_taxable_value)),
+                "total": self.rounded(abs(total)),
+                "total_taxable_value": self.rounded(abs(total_taxable_value)),
+                "total_non_taxable_value": self.rounded(abs(total - total_taxable_value)),
                 "rounding_adjustment": rounding_adjustment,
-                "grand_total": abs(self.rounded(self.doc.get(grand_total_fieldname))),
+                "grand_total": self.rounded(abs(self.doc.get(grand_total_fieldname))),
                 "grand_total_in_foreign_currency": (
-                    abs(self.rounded(self.doc.grand_total))
+                    self.rounded(abs(self.doc.grand_total))
                     if self.doc.get("currency", "INR") != "INR"
                     else ""
                 ),
                 "discount_amount": (
-                    abs(self.rounded(self.doc.base_discount_amount))
+                    self.rounded(abs(self.doc.base_discount_amount))
                     if self.doc.get("is_cash_or_non_trade_discount")
                     else 0
                 ),
@@ -292,13 +294,13 @@ class GSTTransactionData:
         for row in items:
             # Note: `row.taxable_value` is the ERPNext column = full line value
             # `taxable_amount` (taxable portion) and `non_taxable_amount` (nil/exempt/non-gst portion).
-            line_value = abs(self.rounded(row.taxable_value))
+            line_value = self.rounded(abs(row.taxable_value))
             is_taxable = row.gst_treatment in TAXABLE_GST_TREATMENTS
 
             item_details = frappe._dict(
                 {
                     "item_no": row.idx,
-                    "qty": abs(self.rounded(row.qty, 3)),
+                    "qty": self.rounded(abs(row.qty), 3),
                     "taxable_amount": line_value if is_taxable else 0,
                     "non_taxable_amount": 0 if is_taxable else line_value,
                     "hsn_code": row.gst_hsn_code,

--- a/india_compliance/gst_india/utils/transaction_data.py
+++ b/india_compliance/gst_india/utils/transaction_data.py
@@ -70,12 +70,10 @@ class GSTTransactionData:
             )
 
     def set_transaction_details(self):
-        rounding_adjustment = self.doc.get("base_rounding_adjustment") or 0
+        rounding_adjustment = self.rounded(self.doc.get("base_rounding_adjustment") or 0)
 
         if self.doc.get("is_return"):
             rounding_adjustment = -rounding_adjustment
-
-        rounding_adjustment = self.rounded(rounding_adjustment)
 
         grand_total_fieldname = (
             "base_grand_total" if self.doc.get("disable_rounded_total", 1) else "base_rounded_total"
@@ -115,18 +113,18 @@ class GSTTransactionData:
                     or frappe.db.get_value(self.doc.doctype, self.party_name, self.party_name_field)
                 ),
                 "date": format_date(self.doc.posting_date, self.DATE_FORMAT),
-                "total": self.rounded(abs(total)),
-                "total_taxable_value": self.rounded(abs(total_taxable_value)),
-                "total_non_taxable_value": self.rounded(abs(total - total_taxable_value)),
+                "total": abs(self.rounded(total)),
+                "total_taxable_value": abs(self.rounded(total_taxable_value)),
+                "total_non_taxable_value": abs(self.rounded(total - total_taxable_value)),
                 "rounding_adjustment": rounding_adjustment,
-                "grand_total": self.rounded(abs(self.doc.get(grand_total_fieldname))),
+                "grand_total": abs(self.rounded(self.doc.get(grand_total_fieldname))),
                 "grand_total_in_foreign_currency": (
-                    self.rounded(abs(self.doc.grand_total))
+                    abs(self.rounded(self.doc.grand_total))
                     if self.doc.get("currency", "INR") != "INR"
                     else ""
                 ),
                 "discount_amount": (
-                    self.rounded(abs(self.doc.base_discount_amount))
+                    abs(self.rounded(self.doc.base_discount_amount))
                     if self.doc.get("is_cash_or_non_trade_discount")
                     else 0
                 ),
@@ -294,13 +292,13 @@ class GSTTransactionData:
         for row in items:
             # Note: `row.taxable_value` is the ERPNext column = full line value
             # `taxable_amount` (taxable portion) and `non_taxable_amount` (nil/exempt/non-gst portion).
-            line_value = self.rounded(abs(row.taxable_value))
+            line_value = abs(self.rounded(row.taxable_value))
             is_taxable = row.gst_treatment in TAXABLE_GST_TREATMENTS
 
             item_details = frappe._dict(
                 {
                     "item_no": row.idx,
-                    "qty": self.rounded(abs(row.qty), 3),
+                    "qty": abs(self.rounded(row.qty, 3)),
                     "taxable_amount": line_value if is_taxable else 0,
                     "non_taxable_amount": 0 if is_taxable else line_value,
                     "hsn_code": row.gst_hsn_code,
@@ -515,7 +513,9 @@ class GSTTransactionData:
 
     @staticmethod
     def rounded(value, precision=2):
-        return rounded(value, precision)
+        # round the size, then put sign back. frappe rounds half up, so -1.005 != -(1.005)
+        result = rounded(abs(value), precision)
+        return -result if value < 0 and result else result
 
     @staticmethod
     def sanitize_value(


### PR DESCRIPTION
### What
- Credit notes could send a paisa less to the portal (e-invoice / e-waybill) than books show.
- Cause: amount made positive **after** rounding, should be before.

### Why
- Rounding is not symmetric around zero.
  `-2.675` → round then flip = `2.67`, flip then round = `2.68`.
- Credit notes are negative in books, so such amounts went out one paisa low.

### How
- Take magnitude (or flip sign) first, round after.
- 10 spots: invoice totals, grand total, discount, item value, qty, unit rate, paid amount, outstanding, round-off.