### PR TITLE
fix: reverse tax amount proportionately in advance tax reversal

### DIFF
--- a/india_compliance/gst_india/overrides/payment_entry.py
+++ b/india_compliance/gst_india/overrides/payment_entry.py
@@ -4,6 +4,7 @@ from erpnext.accounts.utils import create_payment_ledger_entry
 from erpnext.controllers.accounts_controller import get_advance_payment_entries
 from frappe import _
 from frappe.contacts.doctype.address.address import get_default_address
+from frappe.model.meta import get_field_precision
 from frappe.query_builder.functions import Sum
 from frappe.utils import flt, getdate
 
@@ -364,12 +365,28 @@ def get_advance_payment_entries_for_regional(
     if not taxes:
         return payment_entries
 
+    precision = get_field_precision(frappe.get_meta("Sales Invoice").get_field("outstanding_amount"))
+
+    rows_of_payment = {}
     for pe in payment_entries:
-        tax_row = taxes.get(pe.reference_name)
-        if not tax_row or not tax_row.taxable_amount:
+        rows_of_payment.setdefault(pe.reference_name, []).append(pe)
+
+    for payment_entry, rows in rows_of_payment.items():
+        tax_row = taxes.get(payment_entry)
+        total_amount = sum(row.amount for row in rows)
+
+        if not tax_row or not total_amount:
             continue
 
-        pe.amount += flt(pe.amount * tax_row.tax_amount / tax_row.taxable_amount, 2)
+        pending_taxes = tax_row.tax_amount - tax_row.tax_amount_reversed
+        running_amount = 0
+        running_share = 0
+
+        for row in rows:
+            running_amount += row.amount
+            share = flt(pending_taxes * running_amount / total_amount, precision)
+            row.amount += share - running_share
+            running_share = share
 
     return payment_entries
 

--- a/india_compliance/gst_india/overrides/payment_entry.py
+++ b/india_compliance/gst_india/overrides/payment_entry.py
@@ -365,11 +365,11 @@ def get_advance_payment_entries_for_regional(
         return payment_entries
 
     for pe in payment_entries:
-        tax_row = taxes.get(
-            pe.reference_name,
-            frappe._dict(paid_amount=1, tax_amount=0, tax_amount_reversed=0),
-        )
-        pe.amount += tax_row.tax_amount - tax_row.tax_amount_reversed
+        tax_row = taxes.get(pe.reference_name)
+        if not tax_row or not tax_row.taxable_amount:
+            continue
+
+        pe.amount += flt(pe.amount * tax_row.tax_amount / tax_row.taxable_amount, 2)
 
     return payment_entries
 

--- a/india_compliance/gst_india/overrides/test_advance_payment_entry.py
+++ b/india_compliance/gst_india/overrides/test_advance_payment_entry.py
@@ -359,6 +359,19 @@ class TestAdvancePaymentEntry(IntegrationTestCase):
         invoice_doc = self._create_sales_invoice()
 
         make_payment_reconciliation(payment_doc, invoice_doc, 50)
+
+        payment_entries = get_advance_payment_entries_for_regional(
+            party_type="Customer",
+            party=payment_doc.party,
+            party_account=[payment_doc.paid_from],
+            order_list=[],
+            order_doctype="Sales Order",
+            include_unallocated=True,
+            condition=frappe._dict({"company": payment_doc.company, "name": payment_doc.name}),
+        )
+
+        self.assertEqual(flt(payment_entries[0].amount, 2), 540.01)
+
         make_payment_reconciliation(payment_doc, invoice_doc, 20)
 
         # Verify outstanding amount
@@ -625,8 +638,7 @@ class TestRegionalOverrides(TestAdvancePaymentEntry):
             condition=frappe._dict({"company": payment_doc.company, "name": payment_doc.name}),
         )
 
-        self.assertEqual(len(payment_entries), 2)
-        self.assertEqual(sum(row.amount for row in payment_entries), 590.0)
+        self.assertEqual([row.amount for row in payment_entries], [118.0, 472.0])
 
     def test_adjust_allocations_for_taxes(self):
         payment_doc = self._create_payment_entry()

--- a/india_compliance/gst_india/overrides/test_advance_payment_entry.py
+++ b/india_compliance/gst_india/overrides/test_advance_payment_entry.py
@@ -596,6 +596,38 @@ class TestRegionalOverrides(TestAdvancePaymentEntry):
         # Remaining Unallocated = 590 - 100 (sales invoice amount)
         self.assertEqual(490, payment_entry_amount)
 
+    def test_get_advance_payment_entries_for_regional_grosses_up_once_per_payment(self):
+        """An advance partly earmarked against a Sales Order comes back as two rows -- one for the
+        order reference, one for the unallocated balance.Reversal should be proportionate"""
+        sales_order = create_transaction(doctype="Sales Order", is_in_state=1)
+        payment_doc = self._create_payment_entry(do_not_submit=True)
+        payment_doc.append(
+            "references",
+            {
+                "reference_doctype": sales_order.doctype,
+                "reference_name": sales_order.name,
+                "total_amount": sales_order.grand_total,
+                "outstanding_amount": sales_order.grand_total,
+                "allocated_amount": 100,
+            },
+        )
+        payment_doc.save()
+        payment_doc.submit()
+
+        payment_entries = get_advance_payment_entries_for_regional(
+            party_type="Customer",
+            party=payment_doc.party,
+            party_account=[payment_doc.paid_from],
+            order_list=[],
+            order_doctype="Sales Order",
+            include_unallocated=True,
+            against_all_orders=True,
+            condition=frappe._dict({"company": payment_doc.company, "name": payment_doc.name}),
+        )
+
+        self.assertEqual(len(payment_entries), 2)
+        self.assertEqual(sum(row.amount for row in payment_entries), 590.0)
+
     def test_adjust_allocations_for_taxes(self):
         payment_doc = self._create_payment_entry()
         invoice_doc = self._create_sales_invoice()


### PR DESCRIPTION
Issue:

Advance of 500 + 90 GST (CGST 45 + SGST 45), 590 banked. Two Sales Orders with 100 earmarked against each, leaving 300 unallocated. Nothing reversed yet, so the whole 90 is still pending.

Why one payment becomes three rows
get_advance_payment_entries runs two queries and concatenates them with no dedup — and the reconciliation tool calls it with against_all_orders=True:


if order_list or against_all_orders:
    ...   # one row per Payment Entry Reference pointing at an order
if include_unallocated:
    ...   # plus one row for the leftover balance
Every row carries the same reference_name — the Payment Entry name. So one advance arrives as three rows.

Before — the pot added to every row

row          net    + pot    offered
SO-1         100    + 90  =  190
SO-2         100    + 90  =  190
unallocated  300    + 90  =  390
                            ─────
                             770     ← the payment is worth 590
Over-stated by 180 — the pot counted once too often per extra row. That surplus is spendable: allocate_entries caps an allocation at pay["amount"], so it reaches an invoice and the reconcile then fails late with "Outstanding amount … is less than the total allocated amount with taxes".