### PR TITLE
fix: filters in purchase reconciliation tool

### DIFF
--- a/india_compliance/public/js/components/filter_group.js
+++ b/india_compliance/public/js/components/filter_group.js
@@ -58,10 +58,12 @@ class _Filter extends frappe.ui.Filter {
             (condition) => india_compliance.FILTER_OPERATORS[condition && condition[0]],
         );
 
+        const like_conditions = ["like", "not like"];
+
         // keep like / not like conditions
         for (const [fieldtype, invalid] of Object.entries(this.invalid_condition_map))
             this.invalid_condition_map[fieldtype] = invalid.filter(
-                (condition) => !this.like_conditions.includes(condition),
+                (condition) => !like_conditions.includes(condition),
             );
     }
 }


### PR DESCRIPTION
### Steps to replicate
- open Purchase Reconciliation Tool and click generate
- Try adding additional filters

### Browser Console Error
```javascript
Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'includes')
    at <anonymous>:365:48
    at Array.filter (<anonymous>)
    at _Filter.set_conditions_from_config (<anonymous>:364:57)
    at new frappe.ui.Filter (filter.js:10:8)
    at new _Filter (<anonymous>:351:17)
    at FilterGroup._push_new_filter (filter_list.js:245:16)
    at FilterGroup._push_new_filter (<anonymous>:384:22)
    at FilterGroup.push_new_filter (filter_list.js:216:21)
    at FilterGroup.add_or_remove_filter (<anonymous>:412:20)
    at HTMLAnchorElement.eval (purchase_reconciliation_tool__js:348:43)
(anonymous) @ VM76:365
set_conditions_from_config @ VM76:364
constructor @ filter.js:10
_Filter @ VM76:351
_push_new_filter @ filter_list.js:245
_push_new_filter @ VM76:384
push_new_filter @ filter_list.js:216
add_or_remove_filter @ VM76:412
eval @ purchase_reconciliation_tool__js:348
dispatch @ jquery.js:5135
(anonymous) @ jquery.js:4939

```

Error due to [#4659](https://github.com/resilient-tech/india-compliance/pull/4713)  using `this.invalid_condition_map` which is only available in frappe develop `https://github.com/frappe/frappe/pull/39702/changes`