### PR TITLE
fix: allow Create button in Purchase Reconciliation Tool when not present in 2A/2B

### DIFF
--- a/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.js
+++ b/india_compliance/gst_india/doctype/purchase_reconciliation_tool/purchase_reconciliation_tool.js
@@ -756,7 +756,7 @@ class PurchaseReconciliationToolAction {
 
 class DetailViewDialog extends reconciliation.detail_view_dialog {
     _get_custom_actions() {
-        const doctype = this.dialog.get_value("doctype");
+        const doctype = this.dialog.get_value("doctype") || this.missing_doctype;
         if (this.row.match_status == "Only in Books") return ["Link", "Ignore"];
         else if (this.row.match_status == "Only in 2A/2B")
             if (doctype == "Purchase Invoice") return ["Create", "Link", "Pending", "Ignore"];


### PR DESCRIPTION
The Create button to generate a Purchase Invoice (PI) from 2A/2B is missing in the Purchase Reconciliation Tool (PRT) document view, though it works in IMS.

### Steps to Reproduce
- Open Purchase Reconciliation Tool.
- Click Generate.
- Filter by Only in 2A/2B.
- Go to Document View and click the Eye icon for details.
- Notice the Create button is missing.

### Before
<img width="1289" height="910" alt="Screenshot 2026-08-20 at 2 27 18 PM" src="https://github.com/user-attachments/assets/bf00656d-d320-4ad7-b180-43a44fb59cdd" />


### After

<img width="1218" height="900" alt="Screenshot 2026-08-20 at 2 25 24 PM" src="https://github.com/user-attachments/assets/2ed4e61e-9740-4396-a284-d6ffa43b32a2" />
