### PR TITLE
fix: check items length before accessing gst_treatment

### DIFF
--- a/india_compliance/gst_india/client_scripts/sales_invoice.js
+++ b/india_compliance/gst_india/client_scripts/sales_invoice.js
@@ -86,7 +86,7 @@ function is_gst_invoice(frm) {
         frm.doc.company_gstin != frm.doc.billing_address_gstin &&
         frm.doc.items.some((item) => ["Taxable", "Zero-Rated"].includes(item.gst_treatment));
 
-    if (frm.doc.items[0].gst_treatment === "Zero-Rated")
+    if (frm.doc.items.length > 0 && frm.doc.items[0].gst_treatment === "Zero-Rated")
         return gst_invoice_conditions && frm.doc.is_export_with_gst;
     else return gst_invoice_conditions;
 }


### PR DESCRIPTION
This pull request makes a small but important change to the `is_gst_invoice` function in `sales_invoice.js`. The change ensures that the code safely checks for the existence of items in the invoice before accessing their properties, preventing potential runtime errors.

- Improved safety in `is_gst_invoice`:
  * Added a check to ensure that `frm.doc.items` has at least one item before accessing `gst_treatment` on the first item.

PR fix below error

```js
Uncaught (in promise) TypeError: can't access property "gst_treatment", frm.doc.items[0] is undefined
    is_gst_invoice sales_invoice__js:3471
    gst_invoice_warning sales_invoice__js:3444
    refresh sales_invoice__js:3415
    _handler script_manager.js:30
    runner script_manager.js:109
    trigger script_manager.js:127
    promise callback*frappe.run_serially/< dom.js:273
    run_serially dom.js:271
......
```