### PR TITLE
fix(gst): build warehouse account map lazily in ineligible itc

### DIFF
--- a/india_compliance/gst_india/overrides/ineligible_itc.py
+++ b/india_compliance/gst_india/overrides/ineligible_itc.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from functools import cached_property
 
 import frappe
 from erpnext.assets.doctype.asset.asset import (
@@ -19,7 +20,6 @@ class IneligibleITC:
     def __init__(self, doc):
         self.doc = doc
 
-        self.warehouse_account_map = get_warehouse_account_map(doc.company)
         self.company = frappe.get_cached_doc("Company", doc.company)
         self.is_perpetual = self.company.enable_perpetual_inventory
         self.cost_center = doc.cost_center or self.company.cost_center
@@ -27,6 +27,12 @@ class IneligibleITC:
 
         self.dr_or_cr = "credit" if doc.get("is_return") else "debit"
         self.cr_or_dr = "debit" if doc.get("is_return") else "credit"
+
+    @cached_property
+    def warehouse_account_map(self):
+        # Only read for stock items under perpetual inventory. Building it
+        # eagerly scans every warehouse of the company on each transaction.
+        return get_warehouse_account_map(self.doc.company)
 
     def update_valuation_rate(self):
         """


### PR DESCRIPTION
**Issue:**
IneligibleITC.__init__ builds the company's full warehouse account map on every purchase invoice, purchase receipt and bill of entry, one line before it reads enable_perpetual_inventory. The map is only read in get_item_expense_account, which is gated on _is_stock_item, and that flag is set only when perpetual inventory is enabled.

On a non-perpetual company with a large warehouse tree, get_warehouse_account takes an unguarded rebuild_tree branch for every account-less warehouse, which rewrites the whole tree with auto commit and blocks other writers on lock waits, making save fail.

Defer the map behind cached_property so it is built only when read.

**Ref:** [77070](https://support.frappe.io/helpdesk/tickets/77070)

**Backport Needed for v15 & v16**