### PR TITLE
refactor: extract `TRADE_NAME_BUSINESS_TYPES` in `gstin_info`

### DIFF
--- a/india_compliance/gst_india/utils/gstin_info.py
+++ b/india_compliance/gst_india/utils/gstin_info.py
@@ -37,6 +37,9 @@ GST_CATEGORIES = {
     "URP": "Unregistered",
 }
 
+# business types (constitution of business) where trade name is preferred over legal name
+TRADE_NAME_BUSINESS_TYPES = frozenset(("Proprietorship", "Hindu Undivided Family"))
+
 # order of address keys is important
 KEYS_TO_SANITIZE = ("dst", "stcd", "pncd", "bno", "flno", "bnm", "st", "loc", "city")
 KEYS_TO_FILTER_DUPLICATES = frozenset(("dst", "bnm", "st", "loc", "city"))
@@ -85,9 +88,9 @@ def _get_gstin_info(gstin, *, doc=None, throw_error=True):
             frappe.clear_last_message()
             return frappe._dict()
 
-    business_name = (
-        response.tradeNam if response.ctb in ["Proprietorship", "Hindu Undivided Family"] else response.lgnm
-    )
+    business_name = response.lgnm
+    if response.ctb in TRADE_NAME_BUSINESS_TYPES and response.tradeNam:
+        business_name = response.tradeNam
 
     gstin_info = frappe._dict(
         gstin=response.gstin,

--- a/india_compliance/gst_india/utils/test_gstin_info.py
+++ b/india_compliance/gst_india/utils/test_gstin_info.py
@@ -123,6 +123,15 @@ class TestGstinInfo(IntegrationTestCase):
             },
         )
 
+    def test_business_name_falls_back_to_legal_name(self):
+        """Trade name is preferred for Proprietorship / HUF, but may be empty"""
+        self.mock_public_api.return_value = Mock()
+        self.mock_public_api.return_value.get_gstin_info.return_value = frappe._dict(
+            {**self.MOCK_GSTIN_INFO, "tradeNam": ""}
+        )
+        gstin_info = get_gstin_info(self.gstin)
+        self.assertEqual(gstin_info.business_name, "Nalin Vora")
+
     def test_tcs_gstin_info(self):
         self.mock_public_api.return_value = Mock()
         self.mock_public_api.return_value.get_gstin_info.return_value = frappe._dict(


### PR DESCRIPTION
- replace inline list with `TRADE_NAME_BUSINESS_TYPES` frozenset (`ctb` is not intuitive)
- fall back to legal name when trade name is empty for Proprietorship / HUF