### PR TITLE
fix: allow versioning for e-way bill and e-invoice features

### DIFF
--- a/india_compliance/gst_india/utils/__init__.py
+++ b/india_compliance/gst_india/utils/__init__.py
@@ -178,6 +178,12 @@ def send_updated_doc(doc):
     frappe.response.docs.append(doc)
 
 
+def add_version(doc):
+    """db_set skips Version, write one so timeline shows who changed what"""
+    doc.save_version()
+    doc._doc_before_save = None
+
+
 def publish_doc_update(doc):
     """Send the updated doc to the user's open form."""
     if not frappe.flags.in_bulk_generation:
@@ -1216,6 +1222,7 @@ def handle_server_errors(settings, doc, document_type, error):
         error_message += " " + _("Please try again after some time.")
 
     doc.db_set({document_status_field: document_status})
+    add_version(doc)
 
     notify_user(error_message, title=error_message_title.get(type(error)), indicator="yellow", doc=doc)
 
@@ -1542,6 +1549,7 @@ def _rollback_and_set_status(doc, fieldname, status):
     # if response is pending, other viewers refetch on doc_update;
     # else the pushed doc (publish_doc_update) notifies them
     doc.db_set(fieldname, status, notify=is_response_pending())
+    add_version(doc)
     commit()
 
 

--- a/india_compliance/gst_india/utils/e_invoice.py
+++ b/india_compliance/gst_india/utils/e_invoice.py
@@ -44,6 +44,7 @@ from india_compliance.gst_india.doctype.gst_settings.gst_settings import (
 )
 from india_compliance.gst_india.overrides.transaction import validate_mandatory_fields
 from india_compliance.gst_india.utils import (
+    add_version,
     are_goods_supplied,
     commit,
     handle_server_errors,
@@ -339,6 +340,7 @@ def log_and_process_e_invoice_generation(doc, result, sandbox_mode=False, messag
             "einvoice_status": result.get("einvoice_status") or "Generated",
         }
     )
+    add_version(doc)
 
     invoice_data = None
     if result.SignedInvoice:
@@ -419,6 +421,7 @@ def log_and_process_e_invoice_cancellation(doc, values, result, message):
             "irn": "",
         }
     )
+    add_version(doc)
 
     return notify_user(message, indicator="green", alert=True, doc=doc)
 

--- a/india_compliance/gst_india/utils/e_waybill.py
+++ b/india_compliance/gst_india/utils/e_waybill.py
@@ -53,6 +53,7 @@ from india_compliance.gst_india.overrides.transaction import (
     is_inter_state_supply,
 )
 from india_compliance.gst_india.utils import (
+    add_version,
     commit,
     get_items,
     handle_server_errors,
@@ -309,6 +310,7 @@ def log_and_process_e_waybill_generation(doc, result, *, with_irn=False):
         data["distance"] = distance
 
     doc.db_set(data)
+    add_version(doc)
 
     # dates are entered by the user in ISO format for manual generation
     day_first = not with_irn and status != "Manually Generated"
@@ -393,6 +395,7 @@ def log_and_process_e_waybill_cancellation(doc, values, result):
         data["e_waybill_status"] = result.get("e_waybill_status") or "Cancelled"
 
     doc.db_set(data)
+    add_version(doc)
 
 
 # nosemgrep: frappe-semgrep-rules.rules.security.missing-argument-type-hint
@@ -422,6 +425,7 @@ def update_vehicle_info(*, doctype: str, docname: str, values: str | dict | frap
             "gst_vehicle_type": values.gst_vehicle_type,
         }
     )
+    add_version(doc)
 
     data = EWaybillData(doc).get_update_vehicle_data(values)
     result = EWaybillAPI.create(doc).update_vehicle_info(data)
@@ -484,21 +488,22 @@ def _bulk_update_transporter_in_docs(doctype, docnames, values):
         frappe.db.get_value("Supplier", values.transporter, "supplier_name") if values.transporter else None
     )
 
-    frappe.db.set_value(
-        doctype,
-        {"name": ("in", docs_to_update)},
-        {
-            "transporter": values.transporter,
-            "transporter_name": transporter_name,
-            "gst_transporter_id": values.gst_transporter_id,
-            "vehicle_no": values.vehicle_no,
-            "lr_no": values.lr_no,
-            "lr_date": values.lr_date,
-            "mode_of_transport": values.mode_of_transport,
-            "gst_vehicle_type": values.gst_vehicle_type,
-            "distance": values.distance,
-        },
-    )
+    data = {
+        "transporter": values.transporter,
+        "transporter_name": transporter_name,
+        "gst_transporter_id": values.gst_transporter_id,
+        "vehicle_no": values.vehicle_no,
+        "lr_no": values.lr_no,
+        "lr_date": values.lr_date,
+        "mode_of_transport": values.mode_of_transport,
+        "gst_vehicle_type": values.gst_vehicle_type,
+        "distance": values.distance,
+    }
+
+    for docname in docs_to_update:
+        doc = frappe.get_doc(doctype, docname)
+        doc.db_set(data)
+        add_version(doc)
 
     if docs_with_ewaybill := set(docnames).difference(set(docs_to_update)):
         doc_links = [get_link_to_form(doctype, doc) for doc in docs_with_ewaybill]
@@ -541,6 +546,7 @@ def update_transporter(*, doctype: str, docname: str, values: str | dict | frapp
             "gst_transporter_id": values.gst_transporter_id,
         }
     )
+    add_version(doc)
 
     comment = (
         "Transporter Info has been updated by {user}. Transporter ID changed from"
@@ -592,6 +598,7 @@ def extend_validity(
     result = EWaybillAPI.create(doc).extend_validity(data)
 
     doc.db_set("distance", cint(values.remaining_distance))
+    add_version(doc)
 
     update_e_waybill_log_for_extention(
         values=values,
@@ -685,6 +692,7 @@ def schedule_ewaybill_for_extension(
             "lr_date": values.lr_date,
         }
     )
+    add_version(doc)
 
     validate_data_before_schedule(doc, values)
 
@@ -1087,6 +1095,7 @@ def update_transaction(doc, values):
         data["port_address"] = values.port_address
 
     doc.db_set(data)
+    add_version(doc)
 
     if doc.doctype in ("Delivery Note", "Stock Entry", "Subcontracting Receipt", "Asset Movement"):
         doc._sub_supply_type = SUB_SUPPLY_TYPES[values.sub_supply_type]

--- a/india_compliance/gst_india/utils/test_e_waybill.py
+++ b/india_compliance/gst_india/utils/test_e_waybill.py
@@ -237,6 +237,10 @@ class TestEWaybill(IntegrationTestCase):
             ),
         )
 
+        version = frappe.get_last_doc("Version", {"ref_doctype": "Sales Invoice", "docname": si.name})
+        changed = {field: new for field, _old, new in version.get_data()["changed"]}
+        self.assertEqual(changed.get("gst_transporter_id"), "05AAACG2140A1ZL")
+
     @change_settings("GST Settings", {"fetch_e_waybill_data": 1})
     @responses.activate
     def test_fetch_e_waybill_data(self):


### PR DESCRIPTION
### What

- e-Waybill and e-Invoice actions now leave a Version entry on the invoice, like a normal save would.
- Covers generate, cancel, mark as generated / cancelled, update vehicle info, update transporter, extend validity, schedule extension, bulk transporter update, dialog values before generate, and failure status changes.
- Timeline shows the new entries right after the action, no page reload.

### Why

- These actions write straight to the database. Frappe skips Version for such writes, so the timeline showed nothing. 
- No way to see who changed vehicle or transporter after generation.

### How

- Plain save_version() after each direct write.
- Three flows write the invoice twice in one request (e-Invoice with e-Waybill, cancel e-Invoice, generate with dialog values).
- Response carries the doc's timeline info so the form refreshes it.
